### PR TITLE
Fix TimeUtils test failing if run in a computer with TZ before UTC

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,5 +33,10 @@
         "react/no-did-update-set-state": "error",
         "react/no-find-dom-node": "off",
         "react/sort-comp": "error"
+    },
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
     }
 }

--- a/src/components/utils/__tests__/TimeUtils.test.js
+++ b/src/components/utils/__tests__/TimeUtils.test.js
@@ -6,7 +6,7 @@ import TimeUtils from '../TimeUtils'
 let now = null
 beforeAll(() => {
     // whenever moment() is invoked 2017-03-22 will be taken as date
-    Date.now = jest.fn(() => new Date(Date.UTC(2017, 2, 22)).valueOf())
+    Date.now = jest.fn(() => new Date(2017, 2, 22).valueOf())
     now = moment()
 })
 


### PR DESCRIPTION
## What

There's [a test case](https://github.com/Doist/reactist/blob/7782171e8b5035adf44e87dd4372b3feb8401508/src/components/utils/__tests__/TimeUtils.test.js#L67-L72) for `TimeUtils` that failed if the time zone of the computer running the test comes before `UTC`. This was because `moment`, on subtracting two days from a date that falls flat on midnight of a UTC date, you still get a date that falls flat on midnight UTC two days before. But when formatting that date, `moment` takes into account the current computer's TZ, and if this one falls before UTC, you get a date one day earlier.

Also, it adds some minimal settings for `eslint-plugin-react` that was causing a warning when running `npm run check`.

## PR Checklist

* [x] Added tests for bugs / new features
* [ ] Described changes in CHANGELOG.md
* [x] Executed `npm run check` and made sure no errors / warnings were shown
* [x] Executed `npm run test` and made sure all tests are passing
* [ ] Bumped version in package.json
* [ ] Updated all static build artifacts (`npm run build-all`)
