### PR TITLE
Add test case for Tooltip component with passing simple text

### DIFF
--- a/src/components/__tests__/Tooltip.test.js
+++ b/src/components/__tests__/Tooltip.test.js
@@ -223,6 +223,14 @@ describe('Tooltip', () => {
         expect(clickSpy).toHaveBeenCalledTimes(1)
     })
 
+    it('pass as children simple text', () => {
+        const tooltip = mount(
+            <Tooltip text="Tip">Wrapped Text</Tooltip>
+        ).instance()
+        expect(tooltip.wrapper).toBeTruthy()
+        expect(tooltip.tooltip).toBeTruthy()
+    })
+
     // Helpers ================================================================
     const getTooltip = (props = {}) => (
         <Tooltip text="tip" {...props}>


### PR DESCRIPTION
**Short description:**

I've added the test for Tooltip component to achive the 100% of line coverage.

**PR Checklist:**

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Described changes in CHANGELOG.md
-   [x] Executed `npm run check` and made sure no errors / warnings were shown
-   [x] Executed `npm run test` and made sure all tests are passing
-   [ ] Bumped version in package.json
-   [ ] Updated all static build artifacts (`npm run build-all`)
