### PR TITLE
chore: Upgrade version to 9.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+## 9.1.4
+
+- [Perf] Make the disabled Button component visible to screen readers by swapping `disabled` for `aria-disabled`
+
 ## 9.1.3
 
 - [Tweak] Upgrade Storybook to version v6.2.1. Migrate stories to new version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/reactist",
-    "version": "9.1.3",
+    "version": "9.1.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doist/reactist",
     "description": "Open source React components by Doist",
     "author": "Henning Muszynski <henning@doist.com> (http://doist.com)",
-    "version": "9.1.3",
+    "version": "9.1.4",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": "git+https://github.com/Doist/reactist.git",


### PR DESCRIPTION

## Short description

Upgrading to 9.1.4 ahead of a new release to include changes made to the disabled `Button` component in [this](https://github.com/Doist/reactist/pull/509) PR.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)

## Versioning

A new version 9.1.4 will be published
