### PR TITLE
Remove linebreak-style rule already covered by prettier.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,6 @@
     "rules": {
         "jest/expect-expect": "off",
         "prettier/prettier": "error",
-        "linebreak-style": ["error", "unix"],
         "react/no-did-mount-set-state": "error",
         "react/no-did-update-set-state": "error",
         "react/no-find-dom-node": "off",


### PR DESCRIPTION
## Short description

Remove linebreak-style rule, because it is already covered by prettier/prettier ('lf' linebreak is default since prettier 2.0).

## Versioning

Only affects lint, no release needed.