### PR TITLE
chore: tweak and fix `default-branch-migration` action

### DIFF
--- a/.github/actions/default-branch-migration/Dockerfile
+++ b/.github/actions/default-branch-migration/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.12
+
+RUN apk add --update jq curl git
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/default-branch-migration/action.yml
+++ b/.github/actions/default-branch-migration/action.yml
@@ -1,0 +1,23 @@
+name: 'Default Branch Migration'
+description: "Cleanly transition when changing the repository's default branch"
+author: 'Liyan David Chang (@liyanchang)'
+branding:
+    icon: fast-forward
+    color: black
+inputs:
+    github_token:
+        description: 'Token for the repo. Required. Mostly commonly, "$\{{ secrets.GITHUB_TOKEN }}"'
+        required: true
+    previous_default:
+        description: 'The default branch name you are moving away from. Required. Most commonly, "master"'
+        required: true
+    new_default:
+        description: 'The default branch name you are using going forward. Required. Most commonly, "main"'
+        required: true
+runs:
+    using: 'docker'
+    image: 'Dockerfile'
+    args:
+        - ${{ inputs.github_token }}
+        - ${{ inputs.previous_default }}
+        - ${{ inputs.new_default }}

--- a/.github/actions/default-branch-migration/entrypoint.sh
+++ b/.github/actions/default-branch-migration/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/sh -l
+
+GITHUB_TOKEN=$1
+PREVIOUS_DEFAULT=$2
+NEW_DEFAULT=$3
+GITHUB_API_URL="https://api.github.com"
+
+echo "Migrating from '$PREVIOUS_DEFAULT' to '$NEW_DEFAULT'"
+echo "Repo Name: $GITHUB_REPOSITORY"
+echo "Branch/Tag: $GITHUB_REF"
+
+if [ "$GITHUB_REF" != "refs/heads/$PREVIOUS_DEFAULT" ] && [ "$GITHUB_REF" != "refs/heads/$NEW_DEFAULT" ]; then
+	echo "Push not to either default branches ($NEW_DEFAULT or $PREVIOUS_DEFAULT)"
+	echo "Ignoring push to $GITHUB_REF"
+	exit
+fi;
+
+# Check the API to see what the current default branch is
+CURRENT_DEFAULT=$(curl --silent -u $GITHUB_ACTOR:$GITHUB_TOKEN $GITHUB_API_URL/repos/$GITHUB_REPOSITORY | jq -r .default_branch)
+echo "Default branch: $CURRENT_DEFAULT"
+
+if [ "$CURRENT_DEFAULT" = "$NEW_DEFAULT" ]; then
+	echo "Default has changed to $NEW_DEFAULT"
+	if [ "$GITHUB_REF" = "refs/heads/$PREVIOUS_DEFAULT" ]; then
+		echo "ERROR: Push to $PREVIOUS_DEFAULT even though default branch is now $NEW_DEFAULT"
+		exit 1
+	fi;
+	# Check all existing PRs to see if we should change their base
+	PRS=$(curl --silent -u $GITHUB_ACTOR:$GITHUB_TOKEN "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls?base=$PREVIOUS_DEFAULT&state=open")
+
+	# TODO: PATCH /repos/:owner/:repo/pulls/:pull_number
+	for row in $(echo $PRS | jq -r 'map(select(.locked == false)) | .[].url'); do
+		echo "Attempting to update $row"
+		curl --silent --show-error -w "Status Code: %{http_code}\n" --request PATCH --data '{"base": "'$NEW_DEFAULT'"}' -u $GITHUB_ACTOR:$GITHUB_TOKEN "$row"
+	done
+
+	exit
+fi;
+
+# The default is PREVIOUS_DEFAULT and a push to PREVIOUS_DEFAULT
+# so keep NEW_DEFAULT up to date
+if [ "$GITHUB_REF" = "refs/heads/$PREVIOUS_DEFAULT" ]; then
+	echo "Update $NEW_DEFAULT to match $PREVIOUS_DEFAULT"
+	GIT_REPO="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+	# Specify repo folder as target so it's clear what folder to cd into
+	git clone --depth 3 -b $PREVIOUS_DEFAULT $GIT_REPO target
+	cd target
+	git checkout -b $NEW_DEFAULT $PREVIOUS_DEFAULT
+	git push --set-upstream origin $NEW_DEFAULT
+	exit
+fi;

--- a/.github/workflows/temp-default-branch-migration.yml
+++ b/.github/workflows/temp-default-branch-migration.yml
@@ -11,8 +11,11 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
             - name: Migrate default branch
-              uses: liyanchang/default-branch-migration@v1.0.2
+              uses: ./.github/actions/default-branch-migration
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   previous_default: dev


### PR DESCRIPTION
### Overview

Unfortunately, the original `default-branch-migration` action seems to have an issue when trying to keep `dev` and `main` in sync. This PR moves the action code into the repository so that we can tweak it to our liking and fix any issues (such as the one just described).
