### PR TITLE
 Introduced npmignore to slim down package and fix .git bug

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,22 @@
+# Should be ignored by default but doesn't work
+.git/
+
+# Directories
+.cache/
+.github/
+.storybook/
+.vscode/
+coverage/
+docs/
+scripts/
+src/
+
+# Files
+.babelrc
+.DS_Store
+.eslintignore
+.eslintrc
+.prettierignore
+.prettierrc
+webpack-build-log**
+webpack.config.babel.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+## 1.21.00
+- [Tweak] introduced `.npmignore` file to keep released package smaller and only include the essentials. This also fixes a bug in **v1.20.00** where parts of the `.git` directory ended up in the file package.
+
 ## 1.20.00
 - [Tweak] Replaced Moment with [Day.js](https://github.com/iamkun/dayjs)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/reactist",
-    "version": "1.20.00",
+    "version": "1.21.00",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/reactist",
-    "version": "1.20.00",
+    "version": "1.21.00",
     "description": "Open source React components by Doist",
     "main": "./dist/reactist.js",
     "scripts": {


### PR DESCRIPTION
**Short description:**

In the last release parts `.git` ended up in the final release bundle which can cause problems when running `npm install` in dependent repositories as npm would detect reactist as being a repo instead of a dependency.
While fixing this I took the liberty to remove some more bloat from our published bundle and brought it down from `2.4 MB` to `470.4 kB` (packaged size)

**PR Checklist:**

* [x] Added tests for bugs / new features
* [x] Updated docs (storybooks, readme)
* [x] Described changes in CHANGELOG.md
* [x] Executed `npm run check` and made sure no errors / warnings were shown
* [x] Executed `npm run test` and made sure all tests are passing
* [x] Bumped version in package.json
* [x] Updated all static build artifacts (`npm run build-all`)
