### PR TITLE
chore: Add temporary action for default branch migration (#3576)

### DIFF
--- a/.github/workflows/temp-default-branch-migration.yml
+++ b/.github/workflows/temp-default-branch-migration.yml
@@ -1,0 +1,19 @@
+name: Default Branch Migration
+
+on:
+    push:
+        branches:
+            - dev
+            - main
+
+jobs:
+    migrate-branch:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Migrate default branch
+              uses: liyanchang/default-branch-migration@v1.0.2
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  previous_default: dev
+                  new_default: main


### PR DESCRIPTION
### Overview

This PR introduces a temporary action ([default-branch-migration](https://github.com/marketplace/actions/default-branch-migration)) to help with the default branch migration from `master` to `main`.

The changes here are pretty much copy/paste from the documentation, and there's nothing to test. That's why I'm opening this PR and merge it without tagging anyone.