### PR TITLE
Proxi/recommended requiring type checking

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,7 @@
             "impliedStrict": true
         },
         "sourceType": "module",
-        "project": "tsconfig.json"
+        "project": ["tsconfig.json", "tsconfig.stories.json"]
     },
     "ignorePatterns": [
         "tsdx.config.js",
@@ -38,7 +38,12 @@
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/no-explicit-any": "error",
         "@typescript-eslint/explicit-module-boundary-types": "off",
-        "@typescript-eslint/ban-ts-comment": "off"
+        "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/unbound-method": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-return": "off"
     },
     "settings": {
         "react": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -35,7 +35,6 @@
         "react/no-did-update-set-state": "error",
         "react/no-find-dom-node": "off",
         "react/sort-comp": "error",
-        "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/unbound-method": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,6 @@
         "react/no-find-dom-node": "off",
         "react/sort-comp": "error",
         "@typescript-eslint/explicit-function-return-type": "off",
-        "@typescript-eslint/no-explicit-any": "error",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/unbound-method": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
         "prettier",
         "plugin:@typescript-eslint/eslint-recommended",
         "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
         "prettier/@typescript-eslint"
     ],
     "parser": "@typescript-eslint/parser",
@@ -16,7 +17,8 @@
             "jsx": true,
             "impliedStrict": true
         },
-        "sourceType": "module"
+        "sourceType": "module",
+        "project": "tsconfig.json"
     },
     "ignorePatterns": [
         "tsdx.config.js",

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -45,6 +45,8 @@ class Tabs extends React.Component<React.PropsWithChildren<Props>, State> {
             )
             if (i === -1)
                 throw new Error(
+                    // `hasDefault` being `true` guarantees `defaultTab` being a `number`.
+                    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
                     `(Tabs) Unable to find Tab with the matching defaultTab value "${defaultTab}"`,
                 )
 

--- a/tsconfig.stories.json
+++ b/tsconfig.stories.json
@@ -1,0 +1,27 @@
+{
+    "include": ["stories"],
+    "compilerOptions": {
+        "allowJs": true,
+        "module": "esnext",
+        "lib": ["dom", "esnext"],
+        "importHelpers": true,
+        "declaration": true,
+        "sourceMap": true,
+        "rootDir": "src",
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "moduleResolution": "node",
+        "baseUrl": "./",
+        "paths": {
+            "@": ["./"],
+            "*": ["src/*", "node_modules/*"]
+        },
+        "jsx": "react",
+        "esModuleInterop": true
+    },
+    "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Extends `@typescript-eslint/recommended-requiring-type-checking`. We already use this config elsewhere (in twist-web and upcoming shared eslint-config).

## Short description

We do not seem to typecheck `stories`. I added a separate config which is enough to satisfy typescript-eslint requirements.

## PR Checklist

-   [ ] Executed `npm run lint` and made sure no errors / warnings were shown
-   [ ] Executed `npm run test` and made sure all tests are passing

## Versioning

It does not change any public API.