### PR TITLE
More accurate type of onChange callback.

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -20,7 +20,7 @@ type Props = {
     /** Currently selected value. */
     value?: string | number
     /** Callback for the change event. Will be called with the next value (not the full event). */
-    onChange?: (value: Props['value']) => void
+    onChange?: (value: string) => void
     /** Options that are rendered in the select. */
     options?: Option[]
 }


### PR DESCRIPTION
## Short description

`Select.onChange` callback is currently typed with `string | number | undefined` as return value, but value type will always be `string`.

## PR Checklist

It only changes types. The new type narrower, so the change is non-breaking.