### PR TITLE
fix: Move patch-package to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8083,8 +8083,7 @@
         "@yarnpkg/lockfile": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-            "dev": true
+            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
         },
         "abab": {
             "version": "2.0.3",
@@ -8365,7 +8364,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
             }
@@ -9391,8 +9389,7 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base": {
             "version": "0.11.2",
@@ -9679,7 +9676,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10127,7 +10123,6 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -10309,8 +10304,7 @@
         "ci-info": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-            "dev": true
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
         },
         "cipher-base": {
             "version": "1.0.4",
@@ -10663,7 +10657,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -10671,8 +10664,7 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "color-string": {
             "version": "1.5.3",
@@ -10738,8 +10730,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
             "version": "1.6.2",
@@ -11006,7 +10997,6 @@
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-            "dev": true,
             "requires": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -12428,8 +12418,7 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "escodegen": {
             "version": "1.14.1",
@@ -14109,7 +14098,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
             "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-            "dev": true,
             "requires": {
                 "micromatch": "^4.0.2"
             },
@@ -14118,7 +14106,6 @@
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
                     "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-                    "dev": true,
                     "requires": {
                         "fill-range": "^7.0.1"
                     }
@@ -14127,7 +14114,6 @@
                     "version": "7.0.1",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
                     "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-                    "dev": true,
                     "requires": {
                         "to-regex-range": "^5.0.1"
                     }
@@ -14135,14 +14121,12 @@
                 "is-number": {
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-                    "dev": true
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
                 },
                 "micromatch": {
                     "version": "4.0.2",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
                     "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-                    "dev": true,
                     "requires": {
                         "braces": "^3.0.1",
                         "picomatch": "^2.0.5"
@@ -14152,7 +14136,6 @@
                     "version": "5.0.1",
                     "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
                     "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-                    "dev": true,
                     "requires": {
                         "is-number": "^7.0.0"
                     }
@@ -14415,8 +14398,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "1.2.13",
@@ -14572,7 +14554,6 @@
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
             "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -14726,8 +14707,7 @@
         "graceful-fs": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-            "dev": true
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         },
         "growly": {
             "version": "1.3.0",
@@ -14796,8 +14776,7 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-symbols": {
             "version": "1.0.1",
@@ -15501,7 +15480,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -15510,8 +15488,7 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "ini": {
             "version": "1.3.5",
@@ -15766,7 +15743,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
             "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-            "dev": true,
             "requires": {
                 "ci-info": "^2.0.0"
             }
@@ -15854,8 +15830,7 @@
         "is-docker": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-            "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
-            "dev": true
+            "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
         },
         "is-dom": {
             "version": "1.1.0",
@@ -16139,8 +16114,7 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "4.0.0",
@@ -17534,7 +17508,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
             "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11"
             }
@@ -18779,7 +18752,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -18787,8 +18759,7 @@
         "minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "minipass": {
             "version": "3.1.3",
@@ -19063,8 +19034,7 @@
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-            "dev": true
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "no-case": {
             "version": "3.0.3",
@@ -19430,7 +19400,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -19578,8 +19547,7 @@
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-            "dev": true
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "p-each-series": {
             "version": "1.0.0",
@@ -19778,7 +19746,6 @@
             "version": "6.4.6",
             "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.6.tgz",
             "integrity": "sha512-AO2bh42z8AQL+0OUdcRpS5Z/0X8k9IQ1uc1HzlVye+2RQrtDeNgTk5SbS4rdbLJKtUWRpvPISrYZeyh+OK4AKw==",
-            "dev": true,
             "requires": {
                 "@yarnpkg/lockfile": "^1.1.0",
                 "chalk": "^2.4.2",
@@ -19799,7 +19766,6 @@
                     "version": "7.0.1",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
                     "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
                         "jsonfile": "^4.0.0",
@@ -19810,7 +19776,6 @@
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
                     "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-                    "dev": true,
                     "requires": {
                         "is-docker": "^2.0.0"
                     }
@@ -19819,7 +19784,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
                     "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.6"
                     }
@@ -19828,7 +19792,6 @@
                     "version": "7.4.2",
                     "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
                     "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-                    "dev": true,
                     "requires": {
                         "is-docker": "^2.0.0",
                         "is-wsl": "^2.1.1"
@@ -19838,7 +19801,6 @@
                     "version": "2.7.1",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
                     "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                    "dev": true,
                     "requires": {
                         "glob": "^7.1.3"
                     }
@@ -19893,14 +19855,12 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-            "dev": true
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "path-parse": {
             "version": "1.0.6",
@@ -19942,8 +19902,7 @@
         "picomatch": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-            "dev": true
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
         },
         "pify": {
             "version": "3.0.0",
@@ -23250,8 +23209,7 @@
         "semver": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -23467,7 +23425,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true,
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
@@ -23475,8 +23432,7 @@
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "shell-quote": {
             "version": "1.7.2",
@@ -23575,8 +23531,7 @@
         "slash": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-            "dev": true
+            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
         },
         "slice-ansi": {
             "version": "2.1.0",
@@ -24283,7 +24238,6 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
             }
@@ -24607,7 +24561,6 @@
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
             "requires": {
                 "os-tmpdir": "~1.0.2"
             }
@@ -25659,8 +25612,7 @@
         "universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
         "unpipe": {
             "version": "1.0.0",
@@ -26443,7 +26395,6 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -26626,8 +26577,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write": {
             "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
         "mini-css-extract-plugin": "^0.11.0",
         "mockdate": "^3.0.2",
         "optimize-css-assets-webpack-plugin": "^5.0.3",
-        "patch-package": "^6.4.6",
         "path": "^0.12.7",
         "prettier": "2.1.2",
         "raw-loader": "^4.0.1",
@@ -127,6 +126,7 @@
     },
     "dependencies": {
         "dayjs": "^1.8.10",
+        "patch-package": "^6.4.6",
         "react-keyed-flatten-children": "^1.3.0",
         "reakit": "1.3.0"
     }


### PR DESCRIPTION
## Short description

With #464 I added patch-package in order to patch rollup-plugin-style, however when being installed as a package with `npm ci`, patch-package will not be available and the install will exit.

This moves patch-package to our dependencies so that it'd be available. When installing as a package, it will omit patching dev dependencies, so other than the extra package being installed, there should be no additional consequences: [ref](https://docs.npmjs.com/cli/v6/using-npm/scripts#prepare-and-prepublish)

The alternative is to run patch-package with the [`prepare` script](https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts), which sounds like it covers all the scenarios that we would want it to run in, however, patch-package used to recommend the prepare script and have since changed it to postinstall: https://github.com/ds300/patch-package/commit/f9fb13b2a25c60991ff88f0efe0399f6f5f6f623.

## Test Plan

While not exactly the same as installing off of the registry, we can try installing this off of git and seeing the postinstall script run:

- In another repo, run `npm install git://github.com/doist/reactist#frankie/fix-patch-package`
- Run `rm -rf node_modules`
- Run `npm ci`
- [ ] You should see the following output:
```
> @doist/reactist@9.1.0-beta.1 postinstall /Users/frankie/Documents/twist-web/node_modules/@doist/reactist
> patch-package

patch-package 6.4.6
Applying patches...
No patch files found
```

Whereas if you try the steps above with v9.1.0-beta.1, it should fail

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

v9.1.0-beta.2
