### PR TITLE
Popper and TooltipNew component

### DIFF
--- a/.storybook/stories/components/PopperStory.js
+++ b/.storybook/stories/components/PopperStory.js
@@ -1,0 +1,39 @@
+import React, { useState, useRef } from 'react'
+import { storiesOf } from '@storybook/react'
+import Popper from '../../../src/components/Popper'
+
+function PopperStory() {
+    const btn = useRef()
+    const [isShown, setIsShown] = useState(false)
+
+    return (
+        <>
+            <button
+                ref={btn}
+                style={{
+                    width: '100px',
+                    height: '100px',
+                    cursor: 'pointer',
+                    border: '1px solid black'
+                }}
+                onClick={() => setIsShown(true)}
+            >
+                click to open
+            </button>
+            <Popper
+                referenceElement={btn.current}
+                isShown={isShown}
+                onClose={() => setIsShown(false)}
+            >
+                <p style={{ border: '1px solid black', margin: '0' }}>
+                    The content of the Popper.
+                </p>
+            </Popper>
+        </>
+    )
+}
+
+const Story = () =>
+    storiesOf('Popper', module).add('default', () => <PopperStory />)
+
+export default Story

--- a/.storybook/stories/components/TooltipNewStory.js
+++ b/.storybook/stories/components/TooltipNewStory.js
@@ -1,0 +1,32 @@
+import './styles/tooltip_story.less'
+
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { withKnobs } from '@storybook/addon-knobs'
+import { optionsSourceOnly } from '../utils/StoryUtils'
+
+import TooltipNew from '../../../src/components/TooltipNew'
+
+const TooltipStory = () => (
+    <section className="story tooltip">
+        <TooltipNew title="Very helpful content in this tooltip">
+            <div className="tip_item" tabIndex="0">
+                Hover or focus me for an automatically positioned Tooltip
+            </div>
+        </TooltipNew>
+    </section>
+)
+const TooltipChapter = {
+    subtitle: 'Tooltip',
+    sections: [{ sectionFn: TooltipStory, options: optionsSourceOnly }]
+}
+
+// Story setup ================================================================
+const Story = () =>
+    storiesOf('TooltipNew', module)
+        .addDecorator(withKnobs)
+        .addWithChapters('Component Overview', {
+            chapters: [TooltipChapter]
+        })
+
+export default Story

--- a/.storybook/stories/index.js
+++ b/.storybook/stories/index.js
@@ -12,6 +12,7 @@ import InputStory from './components/InputStory'
 import TabsStory from './components/TabsStory'
 import LinkButtonStory from './components/LinkButtonStory'
 import TooltipStory from './components/TooltipStory'
+import TooltipNewStory from './components/TooltipNewStory'
 import RangeInputStory from './components/RangeInputStory'
 import ErrorMessageStory from './components/ErrorMessageStory'
 import ColorPickerStory from './components/ColorPickerStory'
@@ -21,6 +22,7 @@ import LoadingStory from './components/LoadingStory'
 import AvatarStory from './components/AvatarStory'
 import IconStory from './components/IconStory'
 import KeyCapturerStory from './components/KeyCapturerStory'
+import PopperStory from './components/PopperStory'
 
 ReactistStory()
 // alphabetically sorted component stories
@@ -44,3 +46,5 @@ TabsStory()
 TimeStory()
 TipStory()
 TooltipStory()
+TooltipNewStory()
+PopperStory()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1019,7 +1019,6 @@
             "version": "7.7.2",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
             "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
-            "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.2"
             }
@@ -1494,6 +1493,12 @@
             "requires": {
                 "any-observable": "^0.3.0"
             }
+        },
+        "@sheerun/mutationobserver-shim": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+            "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+            "dev": true
         },
         "@storybook/addon-actions": {
             "version": "5.2.6",
@@ -2702,6 +2707,42 @@
                 "loader-utils": "^1.2.3"
             }
         },
+        "@testing-library/dom": {
+            "version": "6.12.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.12.2.tgz",
+            "integrity": "sha512-KCnvHra5fV+wDxg3wJObGvZFxq7v1DJt829GNFLuRDjKxVNc/B5AdsylNF5PMHFbWMXDsHwM26d2NZcZO9KjbQ==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.6.2",
+                "@sheerun/mutationobserver-shim": "^0.3.2",
+                "@types/testing-library__dom": "^6.0.0",
+                "aria-query": "3.0.0",
+                "pretty-format": "^24.9.0",
+                "wait-for-expect": "^3.0.0"
+            }
+        },
+        "@testing-library/react": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.4.1.tgz",
+            "integrity": "sha512-sta3ui24HPgW92quHyQj6gpOkNgLNx8BX/QOU4k1bddo43ZdqlGwmzCYwL93bExfhergwiau+IzBGl7TCsSFeA==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.8.3",
+                "@testing-library/dom": "^6.11.0",
+                "@types/testing-library__react": "^9.1.2"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.8.4",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+                    "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.13.2"
+                    }
+                }
+            }
+        },
         "@types/babel__core": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -2839,6 +2880,15 @@
                 "@types/react": "*"
             }
         },
+        "@types/react-dom": {
+            "version": "16.9.5",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.5.tgz",
+            "integrity": "sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*"
+            }
+        },
         "@types/react-syntax-highlighter": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-10.1.0.tgz",
@@ -2862,6 +2912,25 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
             "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
             "dev": true
+        },
+        "@types/testing-library__dom": {
+            "version": "6.12.1",
+            "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.12.1.tgz",
+            "integrity": "sha512-cgqnEjxKk31tQt29j4baSWaZPNjQf3bHalj2gcHQTpW5SuHRal76gOpF0vypeEo6o+sS5inOvvNdzLY0B3FB2A==",
+            "dev": true,
+            "requires": {
+                "pretty-format": "^24.3.0"
+            }
+        },
+        "@types/testing-library__react": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.2.tgz",
+            "integrity": "sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==",
+            "dev": true,
+            "requires": {
+                "@types/react-dom": "*",
+                "@types/testing-library__dom": "*"
+            }
         },
         "@types/webpack-env": {
             "version": "1.14.1",
@@ -3409,6 +3478,16 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "aria-query": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+            "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+            "dev": true,
+            "requires": {
+                "ast-types-flow": "0.0.7",
+                "commander": "^2.11.0"
+            }
+        },
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -3601,6 +3680,12 @@
             "version": "0.9.6",
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
             "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+            "dev": true
+        },
+        "ast-types-flow": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+            "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
             "dev": true
         },
         "astral-regex": {
@@ -7743,7 +7828,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
             "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-            "dev": true,
             "requires": {
                 "is-arguments": "^1.0.4",
                 "is-date-object": "^1.0.1",
@@ -7769,7 +7853,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "dev": true,
             "requires": {
                 "object-keys": "^1.0.12"
             }
@@ -10223,8 +10306,7 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "function.prototype.name": {
             "version": "1.1.1",
@@ -10517,8 +10599,7 @@
         "gud": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-            "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-            "dev": true
+            "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
         },
         "gzip-size": {
             "version": "5.1.1",
@@ -10570,7 +10651,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -11451,8 +11531,7 @@
         "is-arguments": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-            "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-            "dev": true
+            "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -11533,8 +11612,7 @@
         "is-date-object": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-            "dev": true
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
         },
         "is-decimal": {
             "version": "1.0.3",
@@ -11730,7 +11808,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-            "dev": true,
             "requires": {
                 "has": "^1.0.1"
             }
@@ -12476,8 +12553,7 @@
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
             "version": "3.13.1",
@@ -13409,7 +13485,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
@@ -14250,8 +14325,7 @@
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-copy": {
             "version": "0.1.0",
@@ -14299,14 +14373,12 @@
         "object-is": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-            "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
-            "dev": true
+            "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
         },
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "object-visit": {
             "version": "1.0.1",
@@ -14977,8 +15049,7 @@
         "popper.js": {
             "version": "1.16.0",
             "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
-            "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw==",
-            "dev": true
+            "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
         },
         "posix-character-classes": {
             "version": "0.1.1",
@@ -17235,7 +17306,6 @@
             "version": "15.7.2",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
             "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-            "dev": true,
             "requires": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -17871,8 +17941,7 @@
         "react-is": {
             "version": "16.12.0",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-            "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
-            "dev": true
+            "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
         },
         "react-lifecycles-compat": {
             "version": "3.0.4",
@@ -17904,13 +17973,13 @@
             }
         },
         "react-popper": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.6.tgz",
-            "integrity": "sha512-kLTfa9z8n+0jJvRVal9+vIuirg41rObg4Bbrvv/ZfsGPQDN9reyVVSxqnHF1ZNgXgV7x11PeUfd5ItF8DZnqhg==",
-            "dev": true,
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
+            "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
             "requires": {
                 "@babel/runtime": "^7.1.2",
                 "create-react-context": "^0.3.0",
+                "deep-equal": "^1.1.1",
                 "popper.js": "^1.14.4",
                 "prop-types": "^15.6.1",
                 "typed-styles": "^0.0.7",
@@ -17921,7 +17990,6 @@
                     "version": "0.3.0",
                     "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
                     "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-                    "dev": true,
                     "requires": {
                         "gud": "^1.0.0",
                         "warning": "^4.0.3"
@@ -17931,7 +17999,6 @@
                     "version": "4.0.3",
                     "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
                     "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-                    "dev": true,
                     "requires": {
                         "loose-envify": "^1.0.0"
                     }
@@ -19935,8 +20002,7 @@
         "regenerator-runtime": {
             "version": "0.13.3",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-            "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-            "dev": true
+            "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         },
         "regenerator-transform": {
             "version": "0.14.1",
@@ -19961,7 +20027,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
             "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
-            "dev": true,
             "requires": {
                 "define-properties": "^1.1.2"
             }
@@ -22034,8 +22099,7 @@
         "typed-styles": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-            "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
-            "dev": true
+            "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
         },
         "typedarray": {
             "version": "0.0.6",
@@ -22628,6 +22692,12 @@
             "requires": {
                 "browser-process-hrtime": "^0.1.2"
             }
+        },
+        "wait-for-expect": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
+            "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
+            "dev": true
         },
         "walker": {
             "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "@storybook/addon-links": "^5.2.6",
         "@storybook/addon-options": "^5.2.6",
         "@storybook/react": "^5.2.6",
+        "@testing-library/react": "^9.4.1",
         "babel-core": "^7.0.0-bridge.0",
         "babel-eslint": "^9.0.0",
         "babel-loader": "^8.0.2",
@@ -93,7 +94,9 @@
         },
         "testURL": "http://localhost"
     },
-    "dependencies": {},
+    "dependencies": {
+        "react-popper": "^1.3.7"
+    },
     "husky": {
         "hooks": {
             "pre-commit": "lint-staged",

--- a/src/components/Popper.jsx
+++ b/src/components/Popper.jsx
@@ -1,0 +1,229 @@
+import React, { useState, useEffect, useRef } from 'react'
+import ReactDOM from 'react-dom'
+import PropTypes from 'prop-types'
+import { Manager, Reference, Popper as _Popper } from 'react-popper'
+import normalizeKey from './utils/normalizeKey'
+import getZIndex from './utils/getZIndex'
+import isFixedPosition from './utils/isFixedPosition'
+import './styles/popper.less'
+
+// arrow distance to anchor (in px)
+const ARROW_GAP = 12
+
+/**
+ * Popper is a component that puts content
+ * above other elements.
+ * It's absolute positioned by default and doesn't support overlays.
+ * For an implementation of overlays and fixed only positioning
+ * check the Popover component.
+ *
+ * @param {Object} referenceElement Popper could be positioned either by a HTMLElement
+ *                                   or a prop render function that serves a React component
+ *
+ * @param {Object} modifiers Modifies the popper behaviour/position, Modifiers
+ *                           list available on https://popper.js.org/popper-documentation.html#modifiers
+ *
+ */
+function Popper({
+    children,
+    modifiers = {},
+    placement = 'bottom',
+    referenceElement,
+    offsetX = '',
+    offsetY = '',
+    hasArrow = true,
+    isShown = false,
+    onClose = () => {},
+    onShown = () => {},
+    className = '',
+    ...props
+}) {
+    const isReferenceRenderProp = typeof referenceElement === 'function'
+
+    const popperRef = useRef(null)
+    const referenceElementRef = useRef(null)
+
+    const [positionFixed, setPositionFixed] = useState(
+        isReferenceRenderProp ? false : isFixedPosition(referenceElement)
+    )
+
+    useEffect(
+        () => {
+            if (isShown) {
+                // Set first the position to fixed and only after
+                // to the final value, due to an issue where if something
+                // inside the Popper get's focused, while it's calculating
+                // its position, the whole page would be scrolled to the top.
+                //
+                // ref: https://github.com/mui-org/material-ui/issues/16740
+                popperRef.current.style.position = 'fixed'
+
+                window.requestAnimationFrame(() => {
+                    if (popperRef.current) {
+                        popperRef.current.style.position = positionFixed
+                            ? 'fixed'
+                            : 'absolute'
+                    }
+                })
+
+                onShown()
+            }
+        },
+        [isShown, onShown, positionFixed]
+    )
+
+    useEffect(() => {
+        if (referenceElementRef.current) {
+            setPositionFixed(isFixedPosition(referenceElementRef.current))
+        }
+    }, [])
+
+    useEffect(
+        () => {
+            if (isShown) {
+                const handleDocumentClick = event => {
+                    if (
+                        popperRef.current &&
+                        !popperRef.current.contains(event.target)
+                    ) {
+                        onClose(event)
+                    }
+                }
+
+                if ('ontouchend' in window) {
+                    document.addEventListener('touchend', handleDocumentClick)
+                } else {
+                    document.addEventListener('click', handleDocumentClick)
+                }
+
+                return () => {
+                    document.removeEventListener(
+                        'touchend',
+                        handleDocumentClick
+                    )
+                    document.removeEventListener('click', handleDocumentClick)
+                }
+            }
+        },
+        [isShown, onClose]
+    )
+
+    const handleKeyDown = evt => {
+        const key = normalizeKey(evt.key)
+
+        if (key === 'Escape' && typeof onClose === 'function') {
+            evt.stopPropagation()
+            onClose(evt)
+        }
+    }
+
+    if (hasArrow) {
+        offsetY = `${offsetY} + ${ARROW_GAP}px`
+    }
+
+    if (offsetX || offsetY) {
+        modifiers = {
+            ...modifiers,
+            offset: { enabled: true, offset: `${offsetX}, ${offsetY}` },
+            computeStyle: { gpuAcceleration: false }
+        }
+    }
+
+    return (
+        <Manager>
+            {isReferenceRenderProp ? (
+                <Reference>
+                    {({ ref }) => {
+                        return referenceElement({
+                            ref: node => {
+                                referenceElementRef.current = node
+                                ref(node)
+                            },
+                            isExpanded: isShown
+                        })
+                    }}
+                </Reference>
+            ) : null}
+            {isShown
+                ? ReactDOM.createPortal(
+                      <_Popper
+                          innerRef={node => (popperRef.current = node)}
+                          referenceElement={
+                              isReferenceRenderProp
+                                  ? undefined
+                                  : referenceElement
+                          }
+                          modifiers={modifiers}
+                          placement={placement}
+                          positionFixed={positionFixed}
+                      >
+                          {({ ref, style, placement, arrowProps }) => {
+                              style = {
+                                  ...style,
+                                  zIndex: getZIndex(
+                                      referenceElementRef.current ||
+                                          referenceElement
+                                  )
+                              }
+
+                              return (
+                                  <div
+                                      className={className + ' popper'}
+                                      ref={ref}
+                                      style={style}
+                                      data-placement={placement}
+                                      onKeyDown={handleKeyDown}
+                                      {...props}
+                                  >
+                                      {hasArrow ? (
+                                          <div
+                                              className="popper__arrow"
+                                              ref={arrowProps.ref}
+                                              style={arrowProps.style}
+                                          />
+                                      ) : null}
+                                      {typeof children === 'function'
+                                          ? children()
+                                          : children}
+                                  </div>
+                              )
+                          }}
+                      </_Popper>,
+                      document.body
+                  )
+                : null}
+        </Manager>
+    )
+}
+
+Popper.propTypes = {
+    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+    modifiers: PropTypes.object,
+    offsetX: PropTypes.string,
+    offsetY: PropTypes.string,
+    placement: PropTypes.oneOf([
+        'top-start',
+        'bottom-start',
+        'left-start',
+        'right-start',
+        'top',
+        'bottom',
+        'left',
+        'right',
+        'top-end',
+        'bottom-end',
+        'left-end',
+        'right-end'
+    ]),
+    referenceElement: PropTypes.oneOfType([
+        PropTypes.instanceOf(HTMLElement),
+        PropTypes.func
+    ]),
+    hasArrow: PropTypes.bool,
+    className: PropTypes.string,
+    isShown: PropTypes.bool,
+    onClose: PropTypes.func,
+    onShown: PropTypes.func
+}
+
+export default Popper

--- a/src/components/TooltipNew.jsx
+++ b/src/components/TooltipNew.jsx
@@ -1,0 +1,87 @@
+import React, { useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+import Popper from './Popper'
+import './styles/tooltip_new.less'
+import useId from './utils/useId'
+import useForkRef from './utils/useForkRef'
+
+export default function TooltipNew({ title, children, placement = 'bottom' }) {
+    const childRef = useRef()
+    const handleRef = useForkRef(children.ref, childRef)
+    const [isShown, setIsShown] = useState(false)
+
+    const handleEnter = event => {
+        const childrenProps = children.props
+        if (
+            event.type === 'mouseover' &&
+            childrenProps.onMouseOver &&
+            event.currentTarget === childRef.current
+        ) {
+            childrenProps.onMouseOver(event)
+        }
+
+        if (
+            event.type === 'focus' &&
+            childrenProps.onFocus &&
+            event.currentTarget === childRef.current
+        ) {
+            childrenProps.onMouseOver(event)
+        }
+
+        setIsShown(true)
+    }
+
+    const handleLeave = event => {
+        const childrenProps = children.props
+        if (
+            event.type === 'mouseleave' &&
+            childrenProps.onMouseLeave &&
+            event.currentTarget === childRef.current
+        ) {
+            childrenProps.onMouseLeave(event)
+        }
+
+        if (
+            event.type === 'blur' &&
+            childrenProps.onBlur &&
+            event.currentTarget === childRef.current
+        ) {
+            childrenProps.onBlur(event)
+        }
+
+        setIsShown(false)
+    }
+
+    const id = useId('tooltip')
+    const childrenProps = {
+        ...children.props,
+        'aria-describedby': isShown ? id : null,
+        onMouseOver: handleEnter,
+        onMouseLeave: handleLeave,
+        onFocus: handleEnter,
+        onBlur: handleLeave,
+        ref: handleRef
+    }
+
+    return (
+        <>
+            {React.cloneElement(children, childrenProps)}
+            <Popper
+                className="reactist tooltip_new"
+                placement={placement}
+                referenceElement={childRef.current}
+                isShown={isShown}
+                id={id}
+            >
+                <div className="tooltip_new__content">{title}</div>
+            </Popper>
+        </>
+    )
+}
+
+TooltipNew.propTypes = {
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType])
+        .isRequired,
+    children: PropTypes.object.isRequired,
+    placement: Popper.propTypes.placement
+}

--- a/src/components/__tests__/TooltipNew.test.js
+++ b/src/components/__tests__/TooltipNew.test.js
@@ -1,0 +1,92 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import TooltipNew from '../TooltipNew'
+
+beforeAll(() => {
+    // jsdom does not support some of the browser API
+    // which popper.js needs. So here we are mocking
+    // some of the API
+    // https://github.com/popperjs/popper-core/issues/478
+    if (global.document) {
+        document.createRange = () => ({
+            setStart: () => {},
+            setEnd: () => {},
+            commonAncestorContainer: {
+                nodeName: 'BODY',
+                ownerDocument: document
+            }
+        })
+    }
+})
+
+describe('TooltipNew', () => {
+    test('should show when mouseover and hide when mouseleave', () => {
+        const { queryByText } = render(
+            <TooltipNew title="tooltip_content">
+                <div>foo</div>
+            </TooltipNew>
+        )
+
+        const target = queryByText('foo')
+
+        expect(target).not.toBeNull()
+        expect(queryByText('tooltip_content')).toBeNull()
+
+        fireEvent.mouseOver(target)
+        expect(queryByText('tooltip_content')).not.toBeNull()
+
+        fireEvent.mouseLeave(target)
+        expect(queryByText('tooltip_content')).toBeNull()
+    })
+
+    test('should show when focus and hide when blur', () => {
+        const { queryByText } = render(
+            <TooltipNew title="tooltip_content">
+                <div>foo</div>
+            </TooltipNew>
+        )
+
+        const target = queryByText('foo')
+
+        expect(target).not.toBeNull()
+        expect(queryByText('tooltip_content')).toBeNull()
+
+        fireEvent.focus(target)
+        expect(queryByText('tooltip_content')).not.toBeNull()
+
+        fireEvent.blur(target)
+        expect(queryByText('tooltip_content')).toBeNull()
+    })
+
+    test('children component mouse event handler should not be affected by the tooltip', () => {
+        const onMouseOver = jest.fn()
+        const onMouseLeave = jest.fn()
+
+        const { queryByText } = render(
+            <TooltipNew title="tooltip_content">
+                <div onMouseOver={onMouseOver} onMouseLeave={onMouseLeave}>
+                    foo
+                </div>
+            </TooltipNew>
+        )
+
+        const target = queryByText('foo')
+        fireEvent.mouseOver(target)
+        expect(onMouseOver).toHaveBeenCalled()
+
+        fireEvent.mouseLeave(target)
+        expect(onMouseLeave).toHaveBeenCalled()
+    })
+
+    test('children props.ref should still receive element instance correctly', () => {
+        const ref = { current: null }
+
+        const { queryByText } = render(
+            <TooltipNew title="tooltip_content">
+                <div ref={ref}>foo</div>
+            </TooltipNew>
+        )
+
+        expect(ref.current).toBe(queryByText('foo'))
+    })
+})

--- a/src/components/styles/popper.less
+++ b/src/components/styles/popper.less
@@ -1,0 +1,63 @@
+@color-border: #dcdcdc;
+
+.popper {
+    &__arrow {
+        position: absolute;
+        z-index: 1002;
+        margin-top: -12px;
+        height: 0;
+        width: 0;
+        border: 6px solid transparent;
+        border-bottom-color: @color-border;
+
+        &:before {
+            content: '';
+            position: absolute;
+            border: 6px solid transparent;
+            border-bottom-color: white;
+            left: -6px;
+            top: -5px;
+        }
+    }
+
+    &[data-placement='top'] &__arrow {
+        top: 100%;
+        margin-top: 0;
+        border-bottom-color: transparent;
+        border-top-color: @color-border;
+
+        &:before {
+            top: -7px;
+            border-bottom-color: transparent;
+            border-top-color: white;
+        }
+    }
+
+    &[data-placement='left'] &__arrow {
+        left: 100%;
+        margin-top: -6px;
+        border-bottom-color: transparent;
+        border-left-color: @color-border;
+
+        &:before {
+            left: -7px;
+            top: -6px;
+            border-bottom-color: transparent;
+            border-left-color: white;
+        }
+    }
+
+    &[data-placement='right'] &__arrow {
+        left: -12px;
+        margin-top: -6px;
+        border-bottom-color: transparent;
+        border-right-color: @color-border;
+
+        &:before {
+            left: -5px;
+            top: -6px;
+            border-bottom-color: transparent;
+            border-right-color: white;
+        }
+    }
+}

--- a/src/components/styles/popper.less.rej
+++ b/src/components/styles/popper.less.rej
@@ -1,0 +1,22 @@
+diff a/src/components/styles/popper.less b/src/components/styles/popper.less	(rejected hunks)
+@@ -12 +12 @@
+-            content: "";
++            content: '';
+@@ -21 +21 @@
+-    &[data-placement="top"] &__arrow {
++    &[data-placement='top'] &__arrow {
+@@ -34 +34 @@
+-    &[data-placement="left"] &__arrow {
++    &[data-placement='left'] &__arrow {
+@@ -48 +48 @@
+-    &[data-placement="right"] &__arrow {
++    &[data-placement='right'] &__arrow {
+@@ -73 +73 @@
+-        &[data-placement="top"] .popper__arrow {
++        &[data-placement='top'] .popper__arrow {
+@@ -81 +81 @@
+-        &[data-placement="left"] .popper__arrow {
++        &[data-placement='left'] .popper__arrow {
+@@ -89 +89 @@
+-        &[data-placement="right"] .popper__arrow {
++        &[data-placement='right'] .popper__arrow {

--- a/src/components/styles/tooltip_new.less
+++ b/src/components/styles/tooltip_new.less
@@ -1,0 +1,48 @@
+@import './constants.less';
+
+@tooltip_background: @color_almost_black;
+
+.tooltip_new__content {
+    .smaller_text();
+    text-align: center;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    padding: 5px 10px;
+    border-radius: 3px;
+    background-color: @tooltip_background;
+    color: white;
+}
+
+.popper.tooltip_new {
+    &[data-placement='bottom'] .popper__arrow {
+        border-bottom-color: @tooltip_background;
+
+        &:before {
+            border-bottom-color: @tooltip_background;
+        }
+    }
+
+    &[data-placement='top'] .popper__arrow {
+        border-top-color: @tooltip_background;
+
+        &:before {
+            border-top-color: @tooltip_background;
+        }
+    }
+
+    &[data-placement='left'] .popper__arrow {
+        border-left-color: @tooltip_background;
+
+        &:before {
+            border-left-color: @tooltip_background;
+        }
+    }
+
+    &[data-placement='right'] .popper__arrow {
+        border-right-color: @tooltip_background;
+
+        &:before {
+            border-right-color: @tooltip_background;
+        }
+    }
+}

--- a/src/components/utils/getZIndex.js
+++ b/src/components/utils/getZIndex.js
@@ -1,0 +1,18 @@
+export default function getZIndex(element, maxZIndex = 1) {
+    if (!element || element === document) {
+        return maxZIndex
+    }
+
+    const zIndex = window.document.defaultView
+        .getComputedStyle(element)
+        .getPropertyValue('z-index')
+
+    if (isNaN(zIndex)) {
+        return getZIndex(element.parentNode, maxZIndex)
+    }
+
+    return getZIndex(
+        element.parentNode,
+        zIndex > maxZIndex ? zIndex : maxZIndex
+    )
+}

--- a/src/components/utils/isFixedPosition.js
+++ b/src/components/utils/isFixedPosition.js
@@ -1,0 +1,20 @@
+/*
+ * Check if the element or one of its parents is fixed
+ */
+export default function isFixedPosition(element) {
+    if (element === document || !element) {
+        return false
+    }
+
+    const isFixed =
+        window
+            .getComputedStyle(element)
+            .getPropertyValue('position')
+            .toLowerCase() === 'fixed'
+
+    if (!isFixed) {
+        return isFixedPosition(element.parentNode)
+    }
+
+    return true
+}

--- a/src/components/utils/normalizeKey.js
+++ b/src/components/utils/normalizeKey.js
@@ -1,0 +1,64 @@
+const SUPPORTED_KEYS = {
+    ARROW_UP: 'ArrowUp',
+    ARROW_RIGHT: 'ArrowRight',
+    ARROW_DOWN: 'ArrowDown',
+    ARROW_LEFT: 'ArrowLeft',
+    ENTER: 'Enter',
+    BACKSPACE: 'Backspace',
+    ESCAPE: 'Escape',
+    TAB: 'Tab'
+}
+
+/**
+ * Resolves an event key value, taking into account
+ * possible edge-cases, e.g different IE key naming
+ * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key#Example
+ * @param {string} params.eventKey
+ * @returns {string} ‚Äì normalized key value
+ */
+export default function normalizeKey(eventKey) {
+    switch (eventKey) {
+        case 37:
+        case 'Left': // IE specific
+        case 'ArrowLeft': {
+            return SUPPORTED_KEYS.ARROW_LEFT
+        }
+        case 38:
+        case 'Up': // IE specific
+        case 'ArrowUp': {
+            return SUPPORTED_KEYS.ARROW_UP
+        }
+        case 39:
+        case 'Right': // IE specific
+        case 'ArrowRight': {
+            return SUPPORTED_KEYS.ARROW_RIGHT
+        }
+        case 40:
+        case 'Down': // IE specific
+        case 'ArrowDown': {
+            return SUPPORTED_KEYS.ARROW_DOWN
+        }
+        case 13:
+        case 'Enter': {
+            return SUPPORTED_KEYS.ENTER
+        }
+        case 8:
+        case 'Backspace': {
+            return SUPPORTED_KEYS.BACKSPACE
+        }
+        case 27:
+        case 'Esc': // IE specific
+        case 'Escape': {
+            return SUPPORTED_KEYS.ESCAPE
+        }
+
+        case 9:
+        case 'Tab': {
+            return SUPPORTED_KEYS.TAB
+        }
+
+        default: {
+            return eventKey
+        }
+    }
+}

--- a/src/components/utils/useForkRef.js
+++ b/src/components/utils/useForkRef.js
@@ -1,0 +1,25 @@
+import { useCallback } from 'react'
+
+function setRef(ref, value) {
+    if (typeof ref === 'function') {
+        ref(value)
+    } else if (ref !== null) {
+        ref.current = value
+    }
+}
+
+// https://github.com/facebook/react/issues/13029#issuecomment-497629971
+export default function useForkRef(refA, refB) {
+    /**
+     * This will create a new function if the ref props change.
+     * This means react will call the old forkRef with `null` and the new forkRef
+     * with the ref. Cleanup naturally emerges from this behavior
+     */
+    return useCallback(
+        instance => {
+            setRef(refA, instance)
+            setRef(refB, instance)
+        },
+        [refA, refB]
+    )
+}

--- a/src/components/utils/useId.js
+++ b/src/components/utils/useId.js
@@ -1,0 +1,11 @@
+import { useRef } from 'react'
+let uid = 0
+
+export default function useId(prefix) {
+    const ref = useRef()
+    if (!ref.current) {
+        ref.current = `${prefix}-${++uid}`
+    }
+
+    return ref.current
+}


### PR DESCRIPTION
The PR implements a new tooltip component TooltipNew to address [issues](https://github.com/Doist/reactist/issues/164) with the existing Tooltip. A new component is introduced here because we cannot fix the issue in a backward-compatible way with the existing Tooltip, as the resulting HTML has also changed.

The PR also fork the Popper component we use internally in Todoist for the tooltip implementation.