### PR TITLE
chore: Remove babel-eslint.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8773,20 +8773,6 @@
             "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
             "dev": true
         },
-        "babel-eslint": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-            "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.7.0",
-                "@babel/traverse": "^7.7.0",
-                "@babel/types": "^7.7.0",
-                "eslint-visitor-keys": "^1.0.0",
-                "resolve": "^1.12.0"
-            }
-        },
         "babel-helper-evaluate-path": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
         "@typescript-eslint/parser": "^4.4.1",
         "autoprefixer": "^9.8.0",
         "babel-core": "^7.0.0-bridge.0",
-        "babel-eslint": "^10.1.0",
         "babel-loader": "^8.1.0",
         "classnames": "^2.2.5",
         "css-loader": "^4.2.2",


### PR DESCRIPTION
## Short description

Remove (now unused) babel-eslint.

## PR Checklist

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json`
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

This is internal change, no need to version.