### PR TITLE
Organize styles during watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "scripts": {
         "setup": "npm install && npm run validate",
         "validate": "npm run lint && npm run type-check && npm run test",
-        "start": "tsdx watch",
+        "start": "tsdx watch --onSuccess \"./scripts/organize-styles.sh\"",
         "build-all": "npm run build && npm run build:storybook",
         "build": "scripts/build.sh",
         "build:storybook": "build-storybook -o docs",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,10 +9,5 @@ rimraf dist/assets dist/index.js
 
 # Reorganize Styles
 # We delete duplicate styles in dist/ & lib/
-mv es/index.css es/reactist.css
-mkdir styles
-find es -iname '*.css' -type f -exec mv {} styles/ \;
-find dist -iname '*.css' -type f -exec rm {} \;
-find lib -iname '*.css' -type f -exec rm {} \;
-
+./scripts/organize-styles.sh
 

--- a/scripts/organize-styles.sh
+++ b/scripts/organize-styles.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+mv es/index.css es/reactist.css
+mkdir -p styles
+find es -iname '*.css' -type f -exec mv {} styles/ \;
+find dist -iname '*.css' -type f -exec rm {} \;
+find lib -iname '*.css' -type f -exec rm {} \;


### PR DESCRIPTION
## Short description

In recent product PRs we've fixed our local reactist setup. This went well for code changes but didn't work for style changes. Also it required to run `npm run build` before running the watch mode with `npm start`. With this PR this gets fully fixed, we no longer need to run build before the watch mode and we can change styles and see them reflected in the apps.

I tried to find a solution that is not based on bash scripts but integrates with tsdx / rollup but couldn't make it work with the copy and delete plugins (the order of these plugins cannot be specified in the way we need it because the hooks are not granular enough).

You can test this PR by running `npm run clean`, then `npm start` and then start up todoist or twist web and see your changes reflected immediately.
