### PR TITLE
Upgrade to Jest v24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -929,6 +929,16 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@cnakazawa/watch": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+            "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+            "dev": true,
+            "requires": {
+                "exec-sh": "^0.3.2",
+                "minimist": "^1.2.0"
+            }
+        },
         "@emotion/cache": {
             "version": "0.8.8",
             "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-0.8.8.tgz",
@@ -1055,6 +1065,246 @@
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.1.3.tgz",
             "integrity": "sha512-QsYGKdhhuDFNq7bjm2r44y0mp5xW3uO3csuTPDWZc0OIiMQv+AIY5Cqwd4mJiC5N8estVl7qlvOx1hbtOuUWbw==",
             "dev": true
+        },
+        "@jest/console": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
+            "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+            "dev": true,
+            "requires": {
+                "@jest/source-map": "^24.3.0",
+                "chalk": "^2.0.1",
+                "slash": "^2.0.0"
+            },
+            "dependencies": {
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/core": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.7.1.tgz",
+            "integrity": "sha512-ivlZ8HX/FOASfHcb5DJpSPFps8ydfUYzLZfgFFqjkLijYysnIEOieg72YRhO4ZUB32xu40hsSMmaw+IGYeKONA==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^24.7.1",
+                "@jest/reporters": "^24.7.1",
+                "@jest/test-result": "^24.7.1",
+                "@jest/transform": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.1.15",
+                "jest-changed-files": "^24.7.0",
+                "jest-config": "^24.7.1",
+                "jest-haste-map": "^24.7.1",
+                "jest-message-util": "^24.7.1",
+                "jest-regex-util": "^24.3.0",
+                "jest-resolve-dependencies": "^24.7.1",
+                "jest-runner": "^24.7.1",
+                "jest-runtime": "^24.7.1",
+                "jest-snapshot": "^24.7.1",
+                "jest-util": "^24.7.1",
+                "jest-validate": "^24.7.0",
+                "jest-watcher": "^24.7.1",
+                "micromatch": "^3.1.10",
+                "p-each-series": "^1.0.0",
+                "pirates": "^4.0.1",
+                "realpath-native": "^1.1.0",
+                "rimraf": "^2.5.4",
+                "strip-ansi": "^5.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "pirates": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+                    "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+                    "dev": true,
+                    "requires": {
+                        "node-modules-regexp": "^1.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "@jest/environment": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.7.1.tgz",
+            "integrity": "sha512-wmcTTYc4/KqA+U5h1zQd5FXXynfa7VGP2NfF+c6QeGJ7c+2nStgh65RQWNX62SC716dTtqheTRrZl0j+54oGHw==",
+            "dev": true,
+            "requires": {
+                "@jest/fake-timers": "^24.7.1",
+                "@jest/transform": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "jest-mock": "^24.7.0"
+            }
+        },
+        "@jest/fake-timers": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.7.1.tgz",
+            "integrity": "sha512-4vSQJDKfR2jScOe12L9282uiwuwQv9Lk7mgrCSZHA9evB9efB/qx8i0KJxsAKtp8fgJYBJdYY7ZU6u3F4/pyjA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.7.0",
+                "jest-message-util": "^24.7.1",
+                "jest-mock": "^24.7.0"
+            }
+        },
+        "@jest/reporters": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.7.1.tgz",
+            "integrity": "sha512-bO+WYNwHLNhrjB9EbPL4kX/mCCG4ZhhfWmO3m4FSpbgr7N83MFejayz30kKjgqr7smLyeaRFCBQMbXpUgnhAJw==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^24.7.1",
+                "@jest/test-result": "^24.7.1",
+                "@jest/transform": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "glob": "^7.1.2",
+                "istanbul-api": "^2.1.1",
+                "istanbul-lib-coverage": "^2.0.2",
+                "istanbul-lib-instrument": "^3.0.1",
+                "istanbul-lib-source-maps": "^3.0.1",
+                "jest-haste-map": "^24.7.1",
+                "jest-resolve": "^24.7.1",
+                "jest-runtime": "^24.7.1",
+                "jest-util": "^24.7.1",
+                "jest-worker": "^24.6.0",
+                "node-notifier": "^5.2.1",
+                "slash": "^2.0.0",
+                "source-map": "^0.6.0",
+                "string-length": "^2.0.0"
+            },
+            "dependencies": {
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/source-map": {
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+            "integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.1.15",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "callsites": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+                    "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/test-result": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.7.1.tgz",
+            "integrity": "sha512-3U7wITxstdEc2HMfBX7Yx3JZgiNBubwDqQMh+BXmZXHa3G13YWF3p6cK+5g0hGkN3iufg/vGPl3hLxQXD74Npg==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "@types/istanbul-lib-coverage": "^2.0.0"
+            }
+        },
+        "@jest/test-sequencer": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.7.1.tgz",
+            "integrity": "sha512-84HQkCpVZI/G1zq53gHJvSmhUer4aMYp9tTaffW28Ih5OxfCg8hGr3nTSbL1OhVDRrFZwvF+/R9gY6JRkDUpUA==",
+            "dev": true,
+            "requires": {
+                "@jest/test-result": "^24.7.1",
+                "jest-haste-map": "^24.7.1",
+                "jest-runner": "^24.7.1",
+                "jest-runtime": "^24.7.1"
+            }
+        },
+        "@jest/transform": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.7.1.tgz",
+            "integrity": "sha512-EsOUqP9ULuJ66IkZQhI5LufCHlTbi7hrcllRMUEV/tOgqBVQi93+9qEvkX0n8mYpVXQ8VjwmICeRgg58mrtIEw==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "@jest/types": "^24.7.0",
+                "babel-plugin-istanbul": "^5.1.0",
+                "chalk": "^2.0.1",
+                "convert-source-map": "^1.4.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "graceful-fs": "^4.1.15",
+                "jest-haste-map": "^24.7.1",
+                "jest-regex-util": "^24.3.0",
+                "jest-util": "^24.7.1",
+                "micromatch": "^3.1.10",
+                "realpath-native": "^1.1.0",
+                "slash": "^2.0.0",
+                "source-map": "^0.6.1",
+                "write-file-atomic": "2.4.1"
+            },
+            "dependencies": {
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/types": {
+            "version": "24.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
+            "integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/yargs": "^12.0.9"
+            }
         },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
@@ -1502,10 +1752,82 @@
                 "react-treebeard": "^3.1.0"
             }
         },
+        "@types/babel__core": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.1.tgz",
+            "integrity": "sha512-+hjBtgcFPYyCTo0A15+nxrCVJL7aC6Acg87TXd5OW3QhHswdrOLoles+ldL2Uk8q++7yIfl4tURtztccdeeyOw==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "@types/babel__generator": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+            "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__template": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+            "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__traverse": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+            "integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.3.0"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+                    "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.11",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@types/istanbul-lib-coverage": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
+            "integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
+            "dev": true
+        },
         "@types/node": {
             "version": "10.12.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.10.tgz",
             "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w==",
+            "dev": true
+        },
+        "@types/stack-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+            "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+            "dev": true
+        },
+        "@types/yargs": {
+            "version": "12.0.12",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
+            "integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
             "dev": true
         },
         "@webassemblyjs/ast": {
@@ -1724,9 +2046,9 @@
             }
         },
         "acorn-globals": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
-            "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+            "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
             "dev": true,
             "requires": {
                 "acorn": "^6.0.1",
@@ -1734,9 +2056,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.0.4",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-                    "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+                    "version": "6.1.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+                    "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
                     "dev": true
                 }
             }
@@ -1926,12 +2248,12 @@
             "dev": true
         },
         "append-transform": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-            "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+            "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
             "dev": true,
             "requires": {
-                "default-require-extensions": "^1.0.0"
+                "default-require-extensions": "^2.0.0"
             }
         },
         "aproba": {
@@ -1979,7 +2301,7 @@
         },
         "array-equal": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
@@ -2521,13 +2843,37 @@
             }
         },
         "babel-jest": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
-            "integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.7.1.tgz",
+            "integrity": "sha512-GPnLqfk8Mtt0i4OemjWkChi73A3ALs4w2/QbG64uAj8b5mmwzxc7jbJVRZt8NJkxi6FopVHog9S3xX6UJKb2qg==",
             "dev": true,
             "requires": {
-                "babel-plugin-istanbul": "^4.1.6",
-                "babel-preset-jest": "^23.2.0"
+                "@jest/transform": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "@types/babel__core": "^7.1.0",
+                "babel-plugin-istanbul": "^5.1.0",
+                "babel-preset-jest": "^24.6.0",
+                "chalk": "^2.4.2",
+                "slash": "^2.0.0"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                }
             }
         },
         "babel-loader": {
@@ -2561,22 +2907,69 @@
             }
         },
         "babel-plugin-istanbul": {
-            "version": "4.1.6",
-            "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-            "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.3.tgz",
+            "integrity": "sha512-IFyehbvRRwdBlI1lDp+FaMsWNnEndEk7065IB8NhzBX+ZKLPwPodgk4I5Gobw/8SNUUzso2Dv3hbqRh88eiSCQ==",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-object-rest-spread": "^6.13.0",
-                "find-up": "^2.1.0",
-                "istanbul-lib-instrument": "^1.10.1",
-                "test-exclude": "^4.2.1"
+                "find-up": "^3.0.0",
+                "istanbul-lib-instrument": "^3.2.0",
+                "test-exclude": "^5.2.2"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                }
             }
         },
         "babel-plugin-jest-hoist": {
-            "version": "23.2.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
-            "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
-            "dev": true
+            "version": "24.6.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+            "integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+            "dev": true,
+            "requires": {
+                "@types/babel__traverse": "^7.0.6"
+            }
         },
         "babel-plugin-macros": {
             "version": "2.4.2",
@@ -3380,13 +3773,13 @@
             }
         },
         "babel-preset-jest": {
-            "version": "23.2.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
-            "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
+            "version": "24.6.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+            "integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
             "dev": true,
             "requires": {
-                "babel-plugin-jest-hoist": "^23.2.0",
-                "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+                "babel-plugin-jest-hoist": "^24.6.0"
             }
         },
         "babel-preset-minify": {
@@ -4210,12 +4603,12 @@
             "dev": true
         },
         "capture-exit": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
-            "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+            "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
             "dev": true,
             "requires": {
-                "rsvp": "^3.3.3"
+                "rsvp": "^4.8.4"
             }
         },
         "case-sensitive-paths-webpack-plugin": {
@@ -4356,9 +4749,9 @@
             }
         },
         "ci-info": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
             "dev": true
         },
         "cipher-base": {
@@ -4691,6 +5084,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+            "dev": true
+        },
+        "compare-versions": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
+            "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
             "dev": true
         },
         "component-emitter": {
@@ -5157,15 +5556,15 @@
             }
         },
         "cssom": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-            "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+            "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
             "dev": true
         },
         "cssstyle": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
-            "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
+            "integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
             "dev": true,
             "requires": {
                 "cssom": "0.3.x"
@@ -5265,12 +5664,12 @@
             "dev": true
         },
         "default-require-extensions": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-            "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+            "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
             "dev": true,
             "requires": {
-                "strip-bom": "^2.0.0"
+                "strip-bom": "^3.0.0"
             }
         },
         "define-properties": {
@@ -5405,10 +5804,10 @@
                 }
             }
         },
-        "diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+        "diff-sequences": {
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+            "integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
             "dev": true
         },
         "diffie-hellman": {
@@ -5895,9 +6294,9 @@
             "dev": true
         },
         "escodegen": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-            "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+            "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
             "dev": true,
             "requires": {
                 "esprima": "^3.1.3",
@@ -6186,13 +6585,10 @@
             }
         },
         "exec-sh": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-            "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
-            "dev": true,
-            "requires": {
-                "merge": "^1.2.0"
-            }
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+            "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+            "dev": true
         },
         "execa": {
             "version": "0.7.0",
@@ -6271,57 +6667,6 @@
                 }
             }
         },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true,
-            "requires": {
-                "fill-range": "^2.1.0"
-            },
-            "dependencies": {
-                "fill-range": {
-                    "version": "2.2.4",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-                    "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-                    "dev": true,
-                    "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^3.0.0",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
-                    }
-                },
-                "is-number": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    }
-                },
-                "isobject": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                    "dev": true,
-                    "requires": {
-                        "isarray": "1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
-        },
         "expand-tilde": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -6332,17 +6677,17 @@
             }
         },
         "expect": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
-            "integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-24.7.1.tgz",
+            "integrity": "sha512-mGfvMTPduksV3xoI0xur56pQsg2vJjNf5+a+bXOjqCkiCBbmCayrBbHS/75y9K430cfqyocPr2ZjiNiRx4SRKw==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.7.0",
                 "ansi-styles": "^3.2.0",
-                "jest-diff": "^23.6.0",
-                "jest-get-type": "^22.1.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-regex-util": "^23.3.0"
+                "jest-get-type": "^24.3.0",
+                "jest-matcher-utils": "^24.7.0",
+                "jest-message-util": "^24.7.1",
+                "jest-regex-util": "^24.3.0"
             }
         },
         "express": {
@@ -6652,12 +6997,6 @@
                 "ramda": "^0.21.0"
             }
         },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
-        },
         "fileset": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
@@ -6782,15 +7121,6 @@
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
-        },
-        "for-own": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true,
-            "requires": {
-                "for-in": "^1.0.1"
-            }
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -7521,42 +7851,6 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
-            "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^2.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                }
-            }
-        },
         "glob-parent": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -7668,12 +7962,12 @@
             }
         },
         "handlebars": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-            "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+            "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
             "dev": true,
             "requires": {
-                "async": "^2.5.0",
+                "neo-async": "^2.6.0",
                 "optimist": "^0.6.1",
                 "source-map": "^0.6.1",
                 "uglify-js": "^3.1.4"
@@ -8121,13 +8415,67 @@
             }
         },
         "import-local": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-            "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+            "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0",
                 "resolve-cwd": "^2.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+                    "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0"
+                    }
+                }
             }
         },
         "imurmurhash": {
@@ -8336,12 +8684,12 @@
             "dev": true
         },
         "is-ci": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-            "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
             "dev": true,
             "requires": {
-                "ci-info": "^1.5.0"
+                "ci-info": "^2.0.0"
             }
         },
         "is-data-descriptor": {
@@ -8401,21 +8749,6 @@
             "integrity": "sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0=",
             "dev": true
         },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
-            "requires": {
-                "is-primitive": "^2.0.0"
-            }
-        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -8453,9 +8786,9 @@
             "dev": true
         },
         "is-generator-fn": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-            "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true
         },
         "is-glob": {
@@ -8507,18 +8840,6 @@
             "requires": {
                 "isobject": "^3.0.1"
             }
-        },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
         },
         "is-promise": {
             "version": "2.1.0",
@@ -8589,12 +8910,6 @@
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
             "dev": true
         },
-        "is-utf8": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-            "dev": true
-        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -8642,456 +8957,303 @@
             "dev": true
         },
         "istanbul-api": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
-            "integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.5.tgz",
+            "integrity": "sha512-meYk1BwDp59Pfse1TvPrkKYgVqAufbdBLEVoqvu/hLLKSaQ054ZTksbNepyc223tMnWdm6AdK2URIJJRqdP87g==",
             "dev": true,
             "requires": {
-                "async": "^2.1.4",
-                "fileset": "^2.0.2",
-                "istanbul-lib-coverage": "^1.2.1",
-                "istanbul-lib-hook": "^1.2.2",
-                "istanbul-lib-instrument": "^1.10.2",
-                "istanbul-lib-report": "^1.1.5",
-                "istanbul-lib-source-maps": "^1.2.6",
-                "istanbul-reports": "^1.5.1",
-                "js-yaml": "^3.7.0",
-                "mkdirp": "^0.5.1",
+                "async": "^2.6.1",
+                "compare-versions": "^3.2.1",
+                "fileset": "^2.0.3",
+                "istanbul-lib-coverage": "^2.0.4",
+                "istanbul-lib-hook": "^2.0.6",
+                "istanbul-lib-instrument": "^3.2.0",
+                "istanbul-lib-report": "^2.0.7",
+                "istanbul-lib-source-maps": "^3.0.5",
+                "istanbul-reports": "^2.2.3",
+                "js-yaml": "^3.13.0",
+                "make-dir": "^2.1.0",
+                "minimatch": "^3.0.4",
                 "once": "^1.4.0"
+            },
+            "dependencies": {
+                "js-yaml": {
+                    "version": "3.13.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+                    "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                }
             }
         },
         "istanbul-lib-coverage": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-            "integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+            "integrity": "sha512-LXTBICkMARVgo579kWDm8SqfB6nvSDKNqIOBEjmJRnL04JvoMHCYGWaMddQnseJYtkEuEvO/sIcOxPLk9gERug==",
             "dev": true
         },
         "istanbul-lib-hook": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
-            "integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.6.tgz",
+            "integrity": "sha512-829DKONApZ7UCiPXcOYWSgkFXa4+vNYoNOt3F+4uDJLKL1OotAoVwvThoEj1i8jmOj7odbYcR3rnaHu+QroaXg==",
             "dev": true,
             "requires": {
-                "append-transform": "^0.4.0"
+                "append-transform": "^1.0.0"
             }
         },
         "istanbul-lib-instrument": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
-            "integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.2.0.tgz",
+            "integrity": "sha512-06IM3xShbNW4NgZv5AP4QH0oHqf1/ivFo8eFys0ZjPXHGldHJQWb3riYOKXqmOqfxXBfxu4B+g/iuhOPZH0RJg==",
             "dev": true,
             "requires": {
-                "babel-generator": "^6.18.0",
-                "babel-template": "^6.16.0",
-                "babel-traverse": "^6.18.0",
-                "babel-types": "^6.18.0",
-                "babylon": "^6.18.0",
-                "istanbul-lib-coverage": "^1.2.1",
-                "semver": "^5.3.0"
+                "@babel/generator": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "istanbul-lib-coverage": "^2.0.4",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+                    "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+                    "dev": true
+                }
             }
         },
         "istanbul-lib-report": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
-            "integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.7.tgz",
+            "integrity": "sha512-wLH6beJBFbRBLiTlMOBxmb85cnVM1Vyl36N48e4e/aTKSM3WbOx7zbVIH1SQ537fhhsPbX0/C5JB4qsmyRXXyA==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "^1.2.1",
-                "mkdirp": "^0.5.1",
-                "path-parse": "^1.0.5",
-                "supports-color": "^3.1.2"
+                "istanbul-lib-coverage": "^2.0.4",
+                "make-dir": "^2.1.0",
+                "supports-color": "^6.0.0"
             },
             "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^1.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
         },
         "istanbul-lib-source-maps": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
-            "integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.5.tgz",
+            "integrity": "sha512-eDhZ7r6r1d1zQPVZehLc3D0K14vRba/eBYkz3rw16DLOrrTzve9RmnkcwrrkWVgO1FL3EK5knujVe5S8QHE9xw==",
             "dev": true,
             "requires": {
-                "debug": "^3.1.0",
-                "istanbul-lib-coverage": "^1.2.1",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.6.1",
-                "source-map": "^0.5.3"
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^2.0.4",
+                "make-dir": "^2.1.0",
+                "rimraf": "^2.6.2",
+                "source-map": "^0.6.1"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
                 }
             }
         },
         "istanbul-reports": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
-            "integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.3.tgz",
+            "integrity": "sha512-T6EbPuc8Cb620LWAYyZ4D8SSn06dY9i1+IgUX2lTH8gbwflMc9Obd33zHTyNX653ybjpamAHS9toKS3E6cGhTw==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.0.3"
+                "handlebars": "^4.1.0"
             }
         },
         "jest": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
-            "integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-24.7.1.tgz",
+            "integrity": "sha512-AbvRar5r++izmqo5gdbAjTeA6uNRGoNRuj5vHB0OnDXo2DXWZJVuaObiGgtlvhKb+cWy2oYbQSfxv7Q7GjnAtA==",
             "dev": true,
             "requires": {
-                "import-local": "^1.0.0",
-                "jest-cli": "^23.6.0"
+                "import-local": "^2.0.0",
+                "jest-cli": "^24.7.1"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.0.1"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
                 "jest-cli": {
-                    "version": "23.6.0",
-                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
-                    "integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
+                    "version": "24.7.1",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.7.1.tgz",
+                    "integrity": "sha512-32OBoSCVPzcTslGFl6yVCMzB2SqX3IrWwZCY5mZYkb0D2WsogmU3eV2o8z7+gRQa4o4sZPX/k7GU+II7CxM6WQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-escapes": "^3.0.0",
+                        "@jest/core": "^24.7.1",
+                        "@jest/test-result": "^24.7.1",
+                        "@jest/types": "^24.7.0",
                         "chalk": "^2.0.1",
                         "exit": "^0.1.2",
-                        "glob": "^7.1.2",
-                        "graceful-fs": "^4.1.11",
-                        "import-local": "^1.0.0",
-                        "is-ci": "^1.0.10",
-                        "istanbul-api": "^1.3.1",
-                        "istanbul-lib-coverage": "^1.2.0",
-                        "istanbul-lib-instrument": "^1.10.1",
-                        "istanbul-lib-source-maps": "^1.2.4",
-                        "jest-changed-files": "^23.4.2",
-                        "jest-config": "^23.6.0",
-                        "jest-environment-jsdom": "^23.4.0",
-                        "jest-get-type": "^22.1.0",
-                        "jest-haste-map": "^23.6.0",
-                        "jest-message-util": "^23.4.0",
-                        "jest-regex-util": "^23.3.0",
-                        "jest-resolve-dependencies": "^23.6.0",
-                        "jest-runner": "^23.6.0",
-                        "jest-runtime": "^23.6.0",
-                        "jest-snapshot": "^23.6.0",
-                        "jest-util": "^23.4.0",
-                        "jest-validate": "^23.6.0",
-                        "jest-watcher": "^23.4.0",
-                        "jest-worker": "^23.2.0",
-                        "micromatch": "^2.3.11",
-                        "node-notifier": "^5.2.1",
-                        "prompts": "^0.1.9",
-                        "realpath-native": "^1.0.0",
-                        "rimraf": "^2.5.4",
-                        "slash": "^1.0.0",
-                        "string-length": "^2.0.0",
-                        "strip-ansi": "^4.0.0",
-                        "which": "^1.2.12",
-                        "yargs": "^11.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "import-local": "^2.0.0",
+                        "is-ci": "^2.0.0",
+                        "jest-config": "^24.7.1",
+                        "jest-util": "^24.7.1",
+                        "jest-validate": "^24.7.0",
+                        "prompts": "^2.0.1",
+                        "realpath-native": "^1.1.0",
+                        "yargs": "^12.0.2"
                     }
                 }
             }
         },
         "jest-changed-files": {
-            "version": "23.4.2",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
-            "integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
+            "version": "24.7.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.7.0.tgz",
+            "integrity": "sha512-33BgewurnwSfJrW7T5/ZAXGE44o7swLslwh8aUckzq2e17/2Os1V0QU506ZNik3hjs8MgnEMKNkcud442NCDTw==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.7.0",
+                "execa": "^1.0.0",
                 "throat": "^4.0.0"
-            }
-        },
-        "jest-config": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
-            "integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
-            "dev": true,
-            "requires": {
-                "babel-core": "^6.0.0",
-                "babel-jest": "^23.6.0",
-                "chalk": "^2.0.1",
-                "glob": "^7.1.1",
-                "jest-environment-jsdom": "^23.4.0",
-                "jest-environment-node": "^23.4.0",
-                "jest-get-type": "^22.1.0",
-                "jest-jasmine2": "^23.6.0",
-                "jest-regex-util": "^23.3.0",
-                "jest-resolve": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-validate": "^23.6.0",
-                "micromatch": "^2.3.11",
-                "pretty-format": "^23.6.0"
             },
             "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1"
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "babel-core": {
-                    "version": "6.26.3",
-                    "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-                    "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-                    "dev": true,
-                    "requires": {
-                        "babel-code-frame": "^6.26.0",
-                        "babel-generator": "^6.26.0",
-                        "babel-helpers": "^6.24.1",
-                        "babel-messages": "^6.23.0",
-                        "babel-register": "^6.26.0",
-                        "babel-runtime": "^6.26.0",
-                        "babel-template": "^6.26.0",
-                        "babel-traverse": "^6.26.0",
-                        "babel-types": "^6.26.0",
-                        "babylon": "^6.18.0",
-                        "convert-source-map": "^1.5.1",
-                        "debug": "^2.6.9",
-                        "json5": "^0.5.1",
-                        "lodash": "^4.17.4",
-                        "minimatch": "^3.0.4",
-                        "path-is-absolute": "^1.0.1",
-                        "private": "^0.1.8",
-                        "slash": "^1.0.0",
-                        "source-map": "^0.5.7"
-                    }
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "is-extglob": {
+                "execa": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     }
                 },
-                "json5": {
-                    "version": "0.5.1",
-                    "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "pump": "^3.0.0"
                     }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
                 }
             }
         },
+        "jest-config": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.7.1.tgz",
+            "integrity": "sha512-8FlJNLI+X+MU37j7j8RE4DnJkvAghXmBWdArVzypW6WxfGuxiL/CCkzBg0gHtXhD2rxla3IMOSUAHylSKYJ83g==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "@jest/test-sequencer": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "babel-jest": "^24.7.1",
+                "chalk": "^2.0.1",
+                "glob": "^7.1.1",
+                "jest-environment-jsdom": "^24.7.1",
+                "jest-environment-node": "^24.7.1",
+                "jest-get-type": "^24.3.0",
+                "jest-jasmine2": "^24.7.1",
+                "jest-regex-util": "^24.3.0",
+                "jest-resolve": "^24.7.1",
+                "jest-util": "^24.7.1",
+                "jest-validate": "^24.7.0",
+                "micromatch": "^3.1.10",
+                "pretty-format": "^24.7.0",
+                "realpath-native": "^1.1.0"
+            }
+        },
         "jest-diff": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
-            "integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
+            "version": "24.7.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.7.0.tgz",
+            "integrity": "sha512-ULQZ5B1lWpH70O4xsANC4tf4Ko6RrpwhE3PtG6ERjMg1TiYTC2Wp4IntJVGro6a8HG9luYHhhmF4grF0Pltckg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.1",
-                "diff": "^3.2.0",
-                "jest-get-type": "^22.1.0",
-                "pretty-format": "^23.6.0"
+                "diff-sequences": "^24.3.0",
+                "jest-get-type": "^24.3.0",
+                "pretty-format": "^24.7.0"
             }
         },
         "jest-docblock": {
@@ -9101,360 +9263,765 @@
             "dev": true
         },
         "jest-each": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
-            "integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.7.1.tgz",
+            "integrity": "sha512-4fsS8fEfLa3lfnI1Jw6NxjhyRTgfpuOVTeUZZFyVYqeTa4hPhr2YkToUhouuLTrL2eMGOfpbdMyRx0GQ/VooKA==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.7.0",
                 "chalk": "^2.0.1",
-                "pretty-format": "^23.6.0"
+                "jest-get-type": "^24.3.0",
+                "jest-util": "^24.7.1",
+                "pretty-format": "^24.7.0"
             }
         },
         "jest-environment-jsdom": {
-            "version": "23.4.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
-            "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.7.1.tgz",
+            "integrity": "sha512-Gnhb+RqE2JuQGb3kJsLF8vfqjt3PHKSstq4Xc8ic+ax7QKo4Z0RWGucU3YV+DwKR3T9SYc+3YCUQEJs8r7+Jxg==",
             "dev": true,
             "requires": {
-                "jest-mock": "^23.2.0",
-                "jest-util": "^23.4.0",
+                "@jest/environment": "^24.7.1",
+                "@jest/fake-timers": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "jest-mock": "^24.7.0",
+                "jest-util": "^24.7.1",
                 "jsdom": "^11.5.1"
             }
         },
         "jest-environment-node": {
-            "version": "23.4.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
-            "integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.7.1.tgz",
+            "integrity": "sha512-GJJQt1p9/C6aj6yNZMvovZuxTUd+BEJprETdvTKSb4kHcw4mFj8777USQV0FJoJ4V3djpOwA5eWyPwfq//PFBA==",
             "dev": true,
             "requires": {
-                "jest-mock": "^23.2.0",
-                "jest-util": "^23.4.0"
+                "@jest/environment": "^24.7.1",
+                "@jest/fake-timers": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "jest-mock": "^24.7.0",
+                "jest-util": "^24.7.1"
             }
         },
         "jest-get-type": {
-            "version": "22.4.3",
-            "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-            "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
+            "integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
             "dev": true
         },
         "jest-haste-map": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
-            "integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.7.1.tgz",
+            "integrity": "sha512-g0tWkzjpHD2qa03mTKhlydbmmYiA2KdcJe762SbfFo/7NIMgBWAA0XqQlApPwkWOF7Cxoi/gUqL0i6DIoLpMBw==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.7.0",
+                "anymatch": "^2.0.0",
                 "fb-watchman": "^2.0.0",
-                "graceful-fs": "^4.1.11",
+                "fsevents": "^1.2.7",
+                "graceful-fs": "^4.1.15",
                 "invariant": "^2.2.4",
-                "jest-docblock": "^23.2.0",
-                "jest-serializer": "^23.0.1",
-                "jest-worker": "^23.2.0",
-                "micromatch": "^2.3.11",
-                "sane": "^2.0.0"
+                "jest-serializer": "^24.4.0",
+                "jest-util": "^24.7.1",
+                "jest-worker": "^24.6.0",
+                "micromatch": "^3.1.10",
+                "sane": "^4.0.3",
+                "walker": "^1.0.7"
             },
             "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                "fsevents": {
+                    "version": "1.2.8",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
+                    "integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1"
+                        "nan": "^2.12.1",
+                        "node-pre-gyp": "^0.12.0"
+                    },
+                    "dependencies": {
+                        "abbrev": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "are-we-there-yet": {
+                            "version": "1.1.5",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "delegates": "^1.0.0",
+                                "readable-stream": "^2.0.6"
+                            }
+                        },
+                        "balanced-match": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "brace-expansion": {
+                            "version": "1.1.11",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "balanced-match": "^1.0.0",
+                                "concat-map": "0.0.1"
+                            }
+                        },
+                        "chownr": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "code-point-at": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "concat-map": {
+                            "version": "0.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "console-control-strings": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "core-util-is": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "debug": {
+                            "version": "4.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "ms": "^2.1.1"
+                            }
+                        },
+                        "deep-extend": {
+                            "version": "0.6.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "delegates": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "detect-libc": {
+                            "version": "1.0.3",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "fs-minipass": {
+                            "version": "1.2.5",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "minipass": "^2.2.1"
+                            }
+                        },
+                        "fs.realpath": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "gauge": {
+                            "version": "2.7.4",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "aproba": "^1.0.3",
+                                "console-control-strings": "^1.0.0",
+                                "has-unicode": "^2.0.0",
+                                "object-assign": "^4.1.0",
+                                "signal-exit": "^3.0.0",
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wide-align": "^1.1.0"
+                            }
+                        },
+                        "glob": {
+                            "version": "7.1.3",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        },
+                        "has-unicode": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "iconv-lite": {
+                            "version": "0.4.24",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "safer-buffer": ">= 2.1.2 < 3"
+                            }
+                        },
+                        "ignore-walk": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "minimatch": "^3.0.4"
+                            }
+                        },
+                        "inflight": {
+                            "version": "1.0.6",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "once": "^1.3.0",
+                                "wrappy": "1"
+                            }
+                        },
+                        "inherits": {
+                            "version": "2.0.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ini": {
+                            "version": "1.3.5",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "number-is-nan": "^1.0.0"
+                            }
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        },
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "minipass": {
+                            "version": "2.3.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
+                            }
+                        },
+                        "minizlib": {
+                            "version": "1.2.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "minipass": "^2.2.1"
+                            }
+                        },
+                        "mkdirp": {
+                            "version": "0.5.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "minimist": "0.0.8"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "needle": {
+                            "version": "2.3.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "debug": "^4.1.0",
+                                "iconv-lite": "^0.4.4",
+                                "sax": "^1.2.4"
+                            }
+                        },
+                        "node-pre-gyp": {
+                            "version": "0.12.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "detect-libc": "^1.0.2",
+                                "mkdirp": "^0.5.1",
+                                "needle": "^2.2.1",
+                                "nopt": "^4.0.1",
+                                "npm-packlist": "^1.1.6",
+                                "npmlog": "^4.0.2",
+                                "rc": "^1.2.7",
+                                "rimraf": "^2.6.1",
+                                "semver": "^5.3.0",
+                                "tar": "^4"
+                            }
+                        },
+                        "nopt": {
+                            "version": "4.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "abbrev": "1",
+                                "osenv": "^0.1.4"
+                            }
+                        },
+                        "npm-bundled": {
+                            "version": "1.0.6",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "npm-packlist": {
+                            "version": "1.4.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "ignore-walk": "^3.0.1",
+                                "npm-bundled": "^1.0.1"
+                            }
+                        },
+                        "npmlog": {
+                            "version": "4.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "are-we-there-yet": "~1.1.2",
+                                "console-control-strings": "~1.1.0",
+                                "gauge": "~2.7.3",
+                                "set-blocking": "~2.0.0"
+                            }
+                        },
+                        "number-is-nan": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "object-assign": {
+                            "version": "4.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "once": {
+                            "version": "1.4.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "wrappy": "1"
+                            }
+                        },
+                        "os-homedir": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "os-tmpdir": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "osenv": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "os-homedir": "^1.0.0",
+                                "os-tmpdir": "^1.0.0"
+                            }
+                        },
+                        "path-is-absolute": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "process-nextick-args": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "rc": {
+                            "version": "1.2.8",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "deep-extend": "^0.6.0",
+                                "ini": "~1.3.0",
+                                "minimist": "^1.2.0",
+                                "strip-json-comments": "~2.0.1"
+                            },
+                            "dependencies": {
+                                "minimist": {
+                                    "version": "1.2.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "optional": true
+                                }
+                            }
+                        },
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "rimraf": {
+                            "version": "2.6.3",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "glob": "^7.1.3"
+                            }
+                        },
+                        "safe-buffer": {
+                            "version": "5.1.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "safer-buffer": {
+                            "version": "2.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "sax": {
+                            "version": "1.2.4",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "semver": {
+                            "version": "5.7.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "set-blocking": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "signal-exit": {
+                            "version": "3.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^2.0.0"
+                            }
+                        },
+                        "strip-json-comments": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "tar": {
+                            "version": "4.4.8",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "chownr": "^1.1.1",
+                                "fs-minipass": "^1.2.5",
+                                "minipass": "^2.3.4",
+                                "minizlib": "^1.1.1",
+                                "mkdirp": "^0.5.0",
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.2"
+                            }
+                        },
+                        "util-deprecate": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "wide-align": {
+                            "version": "1.1.3",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "string-width": "^1.0.2 || 2"
+                            }
+                        },
+                        "wrappy": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "yallist": {
+                            "version": "3.0.3",
+                            "bundled": true,
+                            "dev": true
+                        }
                     }
                 },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                "nan": {
+                    "version": "2.13.2",
+                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+                    "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
                     "dev": true,
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "jest-docblock": {
-                    "version": "23.2.0",
-                    "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
-                    "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
-                    "dev": true,
-                    "requires": {
-                        "detect-newline": "^2.1.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    }
+                    "optional": true
                 }
             }
         },
         "jest-jasmine2": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
-            "integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.7.1.tgz",
+            "integrity": "sha512-Y/9AOJDV1XS44wNwCaThq4Pw3gBPiOv/s6NcbOAkVRRUEPu+36L2xoPsqQXsDrxoBerqeyslpn2TpCI8Zr6J2w==",
             "dev": true,
             "requires": {
-                "babel-traverse": "^6.0.0",
+                "@babel/traverse": "^7.1.0",
+                "@jest/environment": "^24.7.1",
+                "@jest/test-result": "^24.7.1",
+                "@jest/types": "^24.7.0",
                 "chalk": "^2.0.1",
                 "co": "^4.6.0",
-                "expect": "^23.6.0",
-                "is-generator-fn": "^1.0.0",
-                "jest-diff": "^23.6.0",
-                "jest-each": "^23.6.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-snapshot": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "pretty-format": "^23.6.0"
+                "expect": "^24.7.1",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^24.7.1",
+                "jest-matcher-utils": "^24.7.0",
+                "jest-message-util": "^24.7.1",
+                "jest-runtime": "^24.7.1",
+                "jest-snapshot": "^24.7.1",
+                "jest-util": "^24.7.1",
+                "pretty-format": "^24.7.0",
+                "throat": "^4.0.0"
             }
         },
         "jest-leak-detector": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
-            "integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
+            "version": "24.7.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.7.0.tgz",
+            "integrity": "sha512-zV0qHKZGXtmPVVzT99CVEcHE9XDf+8LwiE0Ob7jjezERiGVljmqKFWpV2IkG+rkFIEUHFEkMiICu7wnoPM/RoQ==",
             "dev": true,
             "requires": {
-                "pretty-format": "^23.6.0"
+                "pretty-format": "^24.7.0"
             }
         },
         "jest-matcher-utils": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
-            "integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
+            "version": "24.7.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.7.0.tgz",
+            "integrity": "sha512-158ieSgk3LNXeUhbVJYRXyTPSCqNgVXOp/GT7O94mYd3pk/8+odKTyR1JLtNOQSPzNi8NFYVONtvSWA/e1RDXg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.1",
-                "jest-get-type": "^22.1.0",
-                "pretty-format": "^23.6.0"
+                "jest-diff": "^24.7.0",
+                "jest-get-type": "^24.3.0",
+                "pretty-format": "^24.7.0"
             }
         },
         "jest-message-util": {
-            "version": "23.4.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
-            "integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.7.1.tgz",
+            "integrity": "sha512-dk0gqVtyqezCHbcbk60CdIf+8UHgD+lmRHifeH3JRcnAqh4nEyPytSc9/L1+cQyxC+ceaeP696N4ATe7L+omcg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0-beta.35",
+                "@babel/code-frame": "^7.0.0",
+                "@jest/test-result": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "@types/stack-utils": "^1.0.1",
                 "chalk": "^2.0.1",
-                "micromatch": "^2.3.11",
-                "slash": "^1.0.0",
+                "micromatch": "^3.1.10",
+                "slash": "^2.0.0",
                 "stack-utils": "^1.0.1"
             },
             "dependencies": {
-                "arr-diff": {
+                "slash": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.0.1"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
                     "dev": true
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    }
                 }
             }
         },
         "jest-mock": {
-            "version": "23.2.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
-            "integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=",
+            "version": "24.7.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.7.0.tgz",
+            "integrity": "sha512-6taW4B4WUcEiT2V9BbOmwyGuwuAFT2G8yghF7nyNW1/2gq5+6aTqSPcS9lS6ArvEkX55vbPAS/Jarx5LSm4Fng==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.7.0"
+            }
+        },
+        "jest-pnp-resolver": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+            "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
             "dev": true
         },
         "jest-regex-util": {
-            "version": "23.3.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
-            "integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U=",
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+            "integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
             "dev": true
         },
         "jest-resolve": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
-            "integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.7.1.tgz",
+            "integrity": "sha512-Bgrc+/UUZpGJ4323sQyj85hV9d+ANyPNu6XfRDUcyFNX1QrZpSoM0kE4Mb2vZMAYTJZsBFzYe8X1UaOkOELSbw==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.7.0",
                 "browser-resolve": "^1.11.3",
                 "chalk": "^2.0.1",
-                "realpath-native": "^1.0.0"
+                "jest-pnp-resolver": "^1.2.1",
+                "realpath-native": "^1.1.0"
             }
         },
         "jest-resolve-dependencies": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
-            "integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.7.1.tgz",
+            "integrity": "sha512-2Eyh5LJB2liNzfk4eo7bD1ZyBbqEJIyyrFtZG555cSWW9xVHxII2NuOkSl1yUYTAYCAmM2f2aIT5A7HzNmubyg==",
             "dev": true,
             "requires": {
-                "jest-regex-util": "^23.3.0",
-                "jest-snapshot": "^23.6.0"
+                "@jest/types": "^24.7.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-snapshot": "^24.7.1"
             }
         },
         "jest-runner": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
-            "integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.7.1.tgz",
+            "integrity": "sha512-aNFc9liWU/xt+G9pobdKZ4qTeG/wnJrJna3VqunziDNsWT3EBpmxXZRBMKCsNMyfy+A/XHiV+tsMLufdsNdgCw==",
             "dev": true,
             "requires": {
+                "@jest/console": "^24.7.1",
+                "@jest/environment": "^24.7.1",
+                "@jest/test-result": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "chalk": "^2.4.2",
                 "exit": "^0.1.2",
-                "graceful-fs": "^4.1.11",
-                "jest-config": "^23.6.0",
-                "jest-docblock": "^23.2.0",
-                "jest-haste-map": "^23.6.0",
-                "jest-jasmine2": "^23.6.0",
-                "jest-leak-detector": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-runtime": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-worker": "^23.2.0",
+                "graceful-fs": "^4.1.15",
+                "jest-config": "^24.7.1",
+                "jest-docblock": "^24.3.0",
+                "jest-haste-map": "^24.7.1",
+                "jest-jasmine2": "^24.7.1",
+                "jest-leak-detector": "^24.7.0",
+                "jest-message-util": "^24.7.1",
+                "jest-resolve": "^24.7.1",
+                "jest-runtime": "^24.7.1",
+                "jest-util": "^24.7.1",
+                "jest-worker": "^24.6.0",
                 "source-map-support": "^0.5.6",
                 "throat": "^4.0.0"
             },
             "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
                 "jest-docblock": {
-                    "version": "23.2.0",
-                    "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
-                    "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
+                    "version": "24.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+                    "integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
                     "dev": true,
                     "requires": {
                         "detect-newline": "^2.1.0"
@@ -9463,219 +10030,102 @@
             }
         },
         "jest-runtime": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
-            "integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.7.1.tgz",
+            "integrity": "sha512-0VAbyBy7tll3R+82IPJpf6QZkokzXPIS71aDeqh+WzPRXRCNz6StQ45otFariPdJ4FmXpDiArdhZrzNAC3sj6A==",
             "dev": true,
             "requires": {
-                "babel-core": "^6.0.0",
-                "babel-plugin-istanbul": "^4.1.6",
+                "@jest/console": "^24.7.1",
+                "@jest/environment": "^24.7.1",
+                "@jest/source-map": "^24.3.0",
+                "@jest/transform": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "@types/yargs": "^12.0.2",
                 "chalk": "^2.0.1",
-                "convert-source-map": "^1.4.0",
                 "exit": "^0.1.2",
-                "fast-json-stable-stringify": "^2.0.0",
-                "graceful-fs": "^4.1.11",
-                "jest-config": "^23.6.0",
-                "jest-haste-map": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-regex-util": "^23.3.0",
-                "jest-resolve": "^23.6.0",
-                "jest-snapshot": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-validate": "^23.6.0",
-                "micromatch": "^2.3.11",
-                "realpath-native": "^1.0.0",
-                "slash": "^1.0.0",
-                "strip-bom": "3.0.0",
-                "write-file-atomic": "^2.1.0",
-                "yargs": "^11.0.0"
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.1.15",
+                "jest-config": "^24.7.1",
+                "jest-haste-map": "^24.7.1",
+                "jest-message-util": "^24.7.1",
+                "jest-mock": "^24.7.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-resolve": "^24.7.1",
+                "jest-snapshot": "^24.7.1",
+                "jest-util": "^24.7.1",
+                "jest-validate": "^24.7.0",
+                "realpath-native": "^1.1.0",
+                "slash": "^2.0.0",
+                "strip-bom": "^3.0.0",
+                "yargs": "^12.0.2"
             },
             "dependencies": {
-                "arr-diff": {
+                "slash": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.0.1"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "babel-core": {
-                    "version": "6.26.3",
-                    "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-                    "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-                    "dev": true,
-                    "requires": {
-                        "babel-code-frame": "^6.26.0",
-                        "babel-generator": "^6.26.0",
-                        "babel-helpers": "^6.24.1",
-                        "babel-messages": "^6.23.0",
-                        "babel-register": "^6.26.0",
-                        "babel-runtime": "^6.26.0",
-                        "babel-template": "^6.26.0",
-                        "babel-traverse": "^6.26.0",
-                        "babel-types": "^6.26.0",
-                        "babylon": "^6.18.0",
-                        "convert-source-map": "^1.5.1",
-                        "debug": "^2.6.9",
-                        "json5": "^0.5.1",
-                        "lodash": "^4.17.4",
-                        "minimatch": "^3.0.4",
-                        "path-is-absolute": "^1.0.1",
-                        "private": "^0.1.8",
-                        "slash": "^1.0.0",
-                        "source-map": "^0.5.7"
-                    }
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "json5": {
-                    "version": "0.5.1",
-                    "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                },
-                "strip-bom": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
                     "dev": true
                 }
             }
         },
         "jest-serializer": {
-            "version": "23.0.1",
-            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-            "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
+            "version": "24.4.0",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+            "integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
             "dev": true
         },
         "jest-snapshot": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
-            "integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.7.1.tgz",
+            "integrity": "sha512-8Xk5O4p+JsZZn4RCNUS3pxA+ORKpEKepE+a5ejIKrId9CwrVN0NY+vkqEkXqlstA5NMBkNahXkR/4qEBy0t5yA==",
             "dev": true,
             "requires": {
-                "babel-types": "^6.0.0",
+                "@babel/types": "^7.0.0",
+                "@jest/types": "^24.7.0",
                 "chalk": "^2.0.1",
-                "jest-diff": "^23.6.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-resolve": "^23.6.0",
+                "expect": "^24.7.1",
+                "jest-diff": "^24.7.0",
+                "jest-matcher-utils": "^24.7.0",
+                "jest-message-util": "^24.7.1",
+                "jest-resolve": "^24.7.1",
                 "mkdirp": "^0.5.1",
                 "natural-compare": "^1.4.0",
-                "pretty-format": "^23.6.0",
+                "pretty-format": "^24.7.0",
                 "semver": "^5.5.0"
             }
         },
         "jest-util": {
-            "version": "23.4.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
-            "integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.7.1.tgz",
+            "integrity": "sha512-/KilOue2n2rZ5AnEBYoxOXkeTu6vi7cjgQ8MXEkih0oeAXT6JkS3fr7/j8+engCjciOU1Nq5loMSKe0A1oeX0A==",
             "dev": true,
             "requires": {
-                "callsites": "^2.0.0",
+                "@jest/console": "^24.7.1",
+                "@jest/fake-timers": "^24.7.1",
+                "@jest/source-map": "^24.3.0",
+                "@jest/test-result": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "callsites": "^3.0.0",
                 "chalk": "^2.0.1",
-                "graceful-fs": "^4.1.11",
-                "is-ci": "^1.0.10",
-                "jest-message-util": "^23.4.0",
+                "graceful-fs": "^4.1.15",
+                "is-ci": "^2.0.0",
                 "mkdirp": "^0.5.1",
-                "slash": "^1.0.0",
+                "slash": "^2.0.0",
                 "source-map": "^0.6.0"
             },
             "dependencies": {
+                "callsites": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+                    "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9685,35 +10135,53 @@
             }
         },
         "jest-validate": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
-            "integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
+            "version": "24.7.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.7.0.tgz",
+            "integrity": "sha512-cgai/gts9B2chz1rqVdmLhzYxQbgQurh1PEQSvSgPZ8KGa1AqXsqC45W5wKEwzxKrWqypuQrQxnF4+G9VejJJA==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.7.0",
+                "camelcase": "^5.0.0",
                 "chalk": "^2.0.1",
-                "jest-get-type": "^22.1.0",
+                "jest-get-type": "^24.3.0",
                 "leven": "^2.1.0",
-                "pretty-format": "^23.6.0"
+                "pretty-format": "^24.7.0"
             }
         },
         "jest-watcher": {
-            "version": "23.4.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
-            "integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.7.1.tgz",
+            "integrity": "sha512-Wd6TepHLRHVKLNPacEsBwlp9raeBIO+01xrN24Dek4ggTS8HHnOzYSFnvp+6MtkkJ3KfMzy220KTi95e2rRkrw==",
             "dev": true,
             "requires": {
+                "@jest/test-result": "^24.7.1",
+                "@jest/types": "^24.7.0",
+                "@types/yargs": "^12.0.9",
                 "ansi-escapes": "^3.0.0",
                 "chalk": "^2.0.1",
+                "jest-util": "^24.7.1",
                 "string-length": "^2.0.0"
             }
         },
         "jest-worker": {
-            "version": "23.2.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
-            "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+            "version": "24.6.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+            "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
             "dev": true,
             "requires": {
-                "merge-stream": "^1.0.1"
+                "merge-stream": "^1.0.1",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "js-base64": {
@@ -9907,9 +10375,9 @@
             }
         },
         "kleur": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
-            "integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
             "dev": true
         },
         "lazy-cache": {
@@ -10008,33 +10476,15 @@
             }
         },
         "load-json-file": {
-            "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
-            },
-            "dependencies": {
-                "parse-json": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-                    "dev": true,
-                    "requires": {
-                        "error-ex": "^1.2.0"
-                    }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                }
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
             }
         },
         "loader-fs-cache": {
@@ -10354,12 +10804,6 @@
             "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
             "dev": true
         },
-        "math-random": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-            "dev": true
-        },
         "md5.js": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -10395,12 +10839,6 @@
                 "errno": "^0.1.3",
                 "readable-stream": "^2.0.1"
             }
-        },
-        "merge": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-            "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-            "dev": true
         },
         "merge-descriptors": {
             "version": "1.0.1",
@@ -10804,12 +11242,13 @@
             "dev": true
         },
         "node-notifier": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
-            "integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+            "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
             "dev": true,
             "requires": {
                 "growly": "^1.3.0",
+                "is-wsl": "^1.1.0",
                 "semver": "^5.5.0",
                 "shellwords": "^0.1.1",
                 "which": "^1.3.0"
@@ -10924,9 +11363,9 @@
             "dev": true
         },
         "nwsapi": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-            "integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.3.tgz",
+            "integrity": "sha512-RowAaJGEgYXEZfQ7tvvdtAQUKPyTR6T6wNu0fwlNsGQYr/h3yQc6oI8WnVZh3Y/Sylwc+dtAlvPqfFZjhTyk3A==",
             "dev": true
         },
         "oauth-sign": {
@@ -11051,16 +11490,6 @@
                 "es-abstract": "^1.5.1"
             }
         },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true,
-            "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
-            }
-        },
         "object.pick": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -11136,7 +11565,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "0.0.10",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                     "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
                     "dev": true
                 },
@@ -11206,6 +11635,15 @@
             "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
             "dev": true
         },
+        "p-each-series": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+            "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+            "dev": true,
+            "requires": {
+                "p-reduce": "^1.0.0"
+            }
+        },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -11235,6 +11673,12 @@
             "requires": {
                 "p-limit": "^1.1.0"
             }
+        },
+        "p-reduce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+            "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+            "dev": true
         },
         "p-try": {
             "version": "1.0.0",
@@ -11279,35 +11723,6 @@
                 "create-hash": "^1.1.0",
                 "evp_bytestokey": "^1.0.0",
                 "pbkdf2": "^3.0.3"
-            }
-        },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
-            "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                }
             }
         },
         "parse-json": {
@@ -13391,12 +13806,6 @@
             "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
             "dev": true
         },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-            "dev": true
-        },
         "prettier": {
             "version": "1.14.2",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
@@ -13414,19 +13823,27 @@
             }
         },
         "pretty-format": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-            "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+            "version": "24.7.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
+            "integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
             "dev": true,
             "requires": {
-                "ansi-regex": "^3.0.0",
-                "ansi-styles": "^3.2.0"
+                "@jest/types": "^24.7.0",
+                "ansi-regex": "^4.0.0",
+                "ansi-styles": "^3.2.0",
+                "react-is": "^16.8.4"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "react-is": {
+                    "version": "16.8.6",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+                    "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
                     "dev": true
                 }
             }
@@ -13482,13 +13899,13 @@
             }
         },
         "prompts": {
-            "version": "0.1.14",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
-            "integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
+            "integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
             "dev": true,
             "requires": {
-                "kleur": "^2.0.1",
-                "sisteransi": "^0.1.1"
+                "kleur": "^3.0.2",
+                "sisteransi": "^1.0.0"
             }
         },
         "prop-types": {
@@ -13675,25 +14092,6 @@
             "requires": {
                 "discontinuous-range": "1.0.0",
                 "ret": "~0.1.10"
-            }
-        },
-        "randomatic": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-            "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-            "dev": true,
-            "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-                    "dev": true
-                }
             }
         },
         "randombytes": {
@@ -15457,63 +15855,68 @@
             }
         },
         "read-pkg": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
             "dev": true,
             "requires": {
-                "load-json-file": "^1.0.0",
+                "load-json-file": "^4.0.0",
                 "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
-            },
-            "dependencies": {
-                "path-type": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                }
+                "path-type": "^3.0.0"
             }
         },
         "read-pkg-up": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+            "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
             "dev": true,
             "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
             },
             "dependencies": {
                 "find-up": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "locate-path": "^3.0.0"
                     }
                 },
-                "path-exists": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "^2.0.0"
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
                     }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
                 }
             }
         },
@@ -15544,9 +15947,9 @@
             }
         },
         "realpath-native": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
-            "integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+            "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
             "dev": true,
             "requires": {
                 "util.promisify": "^1.0.0"
@@ -15664,15 +16067,6 @@
             "dev": true,
             "requires": {
                 "private": "^0.1.6"
-            }
-        },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "dev": true,
-            "requires": {
-                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -15842,23 +16236,23 @@
             }
         },
         "request-promise-core": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+            "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
             "dev": true,
             "requires": {
-                "lodash": "^4.13.1"
+                "lodash": "^4.17.11"
             }
         },
         "request-promise-native": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+            "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
             "dev": true,
             "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "^1.1.0",
-                "tough-cookie": ">=2.3.3"
+                "request-promise-core": "1.1.2",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
             }
         },
         "require-directory": {
@@ -16013,9 +16407,9 @@
             }
         },
         "rsvp": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+            "integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
             "dev": true
         },
         "run-async": {
@@ -16082,20 +16476,59 @@
             "dev": true
         },
         "sane": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
-            "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+            "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
             "dev": true,
             "requires": {
+                "@cnakazawa/watch": "^1.0.3",
                 "anymatch": "^2.0.0",
-                "capture-exit": "^1.2.0",
-                "exec-sh": "^0.2.0",
+                "capture-exit": "^2.0.0",
+                "exec-sh": "^0.3.2",
+                "execa": "^1.0.0",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^1.2.3",
                 "micromatch": "^3.1.4",
                 "minimist": "^1.1.1",
-                "walker": "~1.0.5",
-                "watch": "~0.18.0"
+                "walker": "~1.0.5"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                }
             }
         },
         "sax": {
@@ -16316,9 +16749,9 @@
             "dev": true
         },
         "sisteransi": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
-            "integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+            "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
             "dev": true
         },
         "slash": {
@@ -16815,13 +17248,10 @@
             }
         },
         "strip-bom": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true,
-            "requires": {
-                "is-utf8": "^0.2.0"
-            }
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
         },
         "strip-eof": {
             "version": "1.0.0",
@@ -17125,106 +17555,22 @@
             }
         },
         "test-exclude": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
-            "integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.2.tgz",
+            "integrity": "sha512-N2pvaLpT8guUpb5Fe1GJlmvmzH3x+DAKmmyEQmFP792QcLYoGE1syxztSvPD1V8yPe6VrcCt6YGQVjSRjCASsA==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.1",
-                "micromatch": "^2.3.11",
-                "object-assign": "^4.1.0",
-                "read-pkg-up": "^1.0.1",
-                "require-main-filename": "^1.0.1"
+                "glob": "^7.1.3",
+                "minimatch": "^3.0.4",
+                "read-pkg-up": "^4.0.0",
+                "require-main-filename": "^2.0.0"
             },
             "dependencies": {
-                "arr-diff": {
+                "require-main-filename": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.0.1"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
                     "dev": true
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    }
                 }
             }
         },
@@ -17947,16 +18293,6 @@
                 "loose-envify": "^1.0.0"
             }
         },
-        "watch": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
-            "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-            "dev": true,
-            "requires": {
-                "exec-sh": "^0.2.0",
-                "minimist": "^1.2.0"
-            }
-        },
         "watchpack": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
@@ -18484,9 +18820,9 @@
             }
         },
         "write-file-atomic": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-            "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+            "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11",
@@ -18528,23 +18864,23 @@
             "dev": true
         },
         "yargs": {
-            "version": "11.1.0",
-            "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-            "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+            "version": "12.0.5",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+            "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
             "dev": true,
             "requires": {
                 "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^3.0.0",
                 "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
+                "os-locale": "^3.0.0",
                 "require-directory": "^2.1.1",
                 "require-main-filename": "^1.0.1",
                 "set-blocking": "^2.0.0",
                 "string-width": "^2.0.0",
                 "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
+                "y18n": "^3.2.1 || ^4.0.0",
+                "yargs-parser": "^11.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -18553,10 +18889,139 @@
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                    "dev": true
+                },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "mem": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+                    "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+                    "dev": true,
+                    "requires": {
+                        "map-age-cleaner": "^0.1.1",
+                        "mimic-fn": "^2.0.0",
+                        "p-is-promise": "^2.0.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "p-is-promise": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+                    "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
                     "dev": true
                 },
                 "string-width": {
@@ -18577,30 +19042,17 @@
                     "requires": {
                         "ansi-regex": "^3.0.0"
                     }
-                },
-                "y18n": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-                    "dev": true
                 }
             }
         },
         "yargs-parser": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-            "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+            "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
             "dev": true,
             "requires": {
-                "camelcase": "^4.1.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-                    "dev": true
-                }
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,90 @@
                 "@babel/types": "^7.0.0"
             }
         },
+        "@babel/helper-create-class-features-plugin": {
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.3.tgz",
+            "integrity": "sha512-UMl3TSpX11PuODYdWGrUeW6zFkdYhDn7wRLrOuNVM6f9L+S9CzmDXYyrp3MTHcwWjnzur1f/Op8A7iYZWya2Yg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-member-expression-to-functions": "^7.0.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.4.0",
+                "@babel/helper-split-export-declaration": "^7.4.0"
+            },
+            "dependencies": {
+                "@babel/generator": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+                    "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.0",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.11",
+                        "source-map": "^0.5.0",
+                        "trim-right": "^1.0.1"
+                    }
+                },
+                "@babel/helper-replace-supers": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
+                    "integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-member-expression-to-functions": "^7.0.0",
+                        "@babel/helper-optimise-call-expression": "^7.0.0",
+                        "@babel/traverse": "^7.4.0",
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+                    "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+                    "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+                    "dev": true
+                },
+                "@babel/traverse": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+                    "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/generator": "^7.4.0",
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-split-export-declaration": "^7.4.0",
+                        "@babel/parser": "^7.4.3",
+                        "@babel/types": "^7.4.0",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.11"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+                    "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.11",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
         "@babel/helper-define-map": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
@@ -303,6 +387,18 @@
                 "@babel/plugin-syntax-class-properties": "^7.0.0"
             }
         },
+        "@babel/plugin-proposal-decorators": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.1.2.tgz",
+            "integrity": "sha512-YooynBO6PmBgHvAd0fl5e5Tq/a0pEC6RqF62ouafme8FzdIVH41Mz/u1dn8fFVm4jzEJ+g/MsOxouwybJPuP8Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/plugin-syntax-decorators": "^7.1.0"
+            }
+        },
         "@babel/plugin-proposal-export-default-from": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.0.0.tgz",
@@ -382,6 +478,24 @@
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
+        "@babel/plugin-syntax-decorators": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
+            "integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-dynamic-import": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
+            "integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
         "@babel/plugin-syntax-export-default-from": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.0.0.tgz",
@@ -401,9 +515,9 @@
             }
         },
         "@babel/plugin-syntax-flow": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0.tgz",
-            "integrity": "sha512-zGcuZWiWWDa5qTZ6iAnpG0fnX/GOu49pGR5PFvkQ9GmKNaSphXQnlNXh/LG20sqWtNrx/eB6krzfEzcwvUyeFA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
+            "integrity": "sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
@@ -440,6 +554,15 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
             "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-typescript": {
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
+            "integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
@@ -549,13 +672,13 @@
             }
         },
         "@babel/plugin-transform-flow-strip-types": {
-            "version": "7.1.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.1.6.tgz",
-            "integrity": "sha512-0tyFAAjJmnRlr8MVJV39ASn1hv+PbdVP71hf7aAseqLfQ0o9QXk9htbMbq7/ZYXnUIp6gDw0lUUP0+PQMbbtmg==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.0.tgz",
+            "integrity": "sha512-C4ZVNejHnfB22vI2TYN4RUp2oCmq6cSEAg4RygSvYZUECRqUu9O4PMEMNJ4wsemaRGg27BbgYctG4BZh+AgIHw==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-flow": "^7.0.0"
+                "@babel/plugin-syntax-flow": "^7.2.0"
             }
         },
         "@babel/plugin-transform-for-of": {
@@ -581,6 +704,15 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
             "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-member-expression-literals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+            "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
@@ -627,6 +759,15 @@
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.2.tgz",
+            "integrity": "sha512-NsAuliSwkL3WO2dzWTOL1oZJHm0TM8ZY8ZSxk2ANyKkt5SQlToGA4pzctmq1BEjoacurdwZ3xp2dCQWJkME0gQ==",
+            "dev": true,
+            "requires": {
+                "regexp-tree": "^0.1.0"
+            }
+        },
         "@babel/plugin-transform-new-target": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
@@ -654,6 +795,25 @@
             "requires": {
                 "@babel/helper-call-delegate": "^7.1.0",
                 "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-property-literals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+            "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-react-constant-elements": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.2.0.tgz",
+            "integrity": "sha512-YYQFg6giRFMsZPKUM9v+VcHOdfSQdz9jHCx3akAi3UYgyjndmdYGSXylQ/V+HswQt4fL8IklchD9HTsaOCrWQQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
@@ -704,6 +864,15 @@
             "dev": true,
             "requires": {
                 "regenerator-transform": "^0.13.3"
+            }
+        },
+        "@babel/plugin-transform-reserved-words": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+            "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-runtime": {
@@ -763,6 +932,16 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-typescript": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.0.tgz",
+            "integrity": "sha512-U7/+zKnRZg04ggM/Bm+xmu2B/PrwyDQTT/V89FXWYWNMxBDwSx56u6jtk9SEbfLFbZaEI72L+5LPvQjeZgFCrQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-typescript": "^7.2.0"
             }
         },
         "@babel/plugin-transform-unicode-regex": {
@@ -856,6 +1035,16 @@
                 "@babel/plugin-transform-react-jsx": "^7.0.0",
                 "@babel/plugin-transform-react-jsx-self": "^7.0.0",
                 "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+            }
+        },
+        "@babel/preset-typescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.1.0.tgz",
+            "integrity": "sha512-LYveByuF9AOM8WrsNne5+N79k1YxjNB6gmpCQsnuSBAcV8QUeB+ZUxQzL7Rz7HksPbahymKkq2qBR+o36ggFZA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-transform-typescript": "^7.1.0"
             }
         },
         "@babel/register": {
@@ -1064,6 +1253,12 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.1.3.tgz",
             "integrity": "sha512-QsYGKdhhuDFNq7bjm2r44y0mp5xW3uO3csuTPDWZc0OIiMQv+AIY5Cqwd4mJiC5N8estVl7qlvOx1hbtOuUWbw==",
+            "dev": true
+        },
+        "@icons/material": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+            "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
             "dev": true
         },
         "@jest/console": {
@@ -1323,17 +1518,18 @@
             "dev": true
         },
         "@storybook/addon-actions": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-4.0.9.tgz",
-            "integrity": "sha512-CRMofmt1wF8D2MLxXlm/IKSfDpNatooUliRo57jaHMa+0F+alDQbujgQJR7mAvHVN/MFQQ2Go+5PXDnfijKkHw==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-4.1.18.tgz",
+            "integrity": "sha512-/sP/V7anl/jEoqDtW0XfO5qit8wQb0zrtaQtujPex8tL+LcUMHvxppw9/gU0yiJkoePvc1KwbDshziA8LMcCbA==",
             "dev": true,
             "requires": {
                 "@emotion/core": "^0.13.1",
                 "@emotion/provider": "^0.11.2",
                 "@emotion/styled": "^0.10.6",
-                "@storybook/addons": "4.0.9",
-                "@storybook/components": "4.0.9",
-                "@storybook/core-events": "4.0.8",
+                "@storybook/addons": "4.1.18",
+                "@storybook/components": "4.1.18",
+                "@storybook/core-events": "4.1.18",
+                "core-js": "^2.5.7",
                 "deep-equal": "^1.0.1",
                 "global": "^4.3.2",
                 "lodash": "^4.17.11",
@@ -1344,16 +1540,15 @@
             }
         },
         "@storybook/addon-info": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-4.0.9.tgz",
-            "integrity": "sha512-fhenKMloeKbMVg1J6/FOU7fOrxwLUjnuTfO/6dI9pZkmjV8CD2w2x4ZxMQM3ilA3xharuZwYgF5lGfx2O5ZC7Q==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-4.1.18.tgz",
+            "integrity": "sha512-hmFDHOj946rGlprlrkpnHHMUalmswOqjiyyVCs9fw5bvkwcjZCPbe9fcMysvUWoKIIkUUcBtrSIJQ3v//vG2kQ==",
             "dev": true,
             "requires": {
-                "@emotion/styled": "^0.10.6",
-                "@storybook/addons": "4.0.9",
-                "@storybook/client-logger": "4.0.8",
-                "@storybook/components": "4.0.9",
-                "core-js": "2.5.7",
+                "@storybook/addons": "4.1.18",
+                "@storybook/client-logger": "4.1.18",
+                "@storybook/components": "4.1.18",
+                "core-js": "^2.5.7",
                 "global": "^4.3.2",
                 "marksy": "^6.1.0",
                 "nested-object-assign": "^1.0.1",
@@ -1364,16 +1559,17 @@
             }
         },
         "@storybook/addon-knobs": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-4.0.9.tgz",
-            "integrity": "sha512-UBJfi48Zrd5bcuw6APU8meQItNHM1q4ZjDINfVt+sO1Ucz8cMWsCv9XiroknWs37DKzVVgoWa+OkJ09zTn9oXA==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-4.1.18.tgz",
+            "integrity": "sha512-+R+WjZCkQDRv0UwU0Rrrz2EmOG2Y65jrf4S8Itklj6ASlDFt8YVRw7TzHbk7C8H0slQmu8xu0jQdNdEUu48pFg==",
             "dev": true,
             "requires": {
                 "@emotion/styled": "^0.10.6",
-                "@storybook/addons": "4.0.9",
-                "@storybook/components": "4.0.9",
-                "@storybook/core-events": "4.0.8",
+                "@storybook/addons": "4.1.18",
+                "@storybook/components": "4.1.18",
+                "@storybook/core-events": "4.1.18",
                 "copy-to-clipboard": "^3.0.8",
+                "core-js": "^2.5.7",
                 "escape-html": "^1.0.3",
                 "fast-deep-equal": "^2.0.1",
                 "global": "^4.3.2",
@@ -1385,99 +1581,69 @@
             }
         },
         "@storybook/addon-links": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-4.0.9.tgz",
-            "integrity": "sha512-n5KUirtb5r8YcXXV/pLjx0wf9E9YbzUfaaj76Z4hNkLegtG/9AJCXe0paFqwFXM7gi2nQR0ldWopdZqgVpV77g==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-4.1.18.tgz",
+            "integrity": "sha512-qWmYl5nJKw8ozH3QdWIZ33MCmiKRBdeSMaY4Pi8v8mzEjTZKxznIFBYpY46uRwE0Rz4dA7/1486zI1r2uju0Xw==",
             "dev": true,
             "requires": {
-                "@storybook/addons": "4.0.9",
-                "@storybook/components": "4.0.9",
-                "@storybook/core-events": "4.0.8",
+                "@storybook/addons": "4.1.18",
+                "@storybook/components": "4.1.18",
+                "@storybook/core-events": "4.1.18",
+                "core-js": "^2.5.7",
                 "global": "^4.3.2",
                 "prop-types": "^15.6.2"
             }
         },
         "@storybook/addon-options": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-options/-/addon-options-4.0.8.tgz",
-            "integrity": "sha512-vUVN2EdBJkmReRThGpgpS8bgbu/uS0+ToS+T1ofZ9CEvg5wcaiPNo6jnHqLZni0lncCAeDKh4uwbS7dFZCdmsA==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-options/-/addon-options-4.1.18.tgz",
+            "integrity": "sha512-de8ba7q5Gg0nq+jf0sGZEnoE1fv3Af7/L28pGNc5e5di+E1dyADaEJvJmmBWr/eS+NxoRmQlps+a4XlrxxS2Qg==",
             "dev": true,
             "requires": {
-                "@storybook/addons": "4.0.8",
+                "@storybook/addons": "4.1.18",
+                "core-js": "^2.5.7",
                 "util-deprecate": "^1.0.2"
-            },
-            "dependencies": {
-                "@storybook/addons": {
-                    "version": "4.0.8",
-                    "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-4.0.8.tgz",
-                    "integrity": "sha512-rcLqzRHFPYQ5S0/NKc3Qk7klUseiq3YCAKghYjGzXPENgID6rKnqAYrlOybPgR0aUWs6koXKiIjtco9tT1UBxQ==",
-                    "dev": true,
-                    "requires": {
-                        "@storybook/channels": "4.0.8",
-                        "@storybook/components": "4.0.8",
-                        "global": "^4.3.2",
-                        "util-deprecate": "^1.0.2"
-                    }
-                },
-                "@storybook/components": {
-                    "version": "4.0.8",
-                    "resolved": "https://registry.npmjs.org/@storybook/components/-/components-4.0.8.tgz",
-                    "integrity": "sha512-6r6/B2i2sQrDPvOgzo5YgCtSCj3q4E54e6V5fkbrYhSvH7Ro8fwca6Pee0uHbKECT+N8+HzWveV0WKg20TZvIg==",
-                    "dev": true,
-                    "requires": {
-                        "@emotion/core": "^0.13.1",
-                        "@emotion/provider": "^0.11.2",
-                        "@emotion/styled": "^0.10.6",
-                        "global": "^4.3.2",
-                        "lodash": "^4.17.11",
-                        "prop-types": "^15.6.2",
-                        "react-inspector": "^2.3.0",
-                        "react-split-pane": "^0.1.84",
-                        "react-textarea-autosize": "^7.0.4",
-                        "render-fragment": "^0.1.1"
-                    }
-                }
             }
         },
         "@storybook/addons": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-4.0.9.tgz",
-            "integrity": "sha512-D+RsN1fNywgk46UxG6Lue+p9Egf7/DpgEJtQb6RS+UoyOF24p3FlwWMh36kpRfSSgGqFZ+a0jIKhXuRSr31UNQ==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-4.1.18.tgz",
+            "integrity": "sha512-WBWso2NyZci8/X6t63jNaLyV6ziHtu0cpa3xZ5A2m9KlUf+doyycFis36fBZ+v6xb1FTZuFjEkm3H3IuXE1GUQ==",
             "dev": true,
             "requires": {
-                "@storybook/channels": "4.0.8",
-                "@storybook/components": "4.0.9",
+                "@storybook/channels": "4.1.18",
+                "@storybook/components": "4.1.18",
                 "global": "^4.3.2",
                 "util-deprecate": "^1.0.2"
             }
         },
         "@storybook/channel-postmessage": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-4.0.8.tgz",
-            "integrity": "sha512-qnjUgy4/vuFQpb/bt4UVTIZOzlgvGxS59IEE17qWULET8WrI4q2WS7XKQjLr7vmGzu6CFNKgoEKQ+h9G4npknA==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-4.1.18.tgz",
+            "integrity": "sha512-gd8rtMS9q0kFflAQP9hm/L6HNtuVnv0xdSElTKhzrJRyFEGxFuciDip9nz3Nw+PAEiioKWBhnGZEGjELmubrMQ==",
             "dev": true,
             "requires": {
-                "@storybook/channels": "4.0.8",
+                "@storybook/channels": "4.1.18",
                 "global": "^4.3.2",
                 "json-stringify-safe": "^5.0.1"
             }
         },
         "@storybook/channels": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-4.0.8.tgz",
-            "integrity": "sha512-nGMVPN4eOJlAXxS2u3a5aj7YJ4ChhlLx0+4HC6xaU5Uv+PaL6ba0gh84Zd9K73JnTSPPMq/4Mg3oncZumyeN9Q==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-4.1.18.tgz",
+            "integrity": "sha512-SwAAqfrIu0+j2KmmR9QKwKoU9VS7DWrv7fEhy+fEO/YfHnc0G3jcnR/VooiWfZpSrgKB7Mz6Qjp/mj+wRe6wTg==",
             "dev": true
         },
         "@storybook/client-logger": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-4.0.8.tgz",
-            "integrity": "sha512-q2PNkSVjQGLvJp9K8hTUjyRYtN8PDbLBddT2fmb/CFGFLXWTDe79+DuJGEFhUKfbtrvixIPXOeWeDYarwxnhAw==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-4.1.18.tgz",
+            "integrity": "sha512-hcCcM3zT9+S/osDZTEK/mYU/3dnskVahJ7hSQDDfXKVv4zL3U2l+9PYc2MhEQ4egHxrNsl0pzfvNMFFIGryJtg==",
             "dev": true
         },
         "@storybook/components": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@storybook/components/-/components-4.0.9.tgz",
-            "integrity": "sha512-EoPJitDUBkNdg4UiWyrmU6IkpLmJTjJO6KD382isHXA7qCxBJQTPb2m3GXy35KKF510NtJ9H0l4k5x7yg5Wzng==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/components/-/components-4.1.18.tgz",
+            "integrity": "sha512-8vqjzgTE2X4dCrtpALRiMgB8FL7vGV16f/mA7UIL+Hfxm9d+vqoGDf7u+FNX6S39gH7HQrxlOIcWqWGyKvNAUw==",
             "dev": true,
             "requires": {
                 "@emotion/core": "^0.13.1",
@@ -1493,32 +1659,30 @@
             }
         },
         "@storybook/core": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@storybook/core/-/core-4.0.9.tgz",
-            "integrity": "sha512-p2RtqW7EmYrYW/wAj0WCCnBAKD9XzsWTf+Uq/Ge4TnlXNq5jpuPCqe6Drq6kjYA+fHI+KOkkrXWvlaesdO/SXA==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/core/-/core-4.1.18.tgz",
+            "integrity": "sha512-r2RxNLKYrgUKvH/vi0iBTjqcCOXqp6ln8lcLmuH0bUDV1TcOS4/M/ASsMiqtNh739mxw6QlaNbbBE8qzOvUyrA==",
             "dev": true,
             "requires": {
-                "@babel/plugin-proposal-class-properties": "^7.1.0",
-                "@babel/plugin-transform-regenerator": "^7.0.0",
-                "@babel/plugin-transform-runtime": "^7.1.0",
-                "@babel/preset-env": "^7.1.0",
-                "@babel/runtime": "^7.1.2",
+                "@babel/plugin-proposal-class-properties": "^7.2.0",
+                "@babel/preset-env": "^7.2.0",
                 "@emotion/core": "^0.13.1",
                 "@emotion/provider": "^0.11.2",
                 "@emotion/styled": "^0.10.6",
-                "@storybook/addons": "4.0.9",
-                "@storybook/channel-postmessage": "4.0.8",
-                "@storybook/client-logger": "4.0.8",
-                "@storybook/core-events": "4.0.8",
-                "@storybook/node-logger": "4.0.8",
-                "@storybook/ui": "4.0.9",
+                "@storybook/addons": "4.1.18",
+                "@storybook/channel-postmessage": "4.1.18",
+                "@storybook/client-logger": "4.1.18",
+                "@storybook/core-events": "4.1.18",
+                "@storybook/node-logger": "4.1.18",
+                "@storybook/ui": "4.1.18",
                 "airbnb-js-shims": "^1 || ^2",
                 "autoprefixer": "^9.3.1",
                 "babel-plugin-macros": "^2.4.2",
-                "babel-preset-minify": "^0.5.0",
+                "babel-preset-minify": "^0.5.0 || 0.6.0-alpha.5",
                 "boxen": "^2.0.0",
                 "case-sensitive-paths-webpack-plugin": "^2.1.2",
                 "chalk": "^2.4.1",
+                "child-process-promise": "^2.2.1",
                 "cli-table3": "0.5.1",
                 "commander": "^2.19.0",
                 "common-tags": "^1.8.0",
@@ -1527,10 +1691,12 @@
                 "detect-port": "^1.2.3",
                 "dotenv-webpack": "^1.5.7",
                 "ejs": "^2.6.1",
+                "eventemitter3": "^3.1.0",
                 "express": "^4.16.3",
                 "file-loader": "^2.0.0",
                 "file-system-cache": "^1.0.5",
                 "find-cache-dir": "^2.0.0",
+                "fs-extra": "^7.0.1",
                 "global": "^4.3.2",
                 "html-webpack-plugin": "^4.0.0-beta.2",
                 "inquirer": "^6.2.0",
@@ -1542,31 +1708,638 @@
                 "opn": "^5.4.0",
                 "postcss-flexbugs-fixes": "^4.1.0",
                 "postcss-loader": "^3.0.0",
+                "pretty-hrtime": "^1.0.3",
                 "prop-types": "^15.6.2",
                 "qs": "^6.5.2",
                 "raw-loader": "^0.5.1",
                 "react-dev-utils": "^6.1.0",
                 "redux": "^4.0.1",
+                "regenerator-runtime": "^0.12.1",
                 "resolve": "^1.8.1",
+                "resolve-from": "^4.0.0",
                 "semver": "^5.6.0",
                 "serve-favicon": "^2.5.0",
                 "shelljs": "^0.8.2",
+                "spawn-promise": "^0.1.8",
                 "style-loader": "^0.23.1",
                 "svg-url-loader": "^2.3.2",
+                "terser-webpack-plugin": "^1.1.0",
                 "url-loader": "^1.1.2",
                 "webpack": "^4.23.1",
                 "webpack-dev-middleware": "^3.4.0",
                 "webpack-hot-middleware": "^2.24.3"
             },
             "dependencies": {
+                "@babel/generator": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+                    "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.0",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.11",
+                        "source-map": "^0.5.0",
+                        "trim-right": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "jsesc": {
+                            "version": "2.5.2",
+                            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "@babel/helper-call-delegate": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
+                    "integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-hoist-variables": "^7.4.0",
+                        "@babel/traverse": "^7.4.0",
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/helper-define-map": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
+                    "integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/types": "^7.4.0",
+                        "lodash": "^4.17.11"
+                    }
+                },
+                "@babel/helper-hoist-variables": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
+                    "integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/helper-replace-supers": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
+                    "integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-member-expression-to-functions": "^7.0.0",
+                        "@babel/helper-optimise-call-expression": "^7.0.0",
+                        "@babel/traverse": "^7.4.0",
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+                    "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+                    "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+                    "dev": true
+                },
+                "@babel/plugin-proposal-async-generator-functions": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+                    "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-remap-async-to-generator": "^7.1.0",
+                        "@babel/plugin-syntax-async-generators": "^7.2.0"
+                    }
+                },
+                "@babel/plugin-proposal-class-properties": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz",
+                    "integrity": "sha512-t2ECPNOXsIeK1JxJNKmgbzQtoG27KIlVE61vTqX0DKR9E9sZlVVxWUtEW9D5FlZ8b8j7SBNCHY47GgPKCKlpPg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-create-class-features-plugin": "^7.4.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-proposal-json-strings": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+                    "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/plugin-syntax-json-strings": "^7.2.0"
+                    }
+                },
+                "@babel/plugin-proposal-object-rest-spread": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
+                    "integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+                    }
+                },
+                "@babel/plugin-proposal-optional-catch-binding": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+                    "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+                    }
+                },
+                "@babel/plugin-proposal-unicode-property-regex": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
+                    "integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-regex": "^7.0.0",
+                        "regexpu-core": "^4.5.4"
+                    }
+                },
+                "@babel/plugin-syntax-async-generators": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+                    "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-syntax-json-strings": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+                    "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-syntax-object-rest-spread": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+                    "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-syntax-optional-catch-binding": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+                    "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-arrow-functions": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+                    "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-async-to-generator": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
+                    "integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-imports": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-remap-async-to-generator": "^7.1.0"
+                    }
+                },
+                "@babel/plugin-transform-block-scoped-functions": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+                    "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-block-scoping": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
+                    "integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "lodash": "^4.17.11"
+                    }
+                },
+                "@babel/plugin-transform-classes": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
+                    "integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "^7.0.0",
+                        "@babel/helper-define-map": "^7.4.0",
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-optimise-call-expression": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-replace-supers": "^7.4.0",
+                        "@babel/helper-split-export-declaration": "^7.4.0",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "@babel/plugin-transform-computed-properties": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+                    "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-destructuring": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
+                    "integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-dotall-regex": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
+                    "integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-regex": "^7.4.3",
+                        "regexpu-core": "^4.5.4"
+                    },
+                    "dependencies": {
+                        "@babel/helper-regex": {
+                            "version": "7.4.3",
+                            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+                            "integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
+                            "dev": true,
+                            "requires": {
+                                "lodash": "^4.17.11"
+                            }
+                        }
+                    }
+                },
+                "@babel/plugin-transform-duplicate-keys": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
+                    "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-exponentiation-operator": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+                    "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-for-of": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
+                    "integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-function-name": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
+                    "integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-literals": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+                    "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-modules-amd": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
+                    "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "^7.1.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-modules-commonjs": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
+                    "integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "^7.4.3",
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-simple-access": "^7.1.0"
+                    },
+                    "dependencies": {
+                        "@babel/helper-module-transforms": {
+                            "version": "7.4.3",
+                            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
+                            "integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/helper-module-imports": "^7.0.0",
+                                "@babel/helper-simple-access": "^7.1.0",
+                                "@babel/helper-split-export-declaration": "^7.0.0",
+                                "@babel/template": "^7.2.2",
+                                "@babel/types": "^7.2.2",
+                                "lodash": "^4.17.11"
+                            }
+                        }
+                    }
+                },
+                "@babel/plugin-transform-modules-systemjs": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
+                    "integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-hoist-variables": "^7.4.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-modules-umd": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+                    "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "^7.1.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-new-target": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
+                    "integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-object-super": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+                    "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-replace-supers": "^7.1.0"
+                    }
+                },
+                "@babel/plugin-transform-parameters": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
+                    "integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-call-delegate": "^7.4.0",
+                        "@babel/helper-get-function-arity": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-regenerator": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
+                    "integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-transform": "^0.13.4"
+                    }
+                },
+                "@babel/plugin-transform-shorthand-properties": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+                    "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-spread": {
+                    "version": "7.2.2",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+                    "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-sticky-regex": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+                    "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-regex": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-template-literals": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
+                    "integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-typeof-symbol": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+                    "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-unicode-regex": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
+                    "integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-regex": "^7.4.3",
+                        "regexpu-core": "^4.5.4"
+                    },
+                    "dependencies": {
+                        "@babel/helper-regex": {
+                            "version": "7.4.3",
+                            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+                            "integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
+                            "dev": true,
+                            "requires": {
+                                "lodash": "^4.17.11"
+                            }
+                        }
+                    }
+                },
+                "@babel/preset-env": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
+                    "integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-imports": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+                        "@babel/plugin-proposal-json-strings": "^7.2.0",
+                        "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
+                        "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+                        "@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
+                        "@babel/plugin-syntax-async-generators": "^7.2.0",
+                        "@babel/plugin-syntax-json-strings": "^7.2.0",
+                        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+                        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+                        "@babel/plugin-transform-arrow-functions": "^7.2.0",
+                        "@babel/plugin-transform-async-to-generator": "^7.4.0",
+                        "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+                        "@babel/plugin-transform-block-scoping": "^7.4.0",
+                        "@babel/plugin-transform-classes": "^7.4.3",
+                        "@babel/plugin-transform-computed-properties": "^7.2.0",
+                        "@babel/plugin-transform-destructuring": "^7.4.3",
+                        "@babel/plugin-transform-dotall-regex": "^7.4.3",
+                        "@babel/plugin-transform-duplicate-keys": "^7.2.0",
+                        "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+                        "@babel/plugin-transform-for-of": "^7.4.3",
+                        "@babel/plugin-transform-function-name": "^7.4.3",
+                        "@babel/plugin-transform-literals": "^7.2.0",
+                        "@babel/plugin-transform-member-expression-literals": "^7.2.0",
+                        "@babel/plugin-transform-modules-amd": "^7.2.0",
+                        "@babel/plugin-transform-modules-commonjs": "^7.4.3",
+                        "@babel/plugin-transform-modules-systemjs": "^7.4.0",
+                        "@babel/plugin-transform-modules-umd": "^7.2.0",
+                        "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
+                        "@babel/plugin-transform-new-target": "^7.4.0",
+                        "@babel/plugin-transform-object-super": "^7.2.0",
+                        "@babel/plugin-transform-parameters": "^7.4.3",
+                        "@babel/plugin-transform-property-literals": "^7.2.0",
+                        "@babel/plugin-transform-regenerator": "^7.4.3",
+                        "@babel/plugin-transform-reserved-words": "^7.2.0",
+                        "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+                        "@babel/plugin-transform-spread": "^7.2.0",
+                        "@babel/plugin-transform-sticky-regex": "^7.2.0",
+                        "@babel/plugin-transform-template-literals": "^7.2.0",
+                        "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+                        "@babel/plugin-transform-unicode-regex": "^7.4.3",
+                        "@babel/types": "^7.4.0",
+                        "browserslist": "^4.5.2",
+                        "core-js-compat": "^3.0.0",
+                        "invariant": "^2.2.2",
+                        "js-levenshtein": "^1.1.3",
+                        "semver": "^5.5.0"
+                    }
+                },
+                "@babel/template": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+                    "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.4.0",
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+                    "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/generator": "^7.4.0",
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-split-export-declaration": "^7.4.0",
+                        "@babel/parser": "^7.4.3",
+                        "@babel/types": "^7.4.0",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.11"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+                    "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.11",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "browserslist": {
+                    "version": "4.5.5",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+                    "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30000960",
+                        "electron-to-chromium": "^1.3.124",
+                        "node-releases": "^1.1.14"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30000963",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
+                    "integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
+                    "dev": true
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.126",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.126.tgz",
+                    "integrity": "sha512-anr0OeQkZvOGzsz1ZM7BliJjHKfEsodQWoncklQWryDCSXMdVtt/fXlQBKfXXmbMVDhpiydwL3jaonbWuk/F6g==",
+                    "dev": true
+                },
                 "find-cache-dir": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
-                    "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+                    "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
                     "dev": true,
                     "requires": {
                         "commondir": "^1.0.1",
-                        "make-dir": "^1.0.0",
+                        "make-dir": "^2.0.0",
                         "pkg-dir": "^3.0.0"
                     }
                 },
@@ -1579,6 +2352,12 @@
                         "locate-path": "^3.0.0"
                     }
                 },
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                },
                 "locate-path": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -1589,16 +2368,35 @@
                         "path-exists": "^3.0.0"
                     }
                 },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
                 "node-fetch": {
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
                     "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
                     "dev": true
                 },
+                "node-releases": {
+                    "version": "1.1.17",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
+                    "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^5.3.0"
+                    }
+                },
                 "p-limit": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-                    "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
@@ -1614,9 +2412,15 @@
                     }
                 },
                 "p-try": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-                    "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
                     "dev": true
                 },
                 "pkg-dir": {
@@ -1627,13 +2431,78 @@
                     "requires": {
                         "find-up": "^3.0.0"
                     }
+                },
+                "regenerate-unicode-properties": {
+                    "version": "8.0.2",
+                    "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz",
+                    "integrity": "sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "^1.4.0"
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.12.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+                    "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+                    "dev": true
+                },
+                "regenerator-transform": {
+                    "version": "0.13.4",
+                    "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
+                    "integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
+                    "dev": true,
+                    "requires": {
+                        "private": "^0.1.6"
+                    }
+                },
+                "regexpu-core": {
+                    "version": "4.5.4",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+                    "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "^1.4.0",
+                        "regenerate-unicode-properties": "^8.0.2",
+                        "regjsgen": "^0.5.0",
+                        "regjsparser": "^0.6.0",
+                        "unicode-match-property-ecmascript": "^1.0.4",
+                        "unicode-match-property-value-ecmascript": "^1.1.0"
+                    }
+                },
+                "regjsgen": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+                    "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+                    "dev": true
+                },
+                "regjsparser": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+                    "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+                    "dev": true,
+                    "requires": {
+                        "jsesc": "~0.5.0"
+                    }
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                },
+                "unicode-match-property-value-ecmascript": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+                    "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+                    "dev": true
                 }
             }
         },
         "@storybook/core-events": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-4.0.8.tgz",
-            "integrity": "sha512-S7g2oGnJKvLDpwcHFJ+efXww6zS7W3krimsqApf3foBfi3CVPLNJ9hrag30UGtnxQ3LDpkMj/aU4bkCWY7NRYA==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-4.1.18.tgz",
+            "integrity": "sha512-G4vr1zSDdizbLmBdopBJLcfTYuURUevQ6OokbGqOfWRxfLmfCu2azeeQjWEcbHi9Hu3KThDcSUmapKZYNwNxMw==",
             "dev": true
         },
         "@storybook/mantra-core": {
@@ -1648,13 +2517,24 @@
             }
         },
         "@storybook/node-logger": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-4.0.8.tgz",
-            "integrity": "sha512-TmBPctU+TPt0Oi4pA3JKfYaGkC7osgzdCFo3IgVbtLGA97X4CUjmLz8N0EEMHZdqdnHoQGgx94E5zhlJnvgMHQ==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-4.1.18.tgz",
+            "integrity": "sha512-RJEzl8Kv/0ISc5LBI325DKLxd/dqsAxFqQ8H7sF30VWxmnMlsUpbs9IvB3EvU/BLXltyKLHhZ6+E/zZIkIQnWA==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.1.2",
-                "npmlog": "^4.1.2"
+                "chalk": "^2.4.1",
+                "core-js": "^2.5.7",
+                "npmlog": "^4.1.2",
+                "pretty-hrtime": "^1.0.3",
+                "regenerator-runtime": "^0.12.1"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.12.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+                    "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+                    "dev": true
+                }
             }
         },
         "@storybook/podda": {
@@ -1668,26 +2548,39 @@
             }
         },
         "@storybook/react": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@storybook/react/-/react-4.0.9.tgz",
-            "integrity": "sha512-YYBdvwgBJ9paSVzqXwJIiRtqdjvaY+9Wr3EpBy7E8wHWyPUoPcfiD6aMyt0TnGR+mnbbg0B/kLgMGvddxEixYQ==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/react/-/react-4.1.18.tgz",
+            "integrity": "sha512-CcZAnEqw4HlSpwMlmVlIcMZHkhrYizN/zDPs7nDOTVXVuHBW5pVjFM/UXxwW5AuExmKrxUP9RqVQ7Thex9C5rA==",
             "dev": true,
             "requires": {
+                "@babel/plugin-transform-react-constant-elements": "^7.2.0",
                 "@babel/preset-flow": "^7.0.0",
                 "@babel/preset-react": "^7.0.0",
-                "@babel/runtime": "^7.1.2",
                 "@emotion/styled": "^0.10.6",
-                "@storybook/core": "4.0.9",
-                "@storybook/node-logger": "4.0.8",
+                "@storybook/core": "4.1.18",
+                "@storybook/node-logger": "4.1.18",
+                "@svgr/webpack": "^4.0.3",
+                "babel-plugin-named-asset-import": "^0.2.3",
                 "babel-plugin-react-docgen": "^2.0.0",
+                "babel-preset-react-app": "^6.1.0",
                 "common-tags": "^1.8.0",
+                "core-js": "^2.5.7",
                 "global": "^4.3.2",
                 "lodash": "^4.17.11",
                 "mini-css-extract-plugin": "^0.4.4",
                 "prop-types": "^15.6.2",
                 "react-dev-utils": "^6.1.0",
+                "regenerator-runtime": "^0.12.1",
                 "semver": "^5.6.0",
                 "webpack": "^4.23.1"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.12.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+                    "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+                    "dev": true
+                }
             }
         },
         "@storybook/react-komposer": {
@@ -1725,31 +2618,1148 @@
             }
         },
         "@storybook/ui": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-4.0.9.tgz",
-            "integrity": "sha512-kZghSm4v6U8Wfwsa8qk0TeQGBe96QZt2E79PR9uxeTNAEDJWR321CIsRG+FEFXIjNo09B50FgWMM4466CCOeuw==",
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-4.1.18.tgz",
+            "integrity": "sha512-4RfNLWN1EoLXIQ1AAJ3Dg1Kj9ZiJJWk9vTEbnkzPtHtoAGpneIuwmw2ZD+pyNALlF5g4bKccfHDCTVofiwZzCQ==",
             "dev": true,
             "requires": {
                 "@emotion/core": "^0.13.1",
                 "@emotion/provider": "^0.11.2",
                 "@emotion/styled": "^0.10.6",
-                "@storybook/components": "4.0.9",
-                "@storybook/core-events": "4.0.8",
+                "@storybook/components": "4.1.18",
+                "@storybook/core-events": "4.1.18",
                 "@storybook/mantra-core": "^1.7.2",
                 "@storybook/podda": "^1.2.3",
                 "@storybook/react-komposer": "^2.0.5",
                 "deep-equal": "^1.0.1",
-                "events": "^3.0.0",
+                "eventemitter3": "^3.1.0",
                 "fuse.js": "^3.3.0",
                 "global": "^4.3.2",
                 "keycode": "^2.2.0",
                 "lodash": "^4.17.11",
                 "prop-types": "^15.6.2",
                 "qs": "^6.5.2",
+                "react": "^16.7.0",
+                "react-dom": "^16.7.0",
                 "react-fuzzy": "^0.5.2",
                 "react-lifecycles-compat": "^3.0.4",
                 "react-modal": "^3.6.1",
-                "react-treebeard": "^3.1.0"
+                "react-treebeard": "3.1.0"
+            },
+            "dependencies": {
+                "react": {
+                    "version": "16.8.6",
+                    "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
+                    "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1",
+                        "prop-types": "^15.6.2",
+                        "scheduler": "^0.13.6"
+                    }
+                },
+                "react-dom": {
+                    "version": "16.8.6",
+                    "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
+                    "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1",
+                        "prop-types": "^15.6.2",
+                        "scheduler": "^0.13.6"
+                    }
+                },
+                "scheduler": {
+                    "version": "0.13.6",
+                    "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+                    "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
+                    }
+                }
+            }
+        },
+        "@svgr/babel-plugin-add-jsx-attribute": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
+            "integrity": "sha512-j7KnilGyZzYr/jhcrSYS3FGWMZVaqyCG0vzMCwzvei0coIkczuYMcniK07nI0aHJINciujjH11T72ICW5eL5Ig==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-remove-jsx-attribute": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-4.2.0.tgz",
+            "integrity": "sha512-3XHLtJ+HbRCH4n28S7y/yZoEQnRpl0tvTZQsHqvaeNXPra+6vE5tbRliH3ox1yZYPCxrlqaJT/Mg+75GpDKlvQ==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-remove-jsx-empty-expression": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-4.2.0.tgz",
+            "integrity": "sha512-yTr2iLdf6oEuUE9MsRdvt0NmdpMBAkgK8Bjhl6epb+eQWk6abBaX3d65UZ3E3FWaOwePyUgNyNCMVG61gGCQ7w==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-replace-jsx-attribute-value": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.2.0.tgz",
+            "integrity": "sha512-U9m870Kqm0ko8beHawRXLGLvSi/ZMrl89gJ5BNcT452fAjtF2p4uRzXkdzvGJJJYBgx7BmqlDjBN/eCp5AAX2w==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-svg-dynamic-title": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.2.0.tgz",
+            "integrity": "sha512-gH2qItapwCUp6CCqbxvzBbc4dh4OyxdYKsW3EOkYexr0XUmQL0ScbdNh6DexkZ01T+sdClniIbnCObsXcnx3sQ==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-svg-em-dimensions": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.2.0.tgz",
+            "integrity": "sha512-C0Uy+BHolCHGOZ8Dnr1zXy/KgpBOkEUYY9kI/HseHVPeMbluaX3CijJr7D4C5uR8zrc1T64nnq/k63ydQuGt4w==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-transform-react-native-svg": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.2.0.tgz",
+            "integrity": "sha512-7YvynOpZDpCOUoIVlaaOUU87J4Z6RdD6spYN4eUb5tfPoKGSF9OG2NuhgYnq4jSkAxcpMaXWPf1cePkzmqTPNw==",
+            "dev": true
+        },
+        "@svgr/babel-plugin-transform-svg-component": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.2.0.tgz",
+            "integrity": "sha512-hYfYuZhQPCBVotABsXKSCfel2slf/yvJY8heTVX1PCTaq/IgASq1IyxPPKJ0chWREEKewIU/JMSsIGBtK1KKxw==",
+            "dev": true
+        },
+        "@svgr/babel-preset": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-4.2.0.tgz",
+            "integrity": "sha512-iLetHpRCQXfK47voAs5/uxd736cCyocEdorisjAveZo8ShxJ/ivSZgstBmucI1c8HyMF5tOrilJLoFbhpkPiKw==",
+            "dev": true,
+            "requires": {
+                "@svgr/babel-plugin-add-jsx-attribute": "^4.2.0",
+                "@svgr/babel-plugin-remove-jsx-attribute": "^4.2.0",
+                "@svgr/babel-plugin-remove-jsx-empty-expression": "^4.2.0",
+                "@svgr/babel-plugin-replace-jsx-attribute-value": "^4.2.0",
+                "@svgr/babel-plugin-svg-dynamic-title": "^4.2.0",
+                "@svgr/babel-plugin-svg-em-dimensions": "^4.2.0",
+                "@svgr/babel-plugin-transform-react-native-svg": "^4.2.0",
+                "@svgr/babel-plugin-transform-svg-component": "^4.2.0"
+            }
+        },
+        "@svgr/core": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/core/-/core-4.2.0.tgz",
+            "integrity": "sha512-nvzXaf2VavqjMCTTfsZfjL4o9035KedALkMzk82qOlHOwBb8JT+9+zYDgBl0oOunbVF94WTLnvGunEg0csNP3Q==",
+            "dev": true,
+            "requires": {
+                "@svgr/plugin-jsx": "^4.2.0",
+                "camelcase": "^5.3.1",
+                "cosmiconfig": "^5.2.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "cosmiconfig": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+                    "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
+                    "dev": true,
+                    "requires": {
+                        "import-fresh": "^2.0.0",
+                        "is-directory": "^0.3.1",
+                        "js-yaml": "^3.13.0",
+                        "parse-json": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@svgr/hast-util-to-babel-ast": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-4.2.0.tgz",
+            "integrity": "sha512-IvAeb7gqrGB5TH9EGyBsPrMRH/QCzIuAkLySKvH2TLfLb2uqk98qtJamordRQTpHH3e6TORfBXoTo7L7Opo/Ow==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4.0"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+                    "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.11",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@svgr/plugin-jsx": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-4.2.0.tgz",
+            "integrity": "sha512-AM1YokmZITgveY9bulLVquqNmwiFo2Px2HL+IlnTCR01YvWDfRL5QKdnF7VjRaS5MNP938mmqvL0/8oz3zQMkg==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.4.3",
+                "@svgr/babel-preset": "^4.2.0",
+                "@svgr/hast-util-to-babel-ast": "^4.2.0",
+                "rehype-parse": "^6.0.0",
+                "unified": "^7.1.0",
+                "vfile": "^4.0.0"
+            },
+            "dependencies": {
+                "@babel/core": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+                    "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/generator": "^7.4.0",
+                        "@babel/helpers": "^7.4.3",
+                        "@babel/parser": "^7.4.3",
+                        "@babel/template": "^7.4.0",
+                        "@babel/traverse": "^7.4.3",
+                        "@babel/types": "^7.4.0",
+                        "convert-source-map": "^1.1.0",
+                        "debug": "^4.1.0",
+                        "json5": "^2.1.0",
+                        "lodash": "^4.17.11",
+                        "resolve": "^1.3.2",
+                        "semver": "^5.4.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+                    "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.0",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.11",
+                        "source-map": "^0.5.0",
+                        "trim-right": "^1.0.1"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+                    "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/helpers": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
+                    "integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.4.0",
+                        "@babel/traverse": "^7.4.3",
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+                    "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+                    "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.4.0",
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+                    "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/generator": "^7.4.0",
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-split-export-declaration": "^7.4.0",
+                        "@babel/parser": "^7.4.3",
+                        "@babel/types": "^7.4.0",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.11"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+                    "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.11",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@svgr/plugin-svgo": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-4.2.0.tgz",
+            "integrity": "sha512-zUEKgkT172YzHh3mb2B2q92xCnOAMVjRx+o0waZ1U50XqKLrVQ/8dDqTAtnmapdLsGurv8PSwenjLCUpj6hcvw==",
+            "dev": true,
+            "requires": {
+                "cosmiconfig": "^5.2.0",
+                "merge-deep": "^3.0.2",
+                "svgo": "^1.2.1"
+            },
+            "dependencies": {
+                "coa": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+                    "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/q": "^1.5.1",
+                        "chalk": "^2.4.1",
+                        "q": "^1.1.2"
+                    }
+                },
+                "cosmiconfig": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+                    "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
+                    "dev": true,
+                    "requires": {
+                        "import-fresh": "^2.0.0",
+                        "is-directory": "^0.3.1",
+                        "js-yaml": "^3.13.0",
+                        "parse-json": "^4.0.0"
+                    }
+                },
+                "css-select": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
+                    "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
+                    "dev": true,
+                    "requires": {
+                        "boolbase": "^1.0.0",
+                        "css-what": "^2.1.2",
+                        "domutils": "^1.7.0",
+                        "nth-check": "^1.0.2"
+                    }
+                },
+                "csso": {
+                    "version": "3.5.1",
+                    "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+                    "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+                    "dev": true,
+                    "requires": {
+                        "css-tree": "1.0.0-alpha.29"
+                    },
+                    "dependencies": {
+                        "css-tree": {
+                            "version": "1.0.0-alpha.29",
+                            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+                            "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+                            "dev": true,
+                            "requires": {
+                                "mdn-data": "~1.1.0",
+                                "source-map": "^0.5.3"
+                            }
+                        }
+                    }
+                },
+                "domutils": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+                    "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+                    "dev": true,
+                    "requires": {
+                        "dom-serializer": "0",
+                        "domelementtype": "1"
+                    }
+                },
+                "object.values": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+                    "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+                    "dev": true,
+                    "requires": {
+                        "define-properties": "^1.1.3",
+                        "es-abstract": "^1.12.0",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3"
+                    }
+                },
+                "svgo": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
+                    "integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "coa": "^2.0.2",
+                        "css-select": "^2.0.0",
+                        "css-select-base-adapter": "^0.1.1",
+                        "css-tree": "1.0.0-alpha.28",
+                        "css-url-regex": "^1.1.0",
+                        "csso": "^3.5.1",
+                        "js-yaml": "^3.13.1",
+                        "mkdirp": "~0.5.1",
+                        "object.values": "^1.1.0",
+                        "sax": "~1.2.4",
+                        "stable": "^0.1.8",
+                        "unquote": "~1.1.1",
+                        "util.promisify": "~1.0.0"
+                    }
+                }
+            }
+        },
+        "@svgr/webpack": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-4.2.0.tgz",
+            "integrity": "sha512-sm3UUJHmRlqEg8w8bjUT+FAMf5lkgCydxotEapinpd10kzrpQP++Qd+bmuepE3hsIUU68BO24vgQALQ92qBZEw==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.4.3",
+                "@babel/plugin-transform-react-constant-elements": "^7.0.0",
+                "@babel/preset-env": "^7.4.3",
+                "@babel/preset-react": "^7.0.0",
+                "@svgr/core": "^4.2.0",
+                "@svgr/plugin-jsx": "^4.2.0",
+                "@svgr/plugin-svgo": "^4.2.0",
+                "loader-utils": "^1.2.3"
+            },
+            "dependencies": {
+                "@babel/core": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+                    "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/generator": "^7.4.0",
+                        "@babel/helpers": "^7.4.3",
+                        "@babel/parser": "^7.4.3",
+                        "@babel/template": "^7.4.0",
+                        "@babel/traverse": "^7.4.3",
+                        "@babel/types": "^7.4.0",
+                        "convert-source-map": "^1.1.0",
+                        "debug": "^4.1.0",
+                        "json5": "^2.1.0",
+                        "lodash": "^4.17.11",
+                        "resolve": "^1.3.2",
+                        "semver": "^5.4.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+                    "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.0",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.11",
+                        "source-map": "^0.5.0",
+                        "trim-right": "^1.0.1"
+                    }
+                },
+                "@babel/helper-call-delegate": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
+                    "integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-hoist-variables": "^7.4.0",
+                        "@babel/traverse": "^7.4.0",
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/helper-define-map": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
+                    "integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/types": "^7.4.0",
+                        "lodash": "^4.17.11"
+                    }
+                },
+                "@babel/helper-hoist-variables": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
+                    "integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/helper-replace-supers": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
+                    "integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-member-expression-to-functions": "^7.0.0",
+                        "@babel/helper-optimise-call-expression": "^7.0.0",
+                        "@babel/traverse": "^7.4.0",
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+                    "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/helpers": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
+                    "integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.4.0",
+                        "@babel/traverse": "^7.4.3",
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+                    "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+                    "dev": true
+                },
+                "@babel/plugin-proposal-async-generator-functions": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+                    "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-remap-async-to-generator": "^7.1.0",
+                        "@babel/plugin-syntax-async-generators": "^7.2.0"
+                    }
+                },
+                "@babel/plugin-proposal-json-strings": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+                    "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/plugin-syntax-json-strings": "^7.2.0"
+                    }
+                },
+                "@babel/plugin-proposal-object-rest-spread": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
+                    "integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+                    }
+                },
+                "@babel/plugin-proposal-optional-catch-binding": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+                    "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+                    }
+                },
+                "@babel/plugin-proposal-unicode-property-regex": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
+                    "integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-regex": "^7.0.0",
+                        "regexpu-core": "^4.5.4"
+                    }
+                },
+                "@babel/plugin-syntax-async-generators": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+                    "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-syntax-json-strings": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+                    "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-syntax-object-rest-spread": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+                    "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-syntax-optional-catch-binding": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+                    "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-arrow-functions": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+                    "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-async-to-generator": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
+                    "integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-imports": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-remap-async-to-generator": "^7.1.0"
+                    }
+                },
+                "@babel/plugin-transform-block-scoped-functions": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+                    "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-block-scoping": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
+                    "integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "lodash": "^4.17.11"
+                    }
+                },
+                "@babel/plugin-transform-classes": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
+                    "integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "^7.0.0",
+                        "@babel/helper-define-map": "^7.4.0",
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-optimise-call-expression": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-replace-supers": "^7.4.0",
+                        "@babel/helper-split-export-declaration": "^7.4.0",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "@babel/plugin-transform-computed-properties": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+                    "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-destructuring": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
+                    "integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-dotall-regex": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
+                    "integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-regex": "^7.4.3",
+                        "regexpu-core": "^4.5.4"
+                    },
+                    "dependencies": {
+                        "@babel/helper-regex": {
+                            "version": "7.4.3",
+                            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+                            "integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
+                            "dev": true,
+                            "requires": {
+                                "lodash": "^4.17.11"
+                            }
+                        }
+                    }
+                },
+                "@babel/plugin-transform-duplicate-keys": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
+                    "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-exponentiation-operator": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+                    "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-for-of": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
+                    "integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-function-name": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
+                    "integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-literals": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+                    "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-modules-amd": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
+                    "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "^7.1.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-modules-commonjs": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
+                    "integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "^7.4.3",
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-simple-access": "^7.1.0"
+                    },
+                    "dependencies": {
+                        "@babel/helper-module-transforms": {
+                            "version": "7.4.3",
+                            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
+                            "integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/helper-module-imports": "^7.0.0",
+                                "@babel/helper-simple-access": "^7.1.0",
+                                "@babel/helper-split-export-declaration": "^7.0.0",
+                                "@babel/template": "^7.2.2",
+                                "@babel/types": "^7.2.2",
+                                "lodash": "^4.17.11"
+                            }
+                        }
+                    }
+                },
+                "@babel/plugin-transform-modules-systemjs": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
+                    "integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-hoist-variables": "^7.4.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-modules-umd": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+                    "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "^7.1.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-new-target": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
+                    "integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-object-super": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+                    "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-replace-supers": "^7.1.0"
+                    }
+                },
+                "@babel/plugin-transform-parameters": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
+                    "integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-call-delegate": "^7.4.0",
+                        "@babel/helper-get-function-arity": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-regenerator": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
+                    "integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-transform": "^0.13.4"
+                    }
+                },
+                "@babel/plugin-transform-shorthand-properties": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+                    "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-spread": {
+                    "version": "7.2.2",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+                    "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-sticky-regex": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+                    "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-regex": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-template-literals": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
+                    "integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-typeof-symbol": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+                    "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-unicode-regex": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
+                    "integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/helper-regex": "^7.4.3",
+                        "regexpu-core": "^4.5.4"
+                    },
+                    "dependencies": {
+                        "@babel/helper-regex": {
+                            "version": "7.4.3",
+                            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+                            "integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
+                            "dev": true,
+                            "requires": {
+                                "lodash": "^4.17.11"
+                            }
+                        }
+                    }
+                },
+                "@babel/preset-env": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
+                    "integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-imports": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+                        "@babel/plugin-proposal-json-strings": "^7.2.0",
+                        "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
+                        "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+                        "@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
+                        "@babel/plugin-syntax-async-generators": "^7.2.0",
+                        "@babel/plugin-syntax-json-strings": "^7.2.0",
+                        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+                        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+                        "@babel/plugin-transform-arrow-functions": "^7.2.0",
+                        "@babel/plugin-transform-async-to-generator": "^7.4.0",
+                        "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+                        "@babel/plugin-transform-block-scoping": "^7.4.0",
+                        "@babel/plugin-transform-classes": "^7.4.3",
+                        "@babel/plugin-transform-computed-properties": "^7.2.0",
+                        "@babel/plugin-transform-destructuring": "^7.4.3",
+                        "@babel/plugin-transform-dotall-regex": "^7.4.3",
+                        "@babel/plugin-transform-duplicate-keys": "^7.2.0",
+                        "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+                        "@babel/plugin-transform-for-of": "^7.4.3",
+                        "@babel/plugin-transform-function-name": "^7.4.3",
+                        "@babel/plugin-transform-literals": "^7.2.0",
+                        "@babel/plugin-transform-member-expression-literals": "^7.2.0",
+                        "@babel/plugin-transform-modules-amd": "^7.2.0",
+                        "@babel/plugin-transform-modules-commonjs": "^7.4.3",
+                        "@babel/plugin-transform-modules-systemjs": "^7.4.0",
+                        "@babel/plugin-transform-modules-umd": "^7.2.0",
+                        "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
+                        "@babel/plugin-transform-new-target": "^7.4.0",
+                        "@babel/plugin-transform-object-super": "^7.2.0",
+                        "@babel/plugin-transform-parameters": "^7.4.3",
+                        "@babel/plugin-transform-property-literals": "^7.2.0",
+                        "@babel/plugin-transform-regenerator": "^7.4.3",
+                        "@babel/plugin-transform-reserved-words": "^7.2.0",
+                        "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+                        "@babel/plugin-transform-spread": "^7.2.0",
+                        "@babel/plugin-transform-sticky-regex": "^7.2.0",
+                        "@babel/plugin-transform-template-literals": "^7.2.0",
+                        "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+                        "@babel/plugin-transform-unicode-regex": "^7.4.3",
+                        "@babel/types": "^7.4.0",
+                        "browserslist": "^4.5.2",
+                        "core-js-compat": "^3.0.0",
+                        "invariant": "^2.2.2",
+                        "js-levenshtein": "^1.1.3",
+                        "semver": "^5.5.0"
+                    }
+                },
+                "@babel/template": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+                    "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/parser": "^7.4.0",
+                        "@babel/types": "^7.4.0"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+                    "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/generator": "^7.4.0",
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-split-export-declaration": "^7.4.0",
+                        "@babel/parser": "^7.4.3",
+                        "@babel/types": "^7.4.0",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.11"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+                    "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.11",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "big.js": {
+                    "version": "5.2.2",
+                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+                    "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+                    "dev": true
+                },
+                "browserslist": {
+                    "version": "4.5.5",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+                    "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30000960",
+                        "electron-to-chromium": "^1.3.124",
+                        "node-releases": "^1.1.14"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30000963",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
+                    "integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
+                    "dev": true
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.126",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.126.tgz",
+                    "integrity": "sha512-anr0OeQkZvOGzsz1ZM7BliJjHKfEsodQWoncklQWryDCSXMdVtt/fXlQBKfXXmbMVDhpiydwL3jaonbWuk/F6g==",
+                    "dev": true
+                },
+                "loader-utils": {
+                    "version": "1.2.3",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+                    "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "json5": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                            "dev": true,
+                            "requires": {
+                                "minimist": "^1.2.0"
+                            }
+                        }
+                    }
+                },
+                "node-releases": {
+                    "version": "1.1.17",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
+                    "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^5.3.0"
+                    }
+                },
+                "regenerate-unicode-properties": {
+                    "version": "8.0.2",
+                    "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz",
+                    "integrity": "sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "^1.4.0"
+                    }
+                },
+                "regenerator-transform": {
+                    "version": "0.13.4",
+                    "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
+                    "integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
+                    "dev": true,
+                    "requires": {
+                        "private": "^0.1.6"
+                    }
+                },
+                "regexpu-core": {
+                    "version": "4.5.4",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+                    "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "^1.4.0",
+                        "regenerate-unicode-properties": "^8.0.2",
+                        "regjsgen": "^0.5.0",
+                        "regjsparser": "^0.6.0",
+                        "unicode-match-property-ecmascript": "^1.0.4",
+                        "unicode-match-property-value-ecmascript": "^1.1.0"
+                    }
+                },
+                "regjsgen": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+                    "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+                    "dev": true
+                },
+                "regjsparser": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+                    "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+                    "dev": true,
+                    "requires": {
+                        "jsesc": "~0.5.0"
+                    },
+                    "dependencies": {
+                        "jsesc": {
+                            "version": "0.5.0",
+                            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                            "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                            "dev": true
+                        }
+                    }
+                },
+                "unicode-match-property-value-ecmascript": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+                    "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+                    "dev": true
+                }
             }
         },
         "@types/babel__core": {
@@ -1818,11 +3828,44 @@
             "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w==",
             "dev": true
         },
+        "@types/q": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+            "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
+            "dev": true
+        },
         "@types/stack-utils": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
             "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
             "dev": true
+        },
+        "@types/unist": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+            "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+            "dev": true
+        },
+        "@types/vfile": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+            "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "@types/unist": "*",
+                "@types/vfile-message": "*"
+            }
+        },
+        "@types/vfile-message": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
+            "integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "@types/unist": "*"
+            }
         },
         "@types/yargs": {
             "version": "12.0.12",
@@ -2157,18 +4200,18 @@
             "dev": true
         },
         "ansi-align": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-            "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+            "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
             "dev": true,
             "requires": {
-                "string-width": "^2.0.0"
+                "string-width": "^3.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {
@@ -2178,30 +4221,31 @@
                     "dev": true
                 },
                 "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
+                        "emoji-regex": "^7.0.1",
                         "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "strip-ansi": "^5.1.0"
                     }
                 },
                 "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
         },
         "ansi-colors": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.1.tgz",
-            "integrity": "sha512-Xt+zb6nqgvV9SWAVp0EG3lRsHcbq5DDgqjPPz6pwgtj6RKz65zGXMNa82oJfOSBA/to6GmRP7Dr+6o+kbApTzQ==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+            "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
             "dev": true
         },
         "ansi-escapes": {
@@ -2301,7 +4345,7 @@
         },
         "array-equal": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
@@ -2387,12 +4431,6 @@
                 "es-abstract": "^1.10.0",
                 "function-bind": "^1.1.1"
             }
-        },
-        "arrify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-            "dev": true
         },
         "asap": {
             "version": "2.0.6",
@@ -2504,17 +4542,51 @@
             "dev": true
         },
         "autoprefixer": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.3.1.tgz",
-            "integrity": "sha512-DY9gOh8z3tnCbJ13JIWaeQsoYncTGdsrgCceBaQSIL4nvdrLxgbRSBPevg2XbX7u4QCSfLheSJEEIUUSlkbx6Q==",
+            "version": "9.5.1",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
+            "integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.3.3",
-                "caniuse-lite": "^1.0.30000898",
+                "browserslist": "^4.5.4",
+                "caniuse-lite": "^1.0.30000957",
                 "normalize-range": "^0.1.2",
                 "num2fraction": "^1.2.2",
-                "postcss": "^7.0.5",
+                "postcss": "^7.0.14",
                 "postcss-value-parser": "^3.3.1"
+            },
+            "dependencies": {
+                "browserslist": {
+                    "version": "4.5.5",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+                    "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30000960",
+                        "electron-to-chromium": "^1.3.124",
+                        "node-releases": "^1.1.14"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30000963",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
+                    "integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
+                    "dev": true
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.126",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.126.tgz",
+                    "integrity": "sha512-anr0OeQkZvOGzsz1ZM7BliJjHKfEsodQWoncklQWryDCSXMdVtt/fXlQBKfXXmbMVDhpiydwL3jaonbWuk/F6g==",
+                    "dev": true
+                },
+                "node-releases": {
+                    "version": "1.1.17",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
+                    "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^5.3.0"
+                    }
+                }
             }
         },
         "aws-sign2": {
@@ -2906,6 +4978,15 @@
                 "babel-runtime": "^6.22.0"
             }
         },
+        "babel-plugin-dynamic-import-node": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz",
+            "integrity": "sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==",
+            "dev": true,
+            "requires": {
+                "object.assign": "^4.1.0"
+            }
+        },
         "babel-plugin-istanbul": {
             "version": "5.1.3",
             "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.3.tgz",
@@ -3073,14 +5154,84 @@
                 "babel-helper-is-void-0": "^0.4.3"
             }
         },
+        "babel-plugin-named-asset-import": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.2.3.tgz",
+            "integrity": "sha512-9mx2Z9M4EGbutvXxoLV7aUBCY6ps3sqLFl094FeA2tFQzQffIh0XSsmwwQRxiSfpg3rnb5x/o46qRLxS/OzFTg==",
+            "dev": true
+        },
         "babel-plugin-react-docgen": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-2.0.0.tgz",
-            "integrity": "sha512-AaA6IPxCF1EkzpFG41GkVh/VGdoBejPF6oIub2K8E6AD3kwnTZ0DIKG7f20a7zmqBEeO8GkFWdM7tYd9Owkc+Q==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-2.0.2.tgz",
+            "integrity": "sha512-fFendfUUU2KqqE1ki2NyQoZm4uHPoEWPUgBZiPBiowcPZos+4q+chdQh0nlwY5hxs08AMHSH4Pp98RQL0VFS/g==",
             "dev": true,
             "requires": {
                 "lodash": "^4.17.10",
-                "react-docgen": "^3.0.0-rc.1"
+                "react-docgen": "^3.0.0",
+                "recast": "^0.14.7"
+            },
+            "dependencies": {
+                "ast-types": {
+                    "version": "0.11.7",
+                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.7.tgz",
+                    "integrity": "sha512-2mP3TwtkY/aTv5X3ZsMpNAbOnyoC/aMJwJSoaELPkHId0nSQgFcnU4dRW3isxiz7+zBexk0ym3WNVjMiQBnJSw==",
+                    "dev": true
+                },
+                "react-docgen": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-3.0.0.tgz",
+                    "integrity": "sha512-2UseoLWabFNXuk1Foz4VDPSIAkxz+1Hmmq4qijzUmYHDq0ZSloKDLXtGLpQRcAi/M76hRpPtH1rV4BI5jNAOnQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/parser": "^7.1.3",
+                        "@babel/runtime": "^7.0.0",
+                        "async": "^2.1.4",
+                        "commander": "^2.19.0",
+                        "doctrine": "^2.0.0",
+                        "node-dir": "^0.1.10",
+                        "recast": "^0.16.0"
+                    },
+                    "dependencies": {
+                        "recast": {
+                            "version": "0.16.2",
+                            "resolved": "https://registry.npmjs.org/recast/-/recast-0.16.2.tgz",
+                            "integrity": "sha512-O/7qXi51DPjRVdbrpNzoBQH5dnAPQNbfoOFyRiUwreTMJfIHYOEBzwuH+c0+/BTSJ3CQyKs6ILSWXhESH6Op3A==",
+                            "dev": true,
+                            "requires": {
+                                "ast-types": "0.11.7",
+                                "esprima": "~4.0.0",
+                                "private": "~0.1.5",
+                                "source-map": "~0.6.1"
+                            }
+                        }
+                    }
+                },
+                "recast": {
+                    "version": "0.14.7",
+                    "resolved": "https://registry.npmjs.org/recast/-/recast-0.14.7.tgz",
+                    "integrity": "sha512-/nwm9pkrcWagN40JeJhkPaRxiHXBRkXyRh/hgU088Z/v+qCy+zIHHY6bC6o7NaKAxPqtE6nD8zBH1LfU0/Wx6A==",
+                    "dev": true,
+                    "requires": {
+                        "ast-types": "0.11.3",
+                        "esprima": "~4.0.0",
+                        "private": "~0.1.5",
+                        "source-map": "~0.6.1"
+                    },
+                    "dependencies": {
+                        "ast-types": {
+                            "version": "0.11.3",
+                            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
+                            "integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
             }
         },
         "babel-plugin-react-svg": {
@@ -3633,6 +5784,12 @@
                 "babel-runtime": "^6.22.0"
             }
         },
+        "babel-plugin-transform-react-remove-prop-types": {
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.18.tgz",
+            "integrity": "sha512-azed2nHo8vmOy7EY26KH+om5oOcWRs0r1U8wOmhwta+SBMMnmJ4H6yaBZRCcHBtMeWp9AVhvBTL/lpR1kEx+Xw==",
+            "dev": true
+        },
         "babel-plugin-transform-regenerator": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
@@ -3825,6 +5982,165 @@
                 "babel-plugin-transform-react-jsx-self": "^6.22.0",
                 "babel-plugin-transform-react-jsx-source": "^6.22.0",
                 "babel-preset-flow": "^6.23.0"
+            }
+        },
+        "babel-preset-react-app": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-6.1.0.tgz",
+            "integrity": "sha512-8PJ4N+acfYsjhDK4gMWkqJMVRMjDKb93D+nz7lWlNe73Jcv38FNu37i5K/dVQnFDdRYHbe1SjII+Y0mCgink9A==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "7.1.0",
+                "@babel/plugin-proposal-class-properties": "7.1.0",
+                "@babel/plugin-proposal-decorators": "7.1.2",
+                "@babel/plugin-proposal-object-rest-spread": "7.0.0",
+                "@babel/plugin-syntax-dynamic-import": "7.0.0",
+                "@babel/plugin-transform-classes": "7.1.0",
+                "@babel/plugin-transform-destructuring": "7.0.0",
+                "@babel/plugin-transform-flow-strip-types": "7.0.0",
+                "@babel/plugin-transform-react-constant-elements": "7.0.0",
+                "@babel/plugin-transform-react-display-name": "7.0.0",
+                "@babel/plugin-transform-runtime": "7.1.0",
+                "@babel/preset-env": "7.1.0",
+                "@babel/preset-react": "7.0.0",
+                "@babel/preset-typescript": "7.1.0",
+                "@babel/runtime": "7.0.0",
+                "babel-loader": "8.0.4",
+                "babel-plugin-dynamic-import-node": "2.2.0",
+                "babel-plugin-macros": "2.4.2",
+                "babel-plugin-transform-react-remove-prop-types": "0.4.18"
+            },
+            "dependencies": {
+                "@babel/core": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.0.tgz",
+                    "integrity": "sha512-9EWmD0cQAbcXSc+31RIoYgEHx3KQ2CCSMDBhnXrShWvo45TMw+3/55KVxlhkG53kw9tl87DqINgHDgFVhZJV/Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@babel/generator": "^7.0.0",
+                        "@babel/helpers": "^7.1.0",
+                        "@babel/parser": "^7.1.0",
+                        "@babel/template": "^7.1.0",
+                        "@babel/traverse": "^7.1.0",
+                        "@babel/types": "^7.0.0",
+                        "convert-source-map": "^1.1.0",
+                        "debug": "^3.1.0",
+                        "json5": "^0.5.0",
+                        "lodash": "^4.17.10",
+                        "resolve": "^1.3.2",
+                        "semver": "^5.4.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/plugin-transform-destructuring": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0.tgz",
+                    "integrity": "sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-flow-strip-types": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0.tgz",
+                    "integrity": "sha512-WhXUNb4It5a19RsgKKbQPrjmy4yWOY1KynpEbNw7bnd1QTcrT/EIl3MJvnGgpgvrKyKbqX7nUNOJfkpLOnoDKA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/plugin-syntax-flow": "^7.0.0"
+                    }
+                },
+                "@babel/plugin-transform-react-constant-elements": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.0.0.tgz",
+                    "integrity": "sha512-z8yrW4KCVcqPYr0r9dHXe7fu3daLzn0r6TQEFoGbXahdrzEwT1d1ux+/EnFcqIHv9uPilUlnRnPIUf7GMO0ehg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0"
+                    }
+                },
+                "@babel/preset-env": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
+                    "integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-imports": "^7.0.0",
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/plugin-proposal-async-generator-functions": "^7.1.0",
+                        "@babel/plugin-proposal-json-strings": "^7.0.0",
+                        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+                        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+                        "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+                        "@babel/plugin-syntax-async-generators": "^7.0.0",
+                        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+                        "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+                        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+                        "@babel/plugin-transform-async-to-generator": "^7.1.0",
+                        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+                        "@babel/plugin-transform-block-scoping": "^7.0.0",
+                        "@babel/plugin-transform-classes": "^7.1.0",
+                        "@babel/plugin-transform-computed-properties": "^7.0.0",
+                        "@babel/plugin-transform-destructuring": "^7.0.0",
+                        "@babel/plugin-transform-dotall-regex": "^7.0.0",
+                        "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+                        "@babel/plugin-transform-exponentiation-operator": "^7.1.0",
+                        "@babel/plugin-transform-for-of": "^7.0.0",
+                        "@babel/plugin-transform-function-name": "^7.1.0",
+                        "@babel/plugin-transform-literals": "^7.0.0",
+                        "@babel/plugin-transform-modules-amd": "^7.1.0",
+                        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+                        "@babel/plugin-transform-modules-systemjs": "^7.0.0",
+                        "@babel/plugin-transform-modules-umd": "^7.1.0",
+                        "@babel/plugin-transform-new-target": "^7.0.0",
+                        "@babel/plugin-transform-object-super": "^7.1.0",
+                        "@babel/plugin-transform-parameters": "^7.1.0",
+                        "@babel/plugin-transform-regenerator": "^7.0.0",
+                        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+                        "@babel/plugin-transform-spread": "^7.0.0",
+                        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+                        "@babel/plugin-transform-template-literals": "^7.0.0",
+                        "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+                        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+                        "browserslist": "^4.1.0",
+                        "invariant": "^2.2.2",
+                        "js-levenshtein": "^1.1.3",
+                        "semver": "^5.3.0"
+                    }
+                },
+                "@babel/runtime": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+                    "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.12.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "json5": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+                    "dev": true
+                },
+                "regenerator-runtime": {
+                    "version": "0.12.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+                    "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+                    "dev": true
+                }
             }
         },
         "babel-preset-stage-0": {
@@ -4053,6 +6369,12 @@
             "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
             "dev": true
         },
+        "bail": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
+            "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
+            "dev": true
+        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -4228,24 +6550,24 @@
             "dev": true
         },
         "boxen": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/boxen/-/boxen-2.0.0.tgz",
-            "integrity": "sha512-9DK9PQqcOpsvlKOK3f3lVK+vQsqH4JDGMX73FCWcHRxQQtop1U8urn4owrt5rnc2NgZAJ6wWjTDBc7Fhv+vz/w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/boxen/-/boxen-2.1.0.tgz",
+            "integrity": "sha512-luq3RQOt2U5sUX+fiu+qnT+wWnHDcATLpEe63jvge6GUZO99AKbVRfp97d2jgLvq1iQa0ORzaAm4lGVG52ZSlw==",
             "dev": true,
             "requires": {
-                "ansi-align": "^2.0.0",
+                "ansi-align": "^3.0.0",
                 "camelcase": "^5.0.0",
                 "chalk": "^2.4.1",
                 "cli-boxes": "^1.0.0",
-                "string-width": "^2.1.1",
+                "string-width": "^3.0.0",
                 "term-size": "^1.2.0",
                 "widest-line": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {
@@ -4255,22 +6577,23 @@
                     "dev": true
                 },
                 "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
+                        "emoji-regex": "^7.0.1",
                         "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "strip-ansi": "^5.1.0"
                     }
                 },
                 "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
@@ -4623,6 +6946,12 @@
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
             "dev": true
         },
+        "ccount": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
+            "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
+            "dev": true
+        },
         "center-align": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -4708,6 +7037,29 @@
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
                         "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "child-process-promise": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-2.2.1.tgz",
+            "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^4.0.2",
+                "node-version": "^1.0.0",
+                "promise-polyfill": "^6.0.1"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+                    "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "which": "^1.2.9"
                     }
                 }
             }
@@ -4967,6 +7319,30 @@
             "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
             "dev": true
         },
+        "clone-deep": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+            "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+            "dev": true,
+            "requires": {
+                "for-own": "^0.1.3",
+                "is-plain-object": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "lazy-cache": "^1.0.3",
+                "shallow-clone": "^0.1.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5053,9 +7429,9 @@
             }
         },
         "colors": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-            "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+            "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
             "dev": true,
             "optional": true
         },
@@ -5067,6 +7443,12 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
+        },
+        "comma-separated-tokens": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.6.tgz",
+            "integrity": "sha512-f20oA7jsrrmERTS70r3tmRSxR8IJV2MTN7qe6hzgX+3ARfXrdMJFvGWvWQK0xpcBurg9j9eO2MiqzZ8Y+/UPCA==",
+            "dev": true
         },
         "commander": {
             "version": "2.19.0",
@@ -5191,18 +7573,90 @@
             "dev": true
         },
         "copy-to-clipboard": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz",
-            "integrity": "sha512-c3GdeY8qxCHGezVb1EFQfHYK/8NZRemgcTIzPq7PuxjHAf/raKibn2QdhHPb/y6q74PMgH6yizaDZlRmw6QyKw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.1.0.tgz",
+            "integrity": "sha512-+RNyDq266tv5aGhfRsL6lxgj8Y6sCvTrVJnFUVvuxuqkcSMaLISt1wd4JkdQSphbcLTIQ9kEpTULNnoCXAFdng==",
             "dev": true,
             "requires": {
-                "toggle-selection": "^1.0.3"
+                "toggle-selection": "^1.0.6"
             }
         },
         "core-js": {
             "version": "2.5.7",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
             "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+            "dev": true
+        },
+        "core-js-compat": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.0.1.tgz",
+            "integrity": "sha512-2pC3e+Ht/1/gD7Sim/sqzvRplMiRnFQVlPpDVaHtY9l7zZP7knamr3VRD6NyGfHd84MrDC0tAM9ulNxYMW0T3g==",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.5.4",
+                "core-js": "3.0.1",
+                "core-js-pure": "3.0.1",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "browserslist": {
+                    "version": "4.5.5",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+                    "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30000960",
+                        "electron-to-chromium": "^1.3.124",
+                        "node-releases": "^1.1.14"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30000963",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
+                    "integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
+                    "dev": true
+                },
+                "core-js": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
+                    "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
+                    "dev": true
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.126",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.126.tgz",
+                    "integrity": "sha512-anr0OeQkZvOGzsz1ZM7BliJjHKfEsodQWoncklQWryDCSXMdVtt/fXlQBKfXXmbMVDhpiydwL3jaonbWuk/F6g==",
+                    "dev": true
+                },
+                "node-releases": {
+                    "version": "1.1.17",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
+                    "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "semver": {
+                            "version": "5.7.0",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+                            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "semver": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+                    "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+                    "dev": true
+                }
+            }
+        },
+        "core-js-pure": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.1.tgz",
+            "integrity": "sha512-mSxeQ6IghKW3MoyF4cz19GJ1cMm7761ON+WObSyLfTu/Jn3x7w4NwNFnrZxgl4MTSvYYepVLNuRtlB4loMwJ5g==",
             "dev": true
         },
         "core-util-is": {
@@ -5368,6 +7822,12 @@
                 "nth-check": "~1.0.1"
             }
         },
+        "css-select-base-adapter": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+            "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+            "dev": true
+        },
         "css-selector-tokenizer": {
             "version": "0.7.1",
             "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
@@ -5412,6 +7872,22 @@
                     }
                 }
             }
+        },
+        "css-tree": {
+            "version": "1.0.0-alpha.28",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
+            "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+            "dev": true,
+            "requires": {
+                "mdn-data": "~1.1.0",
+                "source-map": "^0.5.3"
+            }
+        },
+        "css-url-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
+            "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
+            "dev": true
         },
         "css-what": {
             "version": "2.1.2",
@@ -5822,12 +8298,11 @@
             }
         },
         "dir-glob": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-            "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+            "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.1",
                 "path-type": "^3.0.0"
             }
         },
@@ -6009,6 +8484,12 @@
                 "minimalistic-assert": "^1.0.0",
                 "minimalistic-crypto-utils": "^1.0.0"
             }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+            "dev": true
         },
         "emojis-list": {
             "version": "2.1.0",
@@ -6559,10 +9040,10 @@
                 "es5-ext": "~0.10.14"
             }
         },
-        "events": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-            "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+        "eventemitter3": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+            "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
             "dev": true
         },
         "eventsource": {
@@ -6873,9 +9354,9 @@
             "dev": true
         },
         "fast-glob": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz",
-            "integrity": "sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==",
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
+            "integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
             "dev": true,
             "requires": {
                 "@mrmlnc/readdir-enhanced": "^2.2.1",
@@ -6995,6 +9476,21 @@
                 "bluebird": "^3.3.5",
                 "fs-extra": "^0.30.0",
                 "ramda": "^0.21.0"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "0.30.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+                    "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^2.1.0",
+                        "klaw": "^1.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "rimraf": "^2.2.8"
+                    }
+                }
             }
         },
         "fileset": {
@@ -7122,6 +9618,15 @@
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
         },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.1"
+            }
+        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -7171,16 +9676,25 @@
             }
         },
         "fs-extra": {
-            "version": "0.30.0",
-            "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-            "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
-                "jsonfile": "^2.1.0",
-                "klaw": "^1.0.0",
-                "path-is-absolute": "^1.0.0",
-                "rimraf": "^2.2.8"
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "dependencies": {
+                "jsonfile": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6"
+                    }
+                }
             }
         },
         "fs-write-stream-atomic": {
@@ -7202,14 +9716,14 @@
             "dev": true
         },
         "fsevents": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-            "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
+            "integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
+                "nan": "^2.12.1",
+                "node-pre-gyp": "^0.12.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -7230,7 +9744,7 @@
                     "optional": true
                 },
                 "are-we-there-yet": {
-                    "version": "1.1.4",
+                    "version": "1.1.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -7254,7 +9768,7 @@
                     }
                 },
                 "chownr": {
-                    "version": "1.0.1",
+                    "version": "1.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -7281,16 +9795,16 @@
                     "optional": true
                 },
                 "debug": {
-                    "version": "2.6.9",
+                    "version": "4.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
                 },
                 "deep-extend": {
-                    "version": "0.5.1",
+                    "version": "0.6.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -7339,7 +9853,7 @@
                     }
                 },
                 "glob": {
-                    "version": "7.1.2",
+                    "version": "7.1.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -7359,12 +9873,12 @@
                     "optional": true
                 },
                 "iconv-lite": {
-                    "version": "0.4.21",
+                    "version": "0.4.24",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "^2.1.0"
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
                 },
                 "ignore-walk": {
@@ -7425,16 +9939,16 @@
                     "dev": true
                 },
                 "minipass": {
-                    "version": "2.2.4",
+                    "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "^5.1.1",
+                        "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
-                    "version": "1.1.0",
+                    "version": "1.2.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -7451,35 +9965,42 @@
                     }
                 },
                 "ms": {
-                    "version": "2.0.0",
+                    "version": "2.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
+                "nan": {
+                    "version": "2.13.2",
+                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+                    "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+                    "dev": true,
+                    "optional": true
+                },
                 "needle": {
-                    "version": "2.2.0",
+                    "version": "2.3.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^2.1.2",
+                        "debug": "^4.1.0",
                         "iconv-lite": "^0.4.4",
                         "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
-                    "version": "0.10.0",
+                    "version": "0.12.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
                         "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
+                        "needle": "^2.2.1",
                         "nopt": "^4.0.1",
                         "npm-packlist": "^1.1.6",
                         "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
+                        "rc": "^1.2.7",
                         "rimraf": "^2.6.1",
                         "semver": "^5.3.0",
                         "tar": "^4"
@@ -7496,13 +10017,13 @@
                     }
                 },
                 "npm-bundled": {
-                    "version": "1.0.3",
+                    "version": "1.0.6",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
-                    "version": "1.1.10",
+                    "version": "1.4.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -7577,12 +10098,12 @@
                     "optional": true
                 },
                 "rc": {
-                    "version": "1.2.7",
+                    "version": "1.2.8",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "^0.5.1",
+                        "deep-extend": "^0.6.0",
                         "ini": "~1.3.0",
                         "minimist": "^1.2.0",
                         "strip-json-comments": "~2.0.1"
@@ -7612,16 +10133,16 @@
                     }
                 },
                 "rimraf": {
-                    "version": "2.6.2",
+                    "version": "2.6.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "^7.1.3"
                     }
                 },
                 "safe-buffer": {
-                    "version": "5.1.1",
+                    "version": "5.1.2",
                     "bundled": true,
                     "dev": true
                 },
@@ -7638,7 +10159,7 @@
                     "optional": true
                 },
                 "semver": {
-                    "version": "5.5.0",
+                    "version": "5.7.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -7689,17 +10210,17 @@
                     "optional": true
                 },
                 "tar": {
-                    "version": "4.4.1",
+                    "version": "4.4.8",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "^1.0.1",
+                        "chownr": "^1.1.1",
                         "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
                         "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
+                        "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.2"
                     }
                 },
@@ -7710,12 +10231,12 @@
                     "optional": true
                 },
                 "wide-align": {
-                    "version": "1.1.2",
+                    "version": "1.1.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "^1.0.2 || 2"
                     }
                 },
                 "wrappy": {
@@ -7724,7 +10245,7 @@
                     "dev": true
                 },
                 "yallist": {
-                    "version": "3.0.2",
+                    "version": "3.0.3",
                     "bundled": true,
                     "dev": true
                 }
@@ -7926,7 +10447,7 @@
         },
         "globby": {
             "version": "8.0.1",
-            "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
             "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
             "dev": true,
             "requires": {
@@ -8085,6 +10606,37 @@
                 "minimalistic-assert": "^1.0.1"
             }
         },
+        "hast-util-from-parse5": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.0.tgz",
+            "integrity": "sha512-A7ev5OseS/J15214cvDdcI62uwovJO2PB60Xhnq7kaxvvQRFDEccuqbkrFXU03GPBGopdPqlpQBRqIcDS/Fjbg==",
+            "dev": true,
+            "requires": {
+                "ccount": "^1.0.3",
+                "hastscript": "^5.0.0",
+                "property-information": "^5.0.0",
+                "web-namespaces": "^1.1.2",
+                "xtend": "^4.0.1"
+            }
+        },
+        "hast-util-parse-selector": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.1.tgz",
+            "integrity": "sha512-Xyh0v+nHmQvrOqop2Jqd8gOdyQtE8sIP9IQf7mlVDqp924W4w/8Liuguk2L2qei9hARnQSG2m+wAOCxM7npJVw==",
+            "dev": true
+        },
+        "hastscript": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.0.0.tgz",
+            "integrity": "sha512-xJtuJ8D42Xtq5yJrnDg/KAIxl2cXBXKoiIJwmWX9XMf8113qHTGl/Bf7jEsxmENJ4w6q4Tfl8s/Y6mEZo8x8qw==",
+            "dev": true,
+            "requires": {
+                "comma-separated-tokens": "^1.0.0",
+                "hast-util-parse-selector": "^2.2.0",
+                "property-information": "^5.0.1",
+                "space-separated-tokens": "^1.0.0"
+            }
+        },
         "he": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -8205,9 +10757,9 @@
             "dev": true
         },
         "html-webpack-plugin": {
-            "version": "4.0.0-beta.4",
-            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.4.tgz",
-            "integrity": "sha512-5JDvn5zoNxcfnbuciyBbHTtUkOXfoVdO4g0Ma2ibVHruEvtx2g5wFgRjl/bAHrnF4EzGlCFn168cOnmMGg9NtA==",
+            "version": "4.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.5.tgz",
+            "integrity": "sha512-y5l4lGxOW3pz3xBTFdfB9rnnrWRPVxlAhX6nrBYIcW+2k2zC3mSp/3DxlWVCMBfnO6UAnoF8OcFn0IMy6kaKAQ==",
             "dev": true,
             "requires": {
                 "html-minifier": "^3.5.20",
@@ -10203,9 +12755,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-            "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -10319,7 +12871,7 @@
         },
         "jsonfile": {
             "version": "2.4.0",
-            "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
             "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
             "dev": true,
             "requires": {
@@ -10400,9 +12952,9 @@
             },
             "dependencies": {
                 "dotenv": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
-                    "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw==",
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+                    "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
                     "dev": true
                 }
             }
@@ -10815,6 +13367,12 @@
                 "safe-buffer": "^5.1.2"
             }
         },
+        "mdn-data": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+            "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+            "dev": true
+        },
         "media-typer": {
             "version": "0.3.0",
             "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -10838,6 +13396,28 @@
             "requires": {
                 "errno": "^0.1.3",
                 "readable-stream": "^2.0.1"
+            }
+        },
+        "merge-deep": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
+            "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "clone-deep": "^0.2.4",
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "merge-descriptors": {
@@ -11011,6 +13591,24 @@
                 }
             }
         },
+        "mixin-object": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+            "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+            "dev": true,
+            "requires": {
+                "for-in": "^0.1.3",
+                "is-extendable": "^0.1.1"
+            },
+            "dependencies": {
+                "for-in": {
+                    "version": "0.1.8",
+                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+                    "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+                    "dev": true
+                }
+            }
+        },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -11074,13 +13672,6 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
             "dev": true
-        },
-        "nan": {
-            "version": "2.11.1",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-            "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-            "dev": true,
-            "optional": true
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -11262,6 +13853,12 @@
             "requires": {
                 "semver": "^5.3.0"
             }
+        },
+        "node-version": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.2.0.tgz",
+            "integrity": "sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==",
+            "dev": true
         },
         "nomnom": {
             "version": "1.6.2",
@@ -11545,9 +14142,9 @@
             "dev": true
         },
         "opn": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-            "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+            "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
             "dev": true,
             "requires": {
                 "is-wsl": "^1.1.0"
@@ -11565,7 +14162,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "0.0.10",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                     "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
                     "dev": true
                 },
@@ -11923,21 +14520,52 @@
             "dev": true
         },
         "postcss": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-            "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+            "version": "7.0.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+            "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.1",
+                "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
-                "supports-color": "^5.5.0"
+                "supports-color": "^6.1.0"
             },
             "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "5.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
+                    }
+                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
                 }
             }
         },
@@ -13848,6 +16476,12 @@
                 }
             }
         },
+        "pretty-hrtime": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+            "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+            "dev": true
+        },
         "private": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -13887,6 +16521,12 @@
             "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
             "dev": true
         },
+        "promise-polyfill": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
+            "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=",
+            "dev": true
+        },
         "promise.prototype.finally": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
@@ -13916,6 +16556,15 @@
             "requires": {
                 "loose-envify": "^1.3.1",
                 "object-assign": "^4.1.1"
+            }
+        },
+        "property-information": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.0.1.tgz",
+            "integrity": "sha512-nAtBDVeSwFM3Ot/YxT7s4NqZmqXI7lLzf46BThvotEtYf2uk2yH0ACYuWQkJ7gxKs49PPtKVY0UlDGkyN9aJlw==",
+            "dev": true,
+            "requires": {
+                "xtend": "^4.0.1"
             }
         },
         "proxy-addr": {
@@ -14080,7 +16729,7 @@
         },
         "ramda": {
             "version": "0.21.0",
-            "resolved": "http://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
             "integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=",
             "dev": true
         },
@@ -14172,12 +16821,13 @@
             }
         },
         "react-color": {
-            "version": "2.14.1",
-            "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.14.1.tgz",
-            "integrity": "sha512-ssv2ArSZdhTbIs29hyfw8JW+s3G4BCx/ILkwCajWZzrcx/2ZQfRpsaLVt38LAPbxe50LLszlmGtRerA14JzzRw==",
+            "version": "2.17.1",
+            "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.17.1.tgz",
+            "integrity": "sha512-S+I6TkUKJaqfALLkAIfiCZ/MANQyy7dKkf7g9ZU5GTUy2rf8c2Rx62otyvADAviWR+6HRkzdf2vL1Qvz9goCLQ==",
             "dev": true,
             "requires": {
-                "lodash": "^4.0.1",
+                "@icons/material": "^0.2.4",
+                "lodash": "^4.17.11",
                 "material-colors": "^1.2.1",
                 "prop-types": "^15.5.10",
                 "reactcss": "^1.2.0",
@@ -14290,10 +16940,19 @@
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true
                 },
+                "opn": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+                    "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+                    "dev": true,
+                    "requires": {
+                        "is-wsl": "^1.1.0"
+                    }
+                },
                 "p-limit": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-                    "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
@@ -14309,9 +16968,9 @@
                     }
                 },
                 "p-try": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-                    "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
                     "dev": true
                 },
                 "strip-ansi": {
@@ -14353,9 +17012,9 @@
             }
         },
         "react-error-overlay": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.0.tgz",
-            "integrity": "sha512-akMy/BQT5m1J3iJIHkSb4qycq2wzllWsmmolaaFVnb+LPV9cIJ/nTud40ZsiiT0H3P+/wXIdbjx2fzF61OaeOQ==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.5.tgz",
+            "integrity": "sha512-O9JRum1Zq/qCPFH5qVEvDDrVun8Jv9vbHtZXCR1EuRj9sKg1xJTlHxBzU6AkCzpvxRLuiY4OKImy3cDLQ+UTdg==",
             "dev": true
         },
         "react-fuzzy": {
@@ -15810,11 +18469,12 @@
             }
         },
         "react-textarea-autosize": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.0.4.tgz",
-            "integrity": "sha512-1cC8pFSrIVH92aE+UKxGQ2Gqq43qdIcMscJKScEFeBNemn6gHa+NwKqdXkHxxg5H6uuvW+cPpJPTes6zh90M+A==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.0.tgz",
+            "integrity": "sha512-c2FlR/fP0qbxmlrW96SdrbgP/v0XZMTupqB90zybvmDVDutytUgPl7beU35klwcTeMepUIQEpQUn3P3bdshGPg==",
             "dev": true,
             "requires": {
+                "@babel/runtime": "^7.1.2",
                 "prop-types": "^15.6.0"
             }
         },
@@ -16079,6 +18739,12 @@
                 "safe-regex": "^1.1.0"
             }
         },
+        "regexp-tree": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.5.tgz",
+            "integrity": "sha512-nUmxvfJyAODw+0B13hj8CFVAxhe7fDEAgJgaotBu3nnR+IgGgZq59YedJP5VYTlkEfqjuK6TuRpnymKdatLZfQ==",
+            "dev": true
+        },
         "regexp.prototype.flags": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
@@ -16127,6 +18793,25 @@
                     "version": "0.5.0",
                     "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
                     "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                }
+            }
+        },
+        "rehype-parse": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.0.tgz",
+            "integrity": "sha512-V2OjMD0xcSt39G4uRdMTqDXXm6HwkUbLMDayYKA/d037j8/OtVSQ+tqKwYWOuyBeoCs/3clXRe30VUjeMDTBSA==",
+            "dev": true,
+            "requires": {
+                "hast-util-from-parse5": "^5.0.0",
+                "parse5": "^5.0.0",
+                "xtend": "^4.0.1"
+            },
+            "dependencies": {
+                "parse5": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+                    "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
                     "dev": true
                 }
             }
@@ -16182,6 +18867,12 @@
             "requires": {
                 "is-finite": "^1.0.0"
             }
+        },
+        "replace-ext": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+            "dev": true
         },
         "request": {
             "version": "2.88.0",
@@ -16692,6 +19383,35 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "shallow-clone": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+            "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+            "dev": true,
+            "requires": {
+                "is-extendable": "^0.1.1",
+                "kind-of": "^2.0.1",
+                "lazy-cache": "^0.2.3",
+                "mixin-object": "^2.0.1"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                    "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.0.2"
+                    }
+                },
+                "lazy-cache": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                    "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+                    "dev": true
+                }
+            }
+        },
         "shallowequal": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -16988,6 +19708,21 @@
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
             "dev": true
         },
+        "space-separated-tokens": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.3.tgz",
+            "integrity": "sha512-/M5RAdBuQlSDPNfA5ube+fkHbHyY08pMuADLmsAQURzo56w90r681oiOoz3o3ZQyWdSeNucpTFjL+Ggd5qui3w==",
+            "dev": true
+        },
+        "spawn-promise": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/spawn-promise/-/spawn-promise-0.1.8.tgz",
+            "integrity": "sha512-pTkEOFxvYLq9SaI1d8bwepj0yD9Yyz65+4e979YZLv/L3oYPxZpDTabcm6e+KIZniGK9mQ+LGrwB5s1v2z67nQ==",
+            "dev": true,
+            "requires": {
+                "co": "^4.6.0"
+            }
+        },
         "spdx-correct": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
@@ -17060,6 +19795,12 @@
             "requires": {
                 "figgy-pudding": "^3.5.1"
             }
+        },
+        "stable": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+            "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+            "dev": true
         },
         "stack-utils": {
             "version": "1.0.2",
@@ -17729,6 +20470,12 @@
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
+        "trough": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
+            "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
+            "dev": true
+        },
         "tryer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -17966,6 +20713,42 @@
             "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
             "dev": true
         },
+        "unified": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+            "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+            "dev": true,
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "@types/vfile": "^3.0.0",
+                "bail": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "trough": "^1.0.0",
+                "vfile": "^3.0.0",
+                "x-is-string": "^0.1.0"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+                    "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+                    "dev": true
+                },
+                "vfile": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+                    "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^2.0.0",
+                        "replace-ext": "1.0.0",
+                        "unist-util-stringify-position": "^1.0.0",
+                        "vfile-message": "^1.0.0"
+                    }
+                }
+            }
+        },
         "union-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -18031,10 +20814,28 @@
                 "imurmurhash": "^0.1.4"
             }
         },
+        "unist-util-stringify-position": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+            "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+            "dev": true
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
+        },
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
+        },
+        "unquote": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+            "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
             "dev": true
         },
         "unset-value": {
@@ -18134,9 +20935,9 @@
             },
             "dependencies": {
                 "mime": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-                    "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+                    "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
                     "dev": true
                 }
             }
@@ -18257,6 +21058,63 @@
                 "extsprintf": "^1.2.0"
             }
         },
+        "vfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.0.tgz",
+            "integrity": "sha512-WMNeHy5djSl895BqE86D7WqA0Ie5fAIeGCa7V1EqiXyJg5LaGch2SUaZueok5abYQGH6mXEAsZ45jkoILIOlyA==",
+            "dev": true,
+            "requires": {
+                "@types/unist": "^2.0.2",
+                "is-buffer": "^2.0.0",
+                "replace-ext": "1.0.0",
+                "unist-util-stringify-position": "^2.0.0",
+                "vfile-message": "^2.0.0"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+                    "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+                    "dev": true
+                },
+                "unist-util-stringify-position": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.0.tgz",
+                    "integrity": "sha512-Uz5negUTrf9zm2ZT2Z9kdOL7Mr7FJLyq3ByqagUi7QZRVK1HnspVazvSqwHt73jj7APHtpuJ4K110Jm8O6/elw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/unist": "^2.0.2"
+                    }
+                },
+                "vfile-message": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.0.tgz",
+                    "integrity": "sha512-YS6qg6UpBfIeiO+6XlhPOuJaoLvt1Y9g2cmlwqhBOOU0XRV8j5RLeoz72t6PWLvNXq3EBG1fQ05wNPrUoz0deQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/unist": "^2.0.2",
+                        "unist-util-stringify-position": "^1.1.1"
+                    },
+                    "dependencies": {
+                        "unist-util-stringify-position": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+                            "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "vfile-message": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+            "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+            "dev": true,
+            "requires": {
+                "unist-util-stringify-position": "^1.1.1"
+            }
+        },
         "vm-browserify": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
@@ -18303,6 +21161,12 @@
                 "graceful-fs": "^4.1.2",
                 "neo-async": "^2.5.0"
             }
+        },
+        "web-namespaces": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.2.tgz",
+            "integrity": "sha512-II+n2ms4mPxK+RnIxRPOw3zwF2jRscdJIUE9BfkKHm4FYEg9+biIoTMnaZF5MpemE3T+VhMLrhbyD4ilkPCSbg==",
+            "dev": true
         },
         "webidl-conversions": {
             "version": "4.0.2",
@@ -18355,12 +21219,13 @@
             }
         },
         "webpack-bundle-analyzer": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.3.tgz",
-            "integrity": "sha512-naLWiRfmtH4UJgtUktRTLw6FdoZJ2RvCR9ePbwM9aRMsS/KjFerkPZG9epEvXRAw5d5oPdrs9+3p+afNjxW8Xw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.3.2.tgz",
+            "integrity": "sha512-7qvJLPKB4rRWZGjVp5U1KEjwutbDHSKboAl0IfafnrdXMrgC0tOtZbQD6Rw0u4cmpgRN4O02Fc0t8eAT+FgGzA==",
             "dev": true,
             "requires": {
-                "acorn": "^5.7.3",
+                "acorn": "^6.0.7",
+                "acorn-walk": "^6.1.1",
                 "bfj": "^6.1.1",
                 "chalk": "^2.4.1",
                 "commander": "^2.18.0",
@@ -18374,10 +21239,16 @@
                 "ws": "^6.0.0"
             },
             "dependencies": {
+                "acorn": {
+                    "version": "6.1.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+                    "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+                    "dev": true
+                },
                 "ws": {
-                    "version": "6.1.2",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
-                    "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+                    "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
                     "dev": true,
                     "requires": {
                         "async-limiter": "~1.0.0"
@@ -18594,21 +21465,21 @@
             }
         },
         "webpack-dev-middleware": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
-            "integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.2.tgz",
+            "integrity": "sha512-A47I5SX60IkHrMmZUlB0ZKSWi29TZTcPz7cha1Z75yYOsgWh/1AcPmQEbC8ZIbU3A1ytSv1PMU0PyPz2Lmz2jg==",
             "dev": true,
             "requires": {
-                "memory-fs": "~0.4.1",
+                "memory-fs": "^0.4.1",
                 "mime": "^2.3.1",
                 "range-parser": "^1.0.3",
                 "webpack-log": "^2.0.0"
             },
             "dependencies": {
                 "mime": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-                    "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+                    "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
                     "dev": true
                 }
             }
@@ -18838,6 +21709,12 @@
             "requires": {
                 "async-limiter": "~1.0.0"
             }
+        },
+        "x-is-string": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+            "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+            "dev": true
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "style-loader": "^0.23.0",
         "svg-url-loader": "^2.3.2",
         "webpack": "^4.18.0",
-        "webpack-bundle-analyzer": "^3.0.2",
+        "webpack-bundle-analyzer": "^3.3.2",
         "webpack-cli": "^3.1.0"
     },
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "eslint-plugin-jest": "^21.22.0",
         "eslint-plugin-prettier": "^2.6.2",
         "eslint-plugin-react": "^7.11.1",
-        "jest": "^23.6.0",
+        "jest": "^24.7.1",
         "less": "^3.8.1",
         "less-loader": "^4.1.0",
         "moment": "^2.18.1",
@@ -76,7 +76,9 @@
         "prop-types": "^15.6.2"
     },
     "jest": {
-        "setupTestFrameworkScriptFile": "./scripts/jestSetup.js",
+        "setupFilesAfterEnv": [
+            "./scripts/jestSetup.js"
+        ],
         "snapshotSerializers": [
             "enzyme-to-json/serializer"
         ],


### PR DESCRIPTION
## What

Upgrades Jest to the next major version.

Also upgrades `webpack-bundle-analyzer`. See details below.

## Why

I needed it to debug the issue fixed in #160, because Jest 23 had an issue with not printing out all the `console.log` statements executed while running tests. But since it did not cause any issues with our tests right now, and since this new version includes [a lot of other new features and improvements](https://jestjs.io/blog/2019/01/25/jest-24-refreshing-polished-typescript-friendly) I figured "why not?" 😄

This also upgrades `webpack-bundle-analyzer`, since it was the source for a significant amount of the vulnerabilities flagged by `npm audit` (there are still unresolved vulnerabilities after this, but this reduces the number a lot without much disruption, I'll probably roll out another PR upgrading more packages to fix them all).

## PR Checklist

* [ ] Added tests for bugs / new features
* [ ] Updated docs (storybooks, readme)
* [ ] Described changes in CHANGELOG.md
* [x] Executed `npm run check` and made sure no errors / warnings were shown
* [x] Executed `npm run test` and made sure all tests are passing
* [ ] Bumped version in package.json
* [ ] Updated all static build artifacts (`npm run build-all`)
