### PR TITLE
Re-enable no-unsafe-* rules in main codebase

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,12 +38,21 @@
         "react/no-find-dom-node": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/ban-ts-comment": "off",
-        "@typescript-eslint/unbound-method": "off",
-        "@typescript-eslint/no-unsafe-member-access": "off",
-        "@typescript-eslint/no-unsafe-call": "off",
-        "@typescript-eslint/no-unsafe-assignment": "off",
-        "@typescript-eslint/no-unsafe-return": "off"
+        "@typescript-eslint/unbound-method": "off"
     },
+    "overrides": [
+        {
+            // Some types are missing in legacy version of Storybook, revisit after update.
+            // jest mocks are hard to type, allow incomplete types in tests.
+            "files": ["stories/**/*", "*.test.*"],
+            "rules": {
+                "@typescript-eslint/no-unsafe-member-access": "off",
+                "@typescript-eslint/no-unsafe-call": "off",
+                "@typescript-eslint/no-unsafe-assignment": "off",
+                "@typescript-eslint/no-unsafe-return": "off"
+            }
+        }
+    ],
     "settings": {
         "react": {
             "version": "detect"

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -228,7 +228,9 @@ class Popover extends React.Component<Props> {
         function handleTriggerClick(event: React.SyntheticEvent) {
             // @ts-expect-error This is temporary while we revisit the Popover interface
             if (onClick) onClick(event)
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             if (typeof triggerElement.props.onClick === 'function') {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
                 triggerElement.props.onClick(event)
             }
         }

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -71,6 +71,7 @@ function Tooltip({
         event.currentTarget.addEventListener('keyup', handleKeyUp, { once: true })
         // Prevent tooltip.show from being called by TooltipReference
         event.preventDefault()
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         if (typeof child.props.onFocus === 'function') child.props.onFocus(event)
     }
 
@@ -78,7 +79,7 @@ function Tooltip({
         <>
             <TooltipReference
                 {...tooltip}
-                /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
                 ref={(child as any).ref}
                 {...child.props}
                 onFocus={handleFocus}

--- a/src/components/__tests__/KeyCapturer.test.tsx
+++ b/src/components/__tests__/KeyCapturer.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { SyntheticEvent } from 'react'
 import { shallow } from 'enzyme'
 import { screen, render, fireEvent } from '@testing-library/react'
 
@@ -110,7 +110,7 @@ describe('KeyCapturer', () => {
         })
 
         it('forwards the event to the handler', () => {
-            const onEnter = jest.fn()
+            const onEnter: jest.MockedFunction<React.EventHandler<SyntheticEvent>> = jest.fn()
 
             render(
                 <KeyCapturer eventName="onKeyDown" onEnter={onEnter}>

--- a/src/components/__tests__/Menu.test.tsx
+++ b/src/components/__tests__/Menu.test.tsx
@@ -61,7 +61,7 @@ it('closes the menu when a menu item is selected (unless the onSelect handler re
 
 it("calls the onSelect and the menu's onItemSelect with the value when menu items are selected", () => {
     const onItemSelect = jest.fn()
-    const onSelect = jest.fn()
+    const onSelect = jest.fn<void, [string]>()
 
     render(
         <Menu onItemSelect={onItemSelect}>
@@ -90,7 +90,7 @@ it("calls the onSelect and the menu's onItemSelect with the value when menu item
 
 it('allows to navigate through the menu items using the keyboard', async () => {
     const onItemSelect = jest.fn()
-    const onSelect = jest.fn()
+    const onSelect = jest.fn<void, [string]>()
 
     render(
         <Menu onItemSelect={onItemSelect}>

--- a/src/components/__tests__/Popover.test.tsx
+++ b/src/components/__tests__/Popover.test.tsx
@@ -52,7 +52,9 @@ describe('Popover', () => {
         })
 
         it('sets the tooltip to the first position that has enough space when `auto` is supplied', () => {
-            ;(PositioningUtils.hasEnoughSpace as jest.Mock<boolean>) = jest
+            ;(PositioningUtils.hasEnoughSpace as jest.MockedFunction<
+                typeof PositioningUtils.hasEnoughSpace
+            >) = jest
                 .fn()
                 .mockReturnValueOnce(false) // top
                 .mockReturnValueOnce(false) // right


### PR DESCRIPTION
## Short description

no-unsafe-* lint rules are important, because violations have potential to produce a runtime crash. This PR re-enables all no-unsafe rules in main codebase, but allow exception in storybook and tests (hard to fix there due to older storybook and complicated mock typing).

Popover and Tooltip are not 100% strict and a couple of violations are ignored there. I never figured out how to retrict `children` type(s).

## Versioning

Only affects linting / types, does not need a release.