### PR TITLE
Fix publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,13 @@ jobs:
           node-version: 12
           registry-url: https://npm.pkg.github.com
           scope: '@doist'
+      # Skip post-install scripts here, as a malicious
+      # script could steal NODE_AUTH_TOKEN.
       - run: npm ci --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # `npm rebuild` will run all those post-install scripts for us.
+      - run: npm rebuild && npm run prepare --if-present
       - run: npm run lint
       - run: npm run type-check
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,10 +26,6 @@ jobs:
       - run: npm test
 
       # Publish to GitHub package registry
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-          registry-url: https://npm.pkg.github.com/
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -37,8 +33,8 @@ jobs:
       # Publish to npm registry
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
           registry-url: https://registry.npmjs.org/
+          scope: ''
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,9 +12,13 @@ jobs:
           node-version: 12
           registry-url: https://npm.pkg.github.com
           scope: '@doist'
+      # Skip post-install scripts here, as a malicious
+      # script could steal NODE_AUTH_TOKEN.
       - run: npm ci --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # `npm rebuild` will run all those post-install scripts for us.
+      - run: npm rebuild && npm run prepare --if-present
       - run: npm run lint
       - run: npm run type-check
       - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
-## 4.1.2
+## 4.1.3
 
 - [Fix] We have a dev dependency being on the GiHub package registry and we had problems with our Github actions pulling it. This is hopefully all fixed. 🤞
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/reactist",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doist/reactist",
     "description": "Open source React components by Doist",
     "author": "Henning Muszynski <henning@doist.com> (http://doist.com)",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": "git+https://github.com/Doist/reactist.git",


### PR DESCRIPTION
## Short description

Another attempt to fix our publish action. Basically, the problem is that we need to authenticate with npm again after authenticating with the GitHub registry in order to publish there. Not sure if the `setup-node` action inherits previous settings but its [demos](https://github.com/actions/setup-node#usage) seem to indicate so, so this is an attempt by resetting the scope and hoping an `.npmrc` will be properly created from it.

## PR Checklist

<!-- Feel free to leave unchecked the lines that are not applicable. -->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Executed `npm run lint` and made sure no errors / warnings were shown
-   [ ] Executed `npm run test` and made sure all tests are passing
-   [ ] Bumped version in `package.json`
-   [ ] Updated all static build artifacts (`npm run build-all`)
