### PR TITLE
Add test case with difference 1 day for TimeUtils

### DIFF
--- a/src/components/utils/__tests__/TimeUtils.test.js
+++ b/src/components/utils/__tests__/TimeUtils.test.js
@@ -47,6 +47,13 @@ describe('Time Utils', () => {
         expect(TimeUtils.timeAgo(testDate)).toBe('10h')
     })
 
+    it('timeAgo == 1d returns `yesterday`', () => {
+        const testDate = dayjs()
+            .subtract(1, 'day')
+            .unix()
+        expect(TimeUtils.timeAgo(testDate)).toBe('yesterday')
+    })
+
     it('timeAgo < 7d returns MM/DD/YYYY', () => {
         const testDate = dayjs()
             .subtract(2, 'days')


### PR DESCRIPTION
**Short description:**

I've added the test to `TimeUtils`. The new test case check if the day was 1 day ago then return the 'yesterday' word.

**PR Checklist:**

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Described changes in CHANGELOG.md
-   [x] Executed `npm run check` and made sure no errors / warnings were shown
-   [x] Executed `npm run test` and made sure all tests are passing
-   [ ] Bumped version in package.json
-   [ ] Updated all static build artifacts (`npm run build-all`)
