### PR TITLE
Remove close prop from button (#198)

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -29,14 +29,6 @@ type Props = Omit<NativeButtonProps, 'title'> & {
      * This replaces `title` which is not supported for these buttons to avoid confusion.
      */
     tooltip?: React.ReactNode
-    /**
-     * A flag to make outer elements know this button is meant to close something (e.g. in
-     * Modal.Actions).
-     *
-     * @deprecated This is being removed in favor of being explicit in calling whatever action the
-     *   button should perform when clicked.
-     */
-    close?: boolean
 }
 
 const Button = React.forwardRef<HTMLButtonElement, Props>(function Button(

--- a/src/components/__tests__/Modal.test.tsx
+++ b/src/components/__tests__/Modal.test.tsx
@@ -197,37 +197,6 @@ describe('Modal.Actions', () => {
         )
         expect(toJson(actions)).toMatchSnapshot()
     })
-
-    it('unmounts modal_box when child with close prop is clicked', () => {
-        const clickSpy = jest.fn()
-        const actions = shallow(
-            <Modal.Actions>
-                <Button variant="primary" close onClick={clickSpy}>
-                    Action 1
-                </Button>
-                <Button variant="primary">Action 2</Button>
-            </Modal.Actions>,
-        )
-
-        const unmountCallCount = getCallCount(ReactDOM.unmountComponentAtNode)
-        actions.find('Button').first().simulate('click')
-        expect(clickSpy).toHaveBeenCalled()
-        expect(getCallCount(ReactDOM.unmountComponentAtNode)).toBe(unmountCallCount + 1)
-    })
-
-    it('unmounts modal_box when child with close prop is clicked even when no onClick is specified', () => {
-        const actions = shallow(
-            <Modal.Actions>
-                <Button variant="primary" close>
-                    Action 1
-                </Button>
-            </Modal.Actions>,
-        )
-
-        const unmountCallCount = getCallCount(ReactDOM.unmountComponentAtNode)
-        actions.find('Button').first().simulate('click')
-        expect(getCallCount(ReactDOM.unmountComponentAtNode)).toBe(unmountCallCount + 1)
-    })
 })
 
 // Helper functions ///////////////////////////////////////////////////////////


### PR DESCRIPTION
*remove close prop from button, since it is deprecated
*remove tests checking for unmounting when child with close prop is clicked

<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Closes #198 

## Short description

1. Removed the close prop from the button component file. 
2. After the removal, 2 tests in the modal component were failing
    * the tests were checking for unmounting when a child component with the close prop was clicked - removed those 2 tests since we are removing the close prop from the button

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Described changes in `CHANGELOG.md`
-   [x] Executed `npm run lint` and made sure no errors / warnings were shown
-   [x] Executed `npm run test` and made sure all tests are passing
-   [ ] Bumped version in `package.json`
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->
This is a breaking change: the prop has been removed from a component