### PR TITLE
Reinstall @doist/prettier-config and update release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,9 @@ jobs:
       - run: npm run type-check
       - run: npm test
 
+      # Verify storybook build and create artifacts for publishing
+      - run: npm run build-all
+
       # Publish to GitHub package registry
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,29 +12,27 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-          registry-url: https://npm.pkg.github.com
-          scope: '@doist'
-      # Skip post-install scripts here, as a malicious
-      # script could steal NODE_AUTH_TOKEN.
-      - run: npm ci --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # `npm rebuild` will run all those post-install scripts for us.
-      - run: npm rebuild && npm run prepare --if-present
+      - run: npm ci
       - run: npm run lint
       - run: npm run type-check
       - run: npm test
 
       # Publish to GitHub package registry
+      - uses: actions/setup-node@v1
+        with:
+            node-version: 12
+            registry-url: https://npm.pkg.github.com/
+            scope: '@doist'
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+            NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       # Publish to npm registry
       - uses: actions/setup-node@v1
         with:
-          registry-url: https://registry.npmjs.org/
-          scope: ''
+            node-version: 12
+            registry-url: https://registry.npmjs.org/
+            scope: '@doist'
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+            NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,41 +1,41 @@
 name: Release @doist/reactist package
 
 on:
-  release:
-    types: [created]
+    release:
+        types: [created]
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run type-check
-      - run: npm test
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v1
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12
+            - run: npm ci
+            - run: npm run lint
+            - run: npm run type-check
+            - run: npm test
 
-      # Verify storybook build and create artifacts for publishing
-      - run: npm run build-all
+            # Verify storybook build and create artifacts for publishing
+            - run: npm run build-all
 
-      # Publish to GitHub package registry
-      - uses: actions/setup-node@v1
-        with:
-            node-version: 12
-            registry-url: https://npm.pkg.github.com/
-            scope: '@doist'
-      - run: npm publish
-        env:
-            NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+            # Publish to GitHub package registry
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12
+                  registry-url: https://npm.pkg.github.com/
+                  scope: '@doist'
+            - run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      # Publish to npm registry
-      - uses: actions/setup-node@v1
-        with:
-            node-version: 12
-            registry-url: https://registry.npmjs.org/
-            scope: '@doist'
-      - run: npm publish
-        env:
-            NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+            # Publish to npm registry
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12
+                  registry-url: https://registry.npmjs.org/
+                  scope: '@doist'
+            - run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,15 +10,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-          registry-url: https://npm.pkg.github.com
-          scope: '@doist'
-      # Skip post-install scripts here, as a malicious
-      # script could steal NODE_AUTH_TOKEN.
-      - run: npm ci --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # `npm rebuild` will run all those post-install scripts for us.
-      - run: npm rebuild && npm run prepare --if-present
+      - run: npm ci
       - run: npm run lint
       - run: npm run type-check
       - run: npm test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,15 +3,15 @@ name: Build and test
 on: pull_request
 
 jobs:
-  build-and-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run type-check
-      - run: npm test
-      - run: npm run build-all
+    build-and-test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v1
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12
+            - run: npm ci
+            - run: npm run lint
+            - run: npm run type-check
+            - run: npm test
+            - run: npm run build-all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+## 4.1.4
+
+-   [Fix] Reinstalled @doist/prettier-config from the npm registry and removed the authentication needed when pulling down dependencies.
+
 ## 4.1.3
 
-- [Fix] We have a dev dependency being on the GiHub package registry and we had problems with our Github actions pulling it. This is hopefully all fixed. 🤞
+-   [Fix] We have a dev dependency being on the GiHub package registry and we had problems with our Github actions pulling it. This is hopefully all fixed. 🤞
 
 ## 4.1.0
 
-- [New] The `event` object is now forwarded to the on* handler in the `KeyCapturer` component. The `onEnter` event will also no longer fire when it's in the middle of an [IME composition session](https://developer.mozilla.org/en-US/docs/Glossary/input_method_editor).
+-   [New] The `event` object is now forwarded to the on* handler in the `KeyCapturer` component. The `onEnter` event will also no longer fire when it's in the middle of an [IME composition session](https://developer.mozilla.org/en-US/docs/Glossary/input_method_editor).
 
 ## 4.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 ## 4.1.0
 
--   [New] The `event` object is now forwarded to the on* handler in the `KeyCapturer` component. The `onEnter` event will also no longer fire when it's in the middle of an [IME composition session](https://developer.mozilla.org/en-US/docs/Glossary/input_method_editor).
+-   [New] The `event` object is now forwarded to the on\* handler in the `KeyCapturer` component. The `onEnter` event will also no longer fire when it's in the middle of an [IME composition session](https://developer.mozilla.org/en-US/docs/Glossary/input_method_editor).
 
 ## 4.0.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3834,9 +3834,10 @@
             }
         },
         "@doist/prettier-config": {
-            "version": "2.1.0",
-            "resolved": "https://npm.pkg.github.com/download/@doist/prettier-config/2.1.0/12abb1b542084ac4c4f2f2ace54e3b6cfbd4cf5d7c835a552eae1663a838b289",
-            "integrity": "sha512-h1GjhitQmOR63O3/oInAGOxPHKxkE6CWMJeQqGvTInsssR3r8OBIQuV5dQE9354UdA7puPtL9iK8R/vJavM/Cw=="
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@doist/prettier-config/-/prettier-config-3.0.5.tgz",
+            "integrity": "sha512-QvMAKaXkg3Jib3VL/2yxFk7sHlUpHm3IsdaBEoDEvBGJL4Y8TtPl3Yvi3Cam9bV5yiuDJbA+Co3NDRMA4iAxog==",
+            "dev": true
         },
         "@egoist/vue-to-react": {
             "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/reactist",
-    "version": "4.1.3",
+    "version": "4.1.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doist/reactist",
     "description": "Open source React components by Doist",
     "author": "Henning Muszynski <henning@doist.com> (http://doist.com)",
-    "version": "4.1.3",
+    "version": "4.1.4",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": "git+https://github.com/Doist/reactist.git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
         "test": "tsdx test --passWithNoTests",
         "type-check": "tsc --noEmit -p ./tsconfig.json",
         "lint": "tsdx lint src stories",
-        "prepare": "npm run build",
         "storybook": "start-storybook -p 6006",
         "prettify": "prettier --write \"./**/*.{js,jsx,ts,tsx,json,css,scss,less,md}\""
     },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "@babel/preset-react": "^7.0.0",
         "@babel/preset-typescript": "^7.10.1",
         "@babel/register": "^7.0.0",
+        "@doist/prettier-config": "^3.0.5",
         "@storybook/addon-actions": "^5.3.18",
         "@storybook/addon-docs": "^5.3.18",
         "@storybook/addon-info": "^5.3.18",
@@ -117,8 +118,5 @@
         "webpack": "^4.43.0",
         "webpack-bundle-analyzer": "^3.3.2",
         "webpack-cli": "^3.1.0"
-    },
-    "dependencies": {
-        "@doist/prettier-config": "^2.1.0"
     }
 }


### PR DESCRIPTION
## Short description

With @doist/prettier-config now released on [npm](https://www.npmjs.com/package/@doist/prettier-config/v/3.0.5), we can remove all the hoops we had to jump to get dependencies installed on CI.

The `npm prepare` script has also been removed, as it was building tarballs with different checksums when publishing to both npm and GitHub. Not sure if this solves it but at least we'll only build once now.

## PR Checklist

<!-- Feel free to leave unchecked the lines that are not applicable. -->

-   ~~Added tests for bugs / new features~~
-   ~~Updated docs (storybooks, readme)~~
-   [x] Described changes in `CHANGELOG.md`
-   ~~Executed `npm run lint` and made sure no errors / warnings were shown~~
-   ~~Executed `npm run test` and made sure all tests are passing~~
-   [x] Bumped version in `package.json`
-   ~~Updated all static build artifacts (`npm run build-all`)~~
