### PR TITLE
Tooltip with portal (WIP)

### DIFF
--- a/.storybook/stories/components/TooltipStory.js
+++ b/.storybook/stories/components/TooltipStory.js
@@ -29,7 +29,10 @@ const TooltipPropTypesChapter = {
 
 const TooltipStory = () => (
     <section className="story tooltip">
-        <Tooltip text="Very helpful content in this tooltip">
+        <Tooltip
+            text="Very helpful content in this tooltip"
+            tooltipClassName="storybook-tooltip-content"
+        >
             <div className="tip_item">
                 Hover me for an automatically positioned Tooltip
             </div>
@@ -43,7 +46,11 @@ const TooltipChapter = {
 
 const InvertedTooltipStory = () => (
     <section className="story tooltip">
-        <Tooltip text="Very helpful inverted content in this tooltip" inverted>
+        <Tooltip
+            text="Very helpful inverted content in this tooltip"
+            tooltipClassName="storybook-tooltip-content"
+            inverted
+        >
             <div className="tip_item">Hover me for an **inverted** Tooltip</div>
         </Tooltip>
     </section>
@@ -69,6 +76,7 @@ const TooltipPlaygroundStory = () => (
             allowVaguePositioning={boolean('Allow Vague Positioning', false)}
             gapSize={number('Gap Size (px)', 5)}
             withArrow={boolean('With Arrow', true)}
+            tooltipClassName="storybook-tooltip-content"
         >
             <div className="tip_item">Hover me to see your tooltip</div>
         </Tooltip>

--- a/.storybook/stories/components/styles/tooltip_story.less
+++ b/.storybook/stories/components/styles/tooltip_story.less
@@ -5,3 +5,10 @@
         background-color: palegreen;
     }
 }
+
+.storybook-tooltip-content {
+    font-family: -apple-system, '.SFNSText-Regular', 'San Francisco',
+        BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+        'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Lucida Grande', Arial,
+        sans-serif;
+}

--- a/src/components/Tooltip.jsx
+++ b/src/components/Tooltip.jsx
@@ -78,7 +78,6 @@ class Tooltip extends React.Component {
         const {
             position,
             allowVaguePositioning,
-            wrapperClassName,
             tooltipClassName,
             text,
             children,
@@ -87,10 +86,6 @@ class Tooltip extends React.Component {
             withArrow
         } = this.props
 
-        const wrapperClass = classNames(
-            'reactist tooltip__wrapper',
-            wrapperClassName
-        )
         const tooltipClass = classNames(
             'reactist tooltip__text',
             tooltipClassName,
@@ -101,7 +96,7 @@ class Tooltip extends React.Component {
         const arrowClass = classNames('reactist tooltip__arrow', { inverted })
 
         if (!text) {
-            return <div className={wrapperClass}>{children}</div>
+            return children
         }
 
         // wrap on click of trigger to hide tooltip on click
@@ -131,7 +126,6 @@ class Tooltip extends React.Component {
                 trigger={trigger}
                 content={text}
                 popoverClassName={tooltipClass}
-                wrapperClassName={wrapperClass}
                 arrowClassName={arrowClass}
                 onMouseEnter={this._show}
                 onMouseLeave={this._hide}
@@ -196,8 +190,6 @@ Tooltip.propTypes = {
         PropTypes.arrayOf(PropTypes.node),
         PropTypes.node
     ]),
-    /** Additional css class that is applied to the wrapper element. */
-    wrapperClassName: PropTypes.string,
     /** Additional css class that is applied to the tooltip element. */
     tooltipClassName: PropTypes.string,
     /** Inverted tooltips have a light background with dark text. */

--- a/src/components/__tests__/Popover.test.js
+++ b/src/components/__tests__/Popover.test.js
@@ -86,7 +86,7 @@ describe('Popover', () => {
             PositioningUtils.hasEnoughSpace = jest.fn(() => true)
 
             const popover = mount(
-                getPopover({ position: 'top', visible: false })
+                getPopover({ position: 'top', visible: true })
             )
             const instance = popover.instance()
 
@@ -102,9 +102,7 @@ describe('Popover', () => {
                 height: 20
             }))
 
-            popover.setProps({ visible: true })
-
-            expect(instance.popover.style.getPropertyValue('top')).toBe('475px')
+            expect(instance.popover.style.getPropertyValue('top')).toBe('-5px')
 
             popover.setProps({ gapSize: 20 })
 
@@ -152,13 +150,9 @@ describe('Popover', () => {
 
     it('updates refs', () => {
         const popoverRefSpy = jest.fn()
-        const wrapperRefSpy = jest.fn()
-        mount(
-            getPopover({ popoverRef: popoverRefSpy, wrapperRef: wrapperRefSpy })
-        )
+        mount(getPopover({ popoverRef: popoverRefSpy }))
 
         expect(popoverRefSpy).toHaveBeenCalled()
-        expect(wrapperRefSpy).toHaveBeenCalled()
     })
 
     // Helpers ================================================================

--- a/src/components/__tests__/Tooltip.test.js
+++ b/src/components/__tests__/Tooltip.test.js
@@ -192,10 +192,24 @@ describe('Tooltip', () => {
         })
     })
 
-    it('sets ref of tooltip and wrapper after mounting', () => {
+    it('sets ref of wrapper after mounting', () => {
         const tooltip = mount(getTooltip()).instance()
 
         expect(tooltip.wrapper).toBeTruthy()
+    })
+
+    it('does not set ref of tooltip when it is not visible', () => {
+        const tooltip = mount(getTooltip()).instance()
+
+        expect(tooltip.tooltip).toBeUndefined()
+    })
+
+    it('sets ref of tooltip when it is visible after mounting', () => {
+        const tooltipWrapper = mount(getTooltip())
+        const tooltip = tooltipWrapper.instance()
+
+        tooltipWrapper.simulate('mouseenter')
+        jest.runAllTimers()
         expect(tooltip.tooltip).toBeTruthy()
     })
 
@@ -224,10 +238,12 @@ describe('Tooltip', () => {
     })
 
     it('pass as children simple text', () => {
-        const tooltip = mount(
-            <Tooltip text="Tip">Wrapped Text</Tooltip>
-        ).instance()
-        expect(tooltip.wrapper).toBeTruthy()
+        const tooltipWrapper = mount(<Tooltip text="Tip">Wrapped Text</Tooltip>)
+        const tooltip = tooltipWrapper.instance()
+
+        tooltipWrapper.simulate('mouseEnter')
+        jest.runAllTimers()
+
         expect(tooltip.tooltip).toBeTruthy()
     })
 

--- a/src/components/__tests__/__snapshots__/Popover.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Popover.test.js.snap
@@ -14,11 +14,37 @@ exports[`Popover adds arrow class when prop is set 1`] = `
   withArrow={true}
 >
   <span
-    className="reactist popover__wrapper"
+    key=".0"
+    onClick={[Function]}
   >
-    <span>
-      Trigger Content
-    </span>
+    Trigger Content
+  </span>
+  <Portal
+    containerInfo={
+      <body>
+        <span
+          class="reactist popover visible"
+          style="top: -5px; left: 0px;"
+        >
+          <span
+            class="reactist popover__content"
+          >
+            Popover Content
+          </span>
+        </span>
+        <span
+          class="reactist popover visible arrow_bottom"
+          style="top: -5px; left: 0px;"
+        >
+          <span
+            class="reactist popover__content"
+          >
+            Popover Content
+          </span>
+        </span>
+      </body>
+    }
+  >
     <span
       className="reactist popover visible arrow_bottom"
     >
@@ -28,7 +54,7 @@ exports[`Popover adds arrow class when prop is set 1`] = `
         Popover Content
       </span>
     </span>
-  </span>
+  </Portal>
 </Popover>
 `;
 
@@ -45,11 +71,27 @@ exports[`Popover renders without crashing 1`] = `
   visible={true}
 >
   <span
-    className="reactist popover__wrapper"
+    key=".0"
+    onClick={[Function]}
   >
-    <span>
-      Trigger Content
-    </span>
+    Trigger Content
+  </span>
+  <Portal
+    containerInfo={
+      <body>
+        <span
+          class="reactist popover visible"
+          style="top: -5px; left: 0px;"
+        >
+          <span
+            class="reactist popover__content"
+          >
+            Popover Content
+          </span>
+        </span>
+      </body>
+    }
+  >
     <span
       className="reactist popover visible"
     >
@@ -59,6 +101,6 @@ exports[`Popover renders without crashing 1`] = `
         Popover Content
       </span>
     </span>
-  </span>
+  </Portal>
 </Popover>
 `;

--- a/src/components/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -1,13 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip renders only children if text prop is not defined 1`] = `
-<div
-  className="reactist tooltip__wrapper"
->
-  <span>
-    Wrapped Content
-  </span>
-</div>
+<span>
+  Wrapped Content
+</span>
 `;
 
 exports[`Tooltip renders without crashing 1`] = `
@@ -43,23 +39,15 @@ exports[`Tooltip renders without crashing 1`] = `
     }
     visible={false}
     withArrow={true}
-    wrapperClassName="reactist tooltip__wrapper"
     wrapperRef={[Function]}
   >
     <span
-      className="reactist popover__wrapper reactist tooltip__wrapper"
+      key=".$.0"
+      onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >
-      <span
-        key=".0"
-        onClick={[Function]}
-      >
-        Wrapped Content
-      </span>
-      <span
-        className="reactist popover"
-      />
+      Wrapped Content
     </span>
   </Popover>
 </Tooltip>

--- a/src/components/styles/popover.less
+++ b/src/components/styles/popover.less
@@ -1,12 +1,6 @@
 @import './constants.less';
 
 .reactist.popover {
-    &__wrapper {
-        display: inline-block;
-        max-width: 100%;
-        cursor: unset;
-    }
-
     .popover__content {
         max-width: 100%;
         display: inline-flex;

--- a/src/components/styles/tooltip.less
+++ b/src/components/styles/tooltip.less
@@ -2,60 +2,54 @@
 
 @tooltip_background: @color_almost_black;
 
-.reactist {
-    &.tooltip__wrapper {
-        display: inline-block;
+.reactist.tooltip__arrow {
+    .reactist.tooltip__text {
+        .smaller_text();
+        text-align: center;
+        text-overflow: ellipsis;
+        overflow: hidden;
         max-width: 100%;
-        cursor: unset;
+        padding: 5px 10px;
+        max-width: 250px;
 
-        .reactist.tooltip__text {
-            .smaller_text();
-            text-align: center;
-            text-overflow: ellipsis;
-            overflow: hidden;
-            max-width: 100%;
-            padding: 5px 10px;
-            max-width: 250px;
+        &:not(.inverted) {
+            background-color: @tooltip_background;
+            color: white;
+            border: none;
+        }
+    }
 
-            &:not(.inverted) {
-                background-color: @tooltip_background;
-                color: white;
-                border: none;
+    &:not(.inverted) {
+        &.arrow_top {
+            &:before {
+                border-bottom-color: @tooltip_background;
+            }
+            &:after {
+                display: none;
             }
         }
-
-        .reactist.tooltip__arrow:not(.inverted) {
-            &.arrow_top {
-                &:before {
-                    border-bottom-color: @tooltip_background;
-                }
-                &:after {
-                    display: none;
-                }
+        &.arrow_right {
+            &:before {
+                border-left-color: @tooltip_background;
             }
-            &.arrow_right {
-                &:before {
-                    border-left-color: @tooltip_background;
-                }
-                &:after {
-                    display: none;
-                }
+            &:after {
+                display: none;
             }
-            &.arrow_bottom {
-                &:before {
-                    border-top-color: @tooltip_background;
-                }
-                &:after {
-                    display: none;
-                }
+        }
+        &.arrow_bottom {
+            &:before {
+                border-top-color: @tooltip_background;
             }
-            &.arrow_left {
-                &:before {
-                    border-right-color: @tooltip_background;
-                }
-                &:after {
-                    display: none;
-                }
+            &:after {
+                display: none;
+            }
+        }
+        &.arrow_left {
+            &:before {
+                border-right-color: @tooltip_background;
+            }
+            &:after {
+                display: none;
             }
         }
     }


### PR DESCRIPTION
**Link to issue:** #164 

**Short description:**

Hey @stkao05, I hope you don't mind that I took a stab at this. This attempts to address some of the issues you've listed in #164 but it will introduce some breaking changes depending on how it's being used in your apps right now.

These are some of the changes made so far:
- The popover now uses `React.createPortal` to attach its content to the `body` element as you suggested
- No extra wrappers are added around trigger elements unless we encounter a plain text node
- Event handlers are attached directly to the trigger element

As the Popover used to depend on its wrapper's ref in order to calculate the correct placement for its content, which is no longer available for components that do not forward their underlying DOM elements as refs. So when we use other components in this library as our trigger, we receive their component instance instead. [Material-ui also has the same limitation](https://material-ui.com/guides/composition/#caveat-with-refs), but they've forwarded refs within all of their own components. In order to continue support for other components within this library to be used as triggers, we'll most likely need to do the same thing here.

Since the tooltip is no longer a sibling to the trigger, we'll likely want to shift the focus to the tooltip content on trigger, or attach an aria label to the triggering element to maintain accessibility too.

I'm not sure if this component is still being used internally in Todoist, as I've noticed the class names used in the tooltip over there is quite different. Let me know if this is still something you'd like to push forward or have any suggestions! I'd love to help out with this if it's still needed :)

**PR Checklist:**

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Described changes in CHANGELOG.md
-   [x] Executed `npm run check` and made sure no errors / warnings were shown
-   [x] Executed `npm run test` and made sure all tests are passing
-   [ ] Bumped version in package.json
-   [ ] Updated all static build artifacts (`npm run build-all`)
