### PR TITLE
Ensure Super key gets sent to translation function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+## 9.1.6
+
+-   [Feature] Change `KeyboardShortcut` to treat `Super` as a key to be translated
+
 ## 9.1.5
 
 -   [Fix] Prevent menu items with `aria-disabled` set to `false` from being disabled

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/reactist",
-    "version": "9.1.5",
+    "version": "9.1.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doist/reactist",
     "description": "Open source React components by Doist",
     "author": "Henning Muszynski <henning@doist.com> (http://doist.com)",
-    "version": "9.1.5",
+    "version": "9.1.6",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": "git+https://github.com/Doist/reactist.git",

--- a/src/components/keyboard-shortcut/__snapshots__/keyboard-shortcut.test.tsx.snap
+++ b/src/components/keyboard-shortcut/__snapshots__/keyboard-shortcut.test.tsx.snap
@@ -82,6 +82,35 @@ exports[`KeyboardShortcut only capitalizes a non-modifier part if the overall sh
 </div>
 `;
 
+exports[`KeyboardShortcut recognizes "Super" as a special key to be translated 1`] = `
+<div>
+  <span
+    class="reactist_keyboard_shortcut"
+  >
+    <kbd>
+      <kbd>
+        [super]
+      </kbd>
+      <kbd>
+        q
+      </kbd>
+    </kbd>
+  </span>
+  <span
+    class="reactist_keyboard_shortcut reactist_keyboard_shortcut--macos"
+  >
+    <kbd>
+      <kbd>
+        Super
+      </kbd>
+      <kbd>
+        q
+      </kbd>
+    </kbd>
+  </span>
+</div>
+`;
+
 exports[`KeyboardShortcut recognizes mod/cmd as a modifier that behaves differently in macOS and outside macOS 1`] = `
 <div>
   <span

--- a/src/components/keyboard-shortcut/keyboard-shortcut.test.tsx
+++ b/src/components/keyboard-shortcut/keyboard-shortcut.test.tsx
@@ -51,4 +51,11 @@ describe('KeyboardShortcut', () => {
         })
         expect(element).toMatchSnapshot()
     })
+
+    it('recognizes "Super" as a special key to be translated', () => {
+        const element = renderKeyboardShortcut('super + q', {
+            translateKey: (modifier) => `[${modifier}]`,
+        })
+        expect(element).toMatchSnapshot()
+    })
 })

--- a/src/components/keyboard-shortcut/keyboard-shortcut.tsx
+++ b/src/components/keyboard-shortcut/keyboard-shortcut.tsx
@@ -45,7 +45,7 @@ function hasModifiers(str: string) {
 }
 
 function isSpecialKey(str: string) {
-    return /^(mod|cmd|ctrl|control|alt|shift|space)$/i.test(str)
+    return /^(mod|cmd|ctrl|control|alt|shift|space|super)$/i.test(str)
 }
 
 function parseKeys(shortcut: string, isMac: boolean, translateKey: TranslateKey) {


### PR DESCRIPTION
## Short description

This makes a small tweak to `KeyboardShortcut`.
The component already has a `translateKey` prop, where you can define a translation function,
that will display certain modifiers in a different way.

So far, this was not possible with the `Super` key.
In this PR, I treat it as a `special` key to be translated, just like `Cmd` and others.

This way, the calling component gets a chance to translate the `Super` key. 

On Windows, super is an alien term, so we want to translate it to `Win` or `Windows` there,
this PR enables that by ensuring `translatekey` is called for `Super` key as well.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

New feature
<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->
