### PR TITLE
Make disabled button component more accessible through aria-disabled

### DIFF
--- a/src/components/button/button.less
+++ b/src/components/button/button.less
@@ -8,7 +8,7 @@
     background-color: transparent;
     padding: 0;
 
-    &:disabled {
+    &[aria-disabled='true'] {
         opacity: 0.4;
         cursor: not-allowed;
     }

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -64,8 +64,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
             ref={ref}
             type={type}
             className={className}
-            disabled={disabled || loading}
-            onClick={onClick}
+            aria-disabled={disabled || loading}
+            onClick={disabled || loading ? undefined : onClick}
         >
             {children}
         </button>

--- a/src/components/dropdown/__snapshots__/dropdown.test.tsx.snap
+++ b/src/components/dropdown/__snapshots__/dropdown.test.tsx.snap
@@ -102,8 +102,8 @@ exports[`Dropdown Dropdown.Box renders the Body component first when top prop is
         size="default"
       >
         <button
+          aria-disabled={false}
           className="reactist_button trigger"
-          disabled={false}
           onClick={[Function]}
           type="button"
         />
@@ -134,8 +134,8 @@ exports[`Dropdown Dropdown.Box renders the Trigger component first when top prop
         size="default"
       >
         <button
+          aria-disabled={false}
           className="reactist_button trigger"
-          disabled={false}
           onClick={[Function]}
           type="button"
         />
@@ -192,8 +192,8 @@ exports[`Dropdown Dropdown.Box renders the Trigger component without crashing 1`
         size="default"
       >
         <button
+          aria-disabled={false}
           className="reactist_button trigger"
-          disabled={false}
           onClick={[Function]}
           type="button"
         />


### PR DESCRIPTION
## Short description

Add `aria-disabled` to the `Button` component to ensure its state is read by screen readers.

## Motivation / longer description 
The current implementation using `disabled` is ignored by screen readers and so I wanted to experiment a bit with this component to make it more accessible. By adding `aria-disabled`, simply changing the CSS selector which already applied opacity anyway, and conditionally blocking `onClick` events, the button is now picked up by screen readers whilst it maintains its disabled state look. 

The change requires no changes to any components making use of the button since it still expects a `disabled` prop. The only difference now is that the prop is only used to determine whether `onClick` should fire or `aria-disabled` should be true or false.


## PR Checklist

- Run storybook 
-   [ ] Inspect any of the buttons within the `Disabled Buttons Story` and make sure that `aria-disabled` is applied and `disabled` is no longer present
-   [ ] Ensure that the button is styled the same as the current disabled one in production and that pointer events are disabled
- To check for onClick events:
    - The best and probably easiest way is to create a dummy function in `button.tsx` where you console.log something out
    - Pass that function to the button's `onClick` attribute and make sure nothing is printed out to the console when you click on the disabled button
    - Set `disabled` to `!disabled` in the `onClick` - ensure something is printed to the console (this is a check to ensure events are fired when disabled is false)

As I mentioned, this is something I wanted to experiment with and I'm open to any feedback  or changes to it!