### PR TITLE
A couple of style fixes

### DIFF
--- a/src/components/button/button.less
+++ b/src/components/button/button.less
@@ -35,7 +35,7 @@
 
     &--primary {
         background-color: @primary_color;
-        color: white !important;
+        color: white;
 
         &:not([disabled]):hover {
             background-color: @primary_color_darker;
@@ -44,7 +44,7 @@
 
     &--danger {
         background-color: @color_red;
-        color: white !important;
+        color: white;
 
         &:not([disabled]):hover {
             background-color: darken(@color_red, 10%);
@@ -53,7 +53,7 @@
 
     &--secondary {
         background-color: white;
-        color: @primary_font_color !important;
+        color: @primary_font_color;
         border-color: @color_border_grey;
 
         &:not([disabled]):hover {

--- a/src/new-components/select-field/select-field.module.css
+++ b/src/new-components/select-field/select-field.module.css
@@ -33,6 +33,7 @@
     appearance: none;
     box-sizing: border-box;
     width: 100%;
+    color: var(--reactis-content-primary);
     background: none;
     border-radius: var(--reactist-border-radius-small);
     border: 1px solid var(--reactist-framework-border);


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Works towards closing https://github.com/Doist/Issues/issues/2709 (it does not actually close it until we upgrade Twist to use the new version of Reactist that we'll release with these changes).

## Short description

I messed up in #497 and added some `!important` rules that right now I'm not even sure why they were needed because removing them does not affect anything in the new settings in Twist (presumably the reason I did this was related to the new settings UI).

Anyway, here I'm reverting that. I also sneaked in an unrelated style fix so that the new `SelectField` components have the correct text color in dark mode in Twist.

## Test plan

- Set Reactist locally to this branch, run `npm start` in the terminal in Reactis's folder, and then run Twist locally while linked to use the local Reactist instead of the one from npm.
    - [ ] Then make sure that buttons all around Twist in dark mode appear with a light text color on a dark background, instead of dark text on dark background.
- With the new twist and new settings feature flags on, visit the new settings while in dark mode.
    - [ ] Make sure that the `select` elements text color is also light-colored text on dark background.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] N/A ~~Added tests for bugs / new features~~
-   [x] N/A ~~Updated docs (storybooks, readme)~~
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

A new beta release.