### PR TITLE
Fix type definition for MenuItem when no as attribute

### DIFF
--- a/src/components/menu/type-helpers.ts
+++ b/src/components/menu/type-helpers.ts
@@ -74,8 +74,9 @@ interface ForwardRefFunction<ComponentType extends As, ComponentProps = {}> {
 }
 
 export interface ForwardRefComponentWithAs<ComponentType extends As, ComponentProps> {
-    <TT extends As>(props: PropsWithAs<TT, ComponentProps>): React.ReactElement | null
-    (props: PropsWithAs<ComponentType, ComponentProps>): React.ReactElement | null
+    <TT extends As = ComponentType>(
+        props: PropsWithAs<TT, ComponentProps>,
+    ): React.ReactElement | null
     readonly $$typeof: symbol
     defaultProps?: Partial<PropsWithAs<ComponentType, ComponentProps>>
     propTypes?: React.WeakValidationMap<PropsWithAs<ComponentType, ComponentProps>>


### PR DESCRIPTION
Closes #421 

## Short description

Not having 'as' attribute defined, results into TT not being defined and probably allow any props as result. I added as default type for TT 'ComponentType', which looks making duplicates but working well.

I deleted the second line which then become useless. 

Here some examples:
![photo_2021-01-20_09-45-13](https://user-images.githubusercontent.com/2178406/105149824-445eea80-5b04-11eb-9b79-77b99f2e9f70.jpg)

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate
` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json`
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->
