### PR TITLE
feat: Forward ref from Heading component

### DIFF
--- a/src/new-components/heading/heading.tsx
+++ b/src/new-components/heading/heading.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react'
 import { getClassNames } from '../responsive-props'
 import { Box } from '../box'
-import styles from './heading.module.css'
+import { forwardRefWithAs } from '../type-helpers'
 import type { Tone } from '../common-types'
+
+import styles from './heading.module.css'
 
 type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6 | '1' | '2' | '3' | '4' | '5' | '6'
 type HeadingElement = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
@@ -21,15 +23,10 @@ type HeadingProps = SupportedHeadingElementProps & {
     lineClamp?: 1 | 2 | 3 | 4 | 5 | '1' | '2' | '3' | '4' | '5'
 }
 
-function Heading({
-    level,
-    weight = 'regular',
-    size,
-    tone = 'normal',
-    children,
-    lineClamp,
-    ...props
-}: HeadingProps) {
+const Heading = forwardRefWithAs<HeadingProps>(function Heading(
+    { level, weight = 'regular', size, tone = 'normal', children, lineClamp, ...props },
+    ref,
+) {
     // In TypeScript v4.1, this would be properly recognized without needing the type assertion
     // https://devblogs.microsoft.com/typescript/announcing-typescript-4-1-beta/#template-literal-types
     const headingElementName = `h${level}` as HeadingElement
@@ -48,11 +45,12 @@ function Heading({
                 lineClamp ? getClassNames(styles, 'line-clamp', lineClamp.toString()) : null,
             ]}
             component={headingElementName}
+            ref={ref}
         >
             {children}
         </Box>
     )
-}
+})
 
 export type { HeadingProps, HeadingLevel }
 export { Heading }


### PR DESCRIPTION
## Short description

Allows the top-level element's ref to be forwarded from the `Heading` component

## PR Checklist

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Test plan

Pull this into Twist with `npm link` (ide-tools won't symlink locally AFAIK) and run the test suite. There should be no test failures. 

## Versioning

v9.2.0-beta.6
