### PR TITLE
chore: Change all `dev` branch references to `main`

### DIFF
--- a/.github/ISSUE_TEMPLATE/Feature.md
+++ b/.github/ISSUE_TEMPLATE/Feature.md
@@ -21,4 +21,4 @@ Provide an example for how this feature would be used.
 
 ### Possible implementations
 
-If possible, describe how this feature could be implemented. See [CONTRIBUTING.md](https://github.com/Doist/reactist/blob/dev/.github/CONTRIBUTING.md).
+If possible, describe how this feature could be implemented. See [CONTRIBUTING.md](https://github.com/Doist/reactist/blob/main/.github/CONTRIBUTING.md).

--- a/.github/actions/default-branch-migration/Dockerfile
+++ b/.github/actions/default-branch-migration/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.12
+
+RUN apk add --update jq curl git
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/default-branch-migration/action.yml
+++ b/.github/actions/default-branch-migration/action.yml
@@ -1,0 +1,23 @@
+name: 'Default Branch Migration'
+description: "Cleanly transition when changing the repository's default branch"
+author: 'Liyan David Chang (@liyanchang)'
+branding:
+    icon: fast-forward
+    color: black
+inputs:
+    github_token:
+        description: 'Token for the repo. Required. Mostly commonly, "$\{{ secrets.GITHUB_TOKEN }}"'
+        required: true
+    previous_default:
+        description: 'The default branch name you are moving away from. Required. Most commonly, "master"'
+        required: true
+    new_default:
+        description: 'The default branch name you are using going forward. Required. Most commonly, "main"'
+        required: true
+runs:
+    using: 'docker'
+    image: 'Dockerfile'
+    args:
+        - ${{ inputs.github_token }}
+        - ${{ inputs.previous_default }}
+        - ${{ inputs.new_default }}

--- a/.github/actions/default-branch-migration/entrypoint.sh
+++ b/.github/actions/default-branch-migration/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/sh -l
+
+GITHUB_TOKEN=$1
+PREVIOUS_DEFAULT=$2
+NEW_DEFAULT=$3
+GITHUB_API_URL="https://api.github.com"
+
+echo "Migrating from '$PREVIOUS_DEFAULT' to '$NEW_DEFAULT'"
+echo "Repo Name: $GITHUB_REPOSITORY"
+echo "Branch/Tag: $GITHUB_REF"
+
+if [ "$GITHUB_REF" != "refs/heads/$PREVIOUS_DEFAULT" ] && [ "$GITHUB_REF" != "refs/heads/$NEW_DEFAULT" ]; then
+	echo "Push not to either default branches ($NEW_DEFAULT or $PREVIOUS_DEFAULT)"
+	echo "Ignoring push to $GITHUB_REF"
+	exit
+fi;
+
+# Check the API to see what the current default branch is
+CURRENT_DEFAULT=$(curl --silent -u $GITHUB_ACTOR:$GITHUB_TOKEN $GITHUB_API_URL/repos/$GITHUB_REPOSITORY | jq -r .default_branch)
+echo "Default branch: $CURRENT_DEFAULT"
+
+if [ "$CURRENT_DEFAULT" = "$NEW_DEFAULT" ]; then
+	echo "Default has changed to $NEW_DEFAULT"
+	if [ "$GITHUB_REF" = "refs/heads/$PREVIOUS_DEFAULT" ]; then
+		echo "ERROR: Push to $PREVIOUS_DEFAULT even though default branch is now $NEW_DEFAULT"
+		exit 1
+	fi;
+	# Check all existing PRs to see if we should change their base
+	PRS=$(curl --silent -u $GITHUB_ACTOR:$GITHUB_TOKEN "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls?base=$PREVIOUS_DEFAULT&state=open")
+
+	# TODO: PATCH /repos/:owner/:repo/pulls/:pull_number
+	for row in $(echo $PRS | jq -r 'map(select(.locked == false)) | .[].url'); do
+		echo "Attempting to update $row"
+		curl --silent --show-error -w "Status Code: %{http_code}\n" --request PATCH --data '{"base": "'$NEW_DEFAULT'"}' -u $GITHUB_ACTOR:$GITHUB_TOKEN "$row"
+	done
+
+	exit
+fi;
+
+# The default is PREVIOUS_DEFAULT and a push to PREVIOUS_DEFAULT
+# so keep NEW_DEFAULT up to date
+if [ "$GITHUB_REF" = "refs/heads/$PREVIOUS_DEFAULT" ]; then
+	echo "Update $NEW_DEFAULT to match $PREVIOUS_DEFAULT"
+	GIT_REPO="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+	# Specify repo folder as target so it's clear what folder to cd into
+	git clone --depth 3 -b $PREVIOUS_DEFAULT $GIT_REPO target
+	cd target
+	git checkout -b $NEW_DEFAULT $PREVIOUS_DEFAULT
+	git push --set-upstream origin $NEW_DEFAULT
+	exit
+fi;

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,55 +1,55 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
-  push:
-    branches: [dev, ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [dev]
-  schedule:
-    - cron: '0 11 * * 2'
+    push:
+        branches: [main]
+    pull_request:
+        # The branches below must be a subset of the branches above
+        branches: [main]
+    schedule:
+        - cron: '0 11 * * 2'
 
 jobs:
-  analyse:
-    name: Analyse
-    runs-on: ubuntu-latest
+    analyse:
+        name: Analyse
+        runs-on: ubuntu-latest
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+              with:
+                  # We must fetch at least the immediate parents so that if this is
+                  # a pull request then we can checkout the head.
+                  fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+            # If this run was triggered by a pull request event, then checkout
+            # the head of the pull request instead of the merge commit.
+            - run: git checkout HEAD^2
+              if: ${{ github.event_name == 'pull_request' }}
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        config-file: ./.github/codeql/codeql-config.yml
-      # Override language selection by uncommenting this and choosing your languages
-      #   languages: go, javascript, csharp, python, cpp, java
+            # Initializes the CodeQL tools for scanning.
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v1
+              with:
+                  config-file: ./.github/codeql/codeql-config.yml
+              # Override language selection by uncommenting this and choosing your languages
+              #   languages: go, javascript, csharp, python, cpp, java
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+            # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+            # If this step fails, then you should remove it and run the build manually (see below)
+            - name: Autobuild
+              uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+            # ℹ️ Command-line programs to run using the OS shell.
+            # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+            # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+            #    and modify them (or add more) to build your code if your project
+            #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+            #- run: |
+            #   make bootstrap
+            #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v1

--- a/.github/workflows/coverage-reporting.yml
+++ b/.github/workflows/coverage-reporting.yml
@@ -3,7 +3,7 @@ name: Coverage Reporting
 on:
     push:
         branches:
-            - dev
+            - main
     pull_request:
 
 jobs:

--- a/.github/workflows/temp-default-branch-migration.yml
+++ b/.github/workflows/temp-default-branch-migration.yml
@@ -11,8 +11,11 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
             - name: Migrate default branch
-              uses: liyanchang/default-branch-migration@v1.0.2
+              uses: ./.github/actions/default-branch-migration
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   previous_default: dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,21 +11,21 @@ series [How to Contribute to an Open Source Project on GitHub][egghead]
 2.  Run `npm run setup` to install dependencies and run validations.
 3.  Create a branch for your PR with `git checkout -b pr/your-branch-name`
 
-> Tip: Keep your `dev` branch pointing at the original repository and make pull
+> Tip: Keep your `main` branch pointing at the original repository and make pull
 > requests from branches on your fork. To do this, run:
 >
 > ```
 > git remote add upstream https://github.com/doist/reactist.git
 > git fetch upstream
-> git branch --set-upstream-to=upstream/dev dev
+> git branch --set-upstream-to=upstream/main main
 > ```
 >
 > This will add the original repository as a "remote" called "upstream," Then
-> fetch the git information from that remote, then set your local `dev` branch
-> to use the upstream `dev` branch whenever you run `git pull`. Then you can
-> make all of your pull request branches based on this `dev` branch.
+> fetch the git information from that remote, then set your local `main` branch
+> to use the upstream `main` branch whenever you run `git pull`. Then you can
+> make all of your pull request branches based on this `main` branch.
 >
-> Whenever you want to update your version of `dev`, do a regular `git pull`.
+> Whenever you want to update your version of `main`, do a regular `git pull`.
 
 ## Committing and Pushing changes
 

--- a/stories/reactist/Reactist.stories.mdx
+++ b/stories/reactist/Reactist.stories.mdx
@@ -1,92 +1,112 @@
-import { Story, Meta } from '@storybook/addon-docs/blocks';
+import { Story, Meta } from '@storybook/addon-docs/blocks'
 
 <Meta title="Reactist" />
 
 ## Welcome
+
 Open source React components made with ❤️ by Doist.
 
 ## How to use
-You can add Reactist to your project by installing it from npm:  
-`npm install @doist/reactist`  
-If you prefer to include static files grab the [minified build from the dist folder](https://github.com/Doist/reactist/tree/develop/dist).
+
+You can add Reactist to your project by installing it from npm:
+`npm install @doist/reactist`
+If you prefer to include static files, download the latest tarball from the [package page](https://github.com/Doist/reactist/packages/60435) and include the following files in your project:
+`/dist/reactist.cjs.production.min.js`
+`/styles/reactist.css`
 
 A detailed explanation and examples on how to use each component can be accessed by clicking on the component name on the left.
 
 ## Development
 
-First clone the repository to your local machine by running:  
-`git clone git@github.com:Doist/reactist.git`  
-We identified two major modes of development for Reactist. First, running an interactive storybook and see the changes you make to a component in an isolated environment. This is especially helpful when developing new components. And second, improving existing components in real-life applications.  
+First clone the repository to your local machine by running:
+`git clone git@github.com:Doist/reactist.git`
+We identified two major modes of development for Reactist. First, running an interactive storybook and see the changes you make to a component in an isolated environment. This is especially helpful when developing new components. And second, improving existing components in real-life applications.
 
 #### Storybook
-For the first development mode run:  
-`npm run storybook`  
-This boots up a development server with hot reloading on http://localhost:6006. You can iterate on the components in the existing stories or add a completely new one.  
+
+For the first development mode run:
+`npm run storybook`
+This boots up a development server with hot reloading on http://localhost:6006. You can iterate on the components in the existing stories or add a completely new one.
 
 #### Inside your application
 
-For the second development mode you can leverage  
-`npm link`  
-First run:  
-`npm run start`  
+For the second development mode you can leverage
+`npm link`
+First run:
+`npm run start`
 this will update the build artifacts whenever you change something.
-In your real application you need to first delete the current *@doist/reactist* dependency and then link to your local one.
+In your real application you need to first delete the current _@doist/reactist_ dependency and then link to your local one.
+
 ```
 cd ~/your-app
 # delete current reactist dependency
-rm -rf ./node_modules/@doist/reactist  
+rm -rf ./node_modules/@doist/reactist
 
 # link local reactist version
 npm link ../reactist
 ```
-The relative path to reactist may need to be changed to match your local environment.  
+
+The relative path to reactist may need to be changed to match your local environment.
 
 To undo the changes and switch back to the reactist version from npm do the following:
+
 ```
 cd ~/your-app
 # first remove linked reactist dependency
 rm -rf ./node_modules/@doist/reactist
 
-# re-install reactist from npm (-E avoids updating the version / package-lock.json)  
+# re-install reactist from npm (-E avoids updating the version / package-lock.json)
 npm install -E @doist/reactist
 ```
 
 ### Development tips and tricks
 
-Independent of the development you operate in to produce a new build (e.g. before submitting a PR) run:  
+Independent of the development you operate in to produce a new build (e.g. before submitting a PR) run:
+
 ```
 npm run build
 ```
+
 **Note:** This will **not** update the docs. In case you want to update the docs you need to run:
+
 ```
 npm run build-storybook
 ```
 
-You can run our eslint checks with  
+You can run our eslint checks with
+
 ```
 npm run check
 ```
-It is mandatory to fix all linting errors before you make a pull request.  
 
-**Tip:** You can fix most of the errors automatically by running:  
+It is mandatory to fix all linting errors before you make a pull request.
+
+**Tip:** You can fix most of the errors automatically by running:
+
 ```
 npm run check -- --fix
 ```
 
 ## Testing
-Tests are executed with jest or by running:  
+
+Tests are executed with jest or by running:
+
 ```
 npm run test
 ```
 
 During development you may find it beneficial to continuously execute the tests. This works by running:
+
 ```
 npm run test-watch
 ```
+
 This also prints the current test coverage.
 
 MacOS users might need to upgrade watchman with
+
 ```
 brew install watchman
 ```
+
 when experiencing troubles with the watch mode. See this issue for details: https://github.com/facebook/jest/issues/1767


### PR DESCRIPTION
### Overview

An attempt to change all `dev` references I could find to `main`. The more critical ones are scripts and CI related files (GitHub Workflows / Azure Pipelines). The less critical ones, documentation files.

Please review carefully, and let me know if you think I've missed some references.

### Reference

<!-- GitHub issues, Twist threads, Zendesk tickets, Dropbox Paper specs, Zeplin/Figma mockups -->

### Test plan

If all pipelines and statuses checks are green, it should be good to go. But the real test will be after this is merged.