### PR TITLE
Fix @typescript-eslint/unbound-method by using class property arrow.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,8 +35,7 @@
         "react/no-did-update-set-state": "error",
         "react/no-find-dom-node": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
-        "@typescript-eslint/ban-ts-comment": "off",
-        "@typescript-eslint/unbound-method": "off"
+        "@typescript-eslint/ban-ts-comment": "off"
     },
     "overrides": [
         {

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -34,9 +34,6 @@ class Box extends React.Component<React.PropsWithChildren<BoxProps>, BoxState> {
             top: props.top || false,
         }
 
-        this._handleClickOutside = this._handleClickOutside.bind(this)
-        this._setPosition = this._setPosition.bind(this)
-        this._toggleShowBody = this._toggleShowBody.bind(this)
         this._timeout = undefined
     }
 
@@ -48,7 +45,7 @@ class Box extends React.Component<React.PropsWithChildren<BoxProps>, BoxState> {
     }
     _timeout?: ReturnType<typeof setTimeout>
 
-    _handleClickOutside(event: MouseEvent) {
+    _handleClickOutside = (event: MouseEvent) => {
         const dropdownDOMNode = ReactDOM.findDOMNode(this)
 
         if (dropdownDOMNode && !dropdownDOMNode.contains(event.target as Node))
@@ -63,7 +60,7 @@ class Box extends React.Component<React.PropsWithChildren<BoxProps>, BoxState> {
         }
     }
 
-    _toggleShowBody() {
+    _toggleShowBody = () => {
         if (!this.state.showBody) {
             // will show
             if (this.props.onShowBody) this.props.onShowBody()
@@ -87,7 +84,7 @@ class Box extends React.Component<React.PropsWithChildren<BoxProps>, BoxState> {
     }
 
     // https://facebook.github.io/react/docs/refs-and-the-dom.html#exposing-dom-refs-to-parent-components
-    _setPosition(body: HTMLElement | null) {
+    _setPosition = (body: HTMLElement | null) => {
         if (body) {
             const scrollingParent = document.getElementById(
                 this.props.scrolling_parent ? this.props.scrolling_parent : '',

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -25,9 +25,6 @@ class Box extends React.Component<React.PropsWithChildren<Props>> {
 
     constructor(props: Props, context: unknown) {
         super(props, context)
-        this._handleKeyDown = this._handleKeyDown.bind(this)
-        this._closeModal = this._closeModal.bind(this)
-        this._handleOverlayClick = this._handleOverlayClick.bind(this)
         window.addEventListener('keydown', this._handleKeyDown)
     }
 
@@ -35,13 +32,13 @@ class Box extends React.Component<React.PropsWithChildren<Props>> {
         window.removeEventListener('keydown', this._handleKeyDown)
     }
 
-    _closeModal() {
+    _closeModal = () => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const modalElement = document.getElementById('modal_box')!
         ReactDOM.unmountComponentAtNode(modalElement)
     }
 
-    _handleKeyDown(event: Partial<KeyboardEvent>) {
+    _handleKeyDown = (event: Partial<KeyboardEvent>) => {
         if (event.keyCode === 27) {
             // ESC
             this._closeModal()
@@ -49,7 +46,7 @@ class Box extends React.Component<React.PropsWithChildren<Props>> {
         }
     }
 
-    _handleOverlayClick(event: React.MouseEvent<Element>) {
+    _handleOverlayClick = (event: React.MouseEvent<Element>) => {
         if (
             event.target instanceof Element &&
             (event.target.id === 'reactist-overlay' || event.target.id === 'reactist-overlay-inner')


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

## Short description

Fix `@typescript-eslint/unbound-method` rule violations and re-enable the rule in preparation to adopt shared [eslint-config](https://github.com/Doist/eslint-config). For context, see discussion in [here](https://github.com/Doist/twist-web/pull/2783).

The fix uses class property syntax. I know we've had some problems with transpiling it in other projects, so please double-check it's ok. I've run the tests and stories and checked output in es directory.

## PR Checklist

-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

It only affects internals and does not require release of its own.