### PR TITLE
Re-enable expect-expect lint rule.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,6 @@
         "webpack.config.*"
     ],
     "rules": {
-        "jest/expect-expect": "off",
         "prettier/prettier": "error",
         "react/no-did-mount-set-state": "error",
         "react/no-did-update-set-state": "error",

--- a/src/components/__tests__/Tooltip.test.tsx
+++ b/src/components/__tests__/Tooltip.test.tsx
@@ -61,6 +61,8 @@ describe('Tooltip', () => {
         })
     })
 
+    // Calls into testShowHide subtest.
+    // eslint-disable-next-line jest/expect-expect
     it('renders a tooltip when the button is hovered, hides it when unhovered', () => {
         render(
             <Tooltip content="tooltip content here">


### PR DESCRIPTION
## Short description

Re-enable expect-expect lint rule. There doesn't seem to be good way to avoid it triggering in case of delegating test to another function, but it's better to address on per-case basis than disable everywhere.

https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/expect-expect.md

Only affects lint.