### PR TITLE
Fixed spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ npm run check -- --fix
 
 # Testing
 
-Tests are executed with jest or by running:
+Tests are executed with Jest or by running:
 ```sh
 npm run test
 ```


### PR DESCRIPTION
jest now changed to Jest in the readme.md file as per the official name of Facebook's testing tool.
