### PR TITLE
feat: Add `lineHeight` prop to `<Text>`

### DIFF
--- a/src/new-components/default-styles.less
+++ b/src/new-components/default-styles.less
@@ -36,6 +36,12 @@
     --reactist-font-weight-medium: 500;
     --reactist-font-weight-strong: 700;
 
+    /* line heights */
+    --reactist-line-height-caption: 16px;
+    --reactist-line-height-copy: 18px;
+    --reactist-line-height-body: 21px;
+    --reactist-line-height-subtitle: 20px;
+
     /* border and separator colors */
     --reactist-framework-separator: rgb(230, 230, 230);
     --reactist-framework-border: rgb(214, 214, 214);

--- a/src/new-components/text/text.module.css
+++ b/src/new-components/text/text.module.css
@@ -31,6 +31,22 @@
     color: var(--reactist-chromatic-content-red);
 }
 
+.lineHeight-caption-paragraph {
+    line-height: var(--reactist-line-height-caption);
+}
+
+.lineHeight-copy-paragraph {
+    line-height: var(--reactist-line-height-copy);
+}
+
+.lineHeight-body-paragraph {
+    line-height: var(--reactist-line-height-body);
+}
+
+.lineHeight-subtitle-paragraph {
+    line-height: var(--reactist-line-height-subtitle);
+}
+
 /* truncated text */
 
 .line-clamp-1 {

--- a/src/new-components/text/text.stories.tsx
+++ b/src/new-components/text/text.stories.tsx
@@ -24,7 +24,7 @@ export default {
 export function TextStory() {
     return (
         <section className="story">
-            <Stack space="medium">
+            <Stack space="medium" paddingBottom="xlarge">
                 <Text size="subtitle" weight="regular">
                     Subtitle Regular
                 </Text>
@@ -40,7 +40,16 @@ export function TextStory() {
                 <Text size="subtitle" weight="bold">
                     Subtitle Bold
                 </Text>
+                <Text size="subtitle" lineHeight="paragraph">
+                    Subtitle with the lineHeight prop set to paragraph. Lorem ipsum dolor sit, amet
+                    consectetur adipisicing elit. Provident cumque recusandae quibusdam, veniam cum
+                    illo? Inventore, doloremque necessitatibus! Sequi porro alias mollitia,
+                    temporibus quidem, aut modi tempora placeat laborum eos sapiente necessitatibus
+                    autem ipsum officia rerum distinctio consectetur tenetur qui!
+                </Text>
+            </Stack>
 
+            <Stack space="medium" paddingBottom="xlarge">
                 <Text size="body" weight="regular">
                     Body Regular
                 </Text>
@@ -56,7 +65,16 @@ export function TextStory() {
                 <Text size="body" weight="bold">
                     Body Bold
                 </Text>
+                <Text size="body" lineHeight="paragraph">
+                    Body with the lineHeight prop set to paragraph. Lorem ipsum dolor sit, amet
+                    consectetur adipisicing elit. Provident cumque recusandae quibusdam, veniam cum
+                    illo? Inventore, doloremque necessitatibus! Sequi porro alias mollitia,
+                    temporibus quidem, aut modi tempora placeat laborum eos sapiente necessitatibus
+                    autem ipsum officia rerum distinctio consectetur tenetur qui!
+                </Text>
+            </Stack>
 
+            <Stack space="medium" paddingBottom="xlarge">
                 <Text size="copy" weight="regular">
                     Copy Regular
                 </Text>
@@ -72,7 +90,16 @@ export function TextStory() {
                 <Text size="copy" weight="bold">
                     Copy Bold
                 </Text>
+                <Text size="copy" lineHeight="paragraph">
+                    Copy with the lineHeight prop set to paragraph. Lorem ipsum dolor sit, amet
+                    consectetur adipisicing elit. Provident cumque recusandae quibusdam, veniam cum
+                    illo? Inventore, doloremque necessitatibus! Sequi porro alias mollitia,
+                    temporibus quidem, aut modi tempora placeat laborum eos sapiente necessitatibus
+                    autem ipsum officia rerum distinctio consectetur tenetur qui!
+                </Text>
+            </Stack>
 
+            <Stack space="medium" paddingBottom="xlarge">
                 <Text size="caption" weight="regular">
                     Caption Regular
                 </Text>
@@ -87,6 +114,13 @@ export function TextStory() {
                 </Text>
                 <Text size="caption" weight="bold">
                     Caption Bold
+                </Text>
+                <Text size="caption" lineHeight="paragraph">
+                    Caption with the lineHeight prop set to paragraph. Lorem ipsum dolor sit, amet
+                    consectetur adipisicing elit. Provident cumque recusandae quibusdam, veniam cum
+                    illo? Inventore, doloremque necessitatibus! Sequi porro alias mollitia,
+                    temporibus quidem, aut modi tempora placeat laborum eos sapiente necessitatibus
+                    autem ipsum officia rerum distinctio consectetur tenetur qui!
                 </Text>
             </Stack>
         </section>

--- a/src/new-components/text/text.tsx
+++ b/src/new-components/text/text.tsx
@@ -11,6 +11,7 @@ type TextProps = {
     component?: ComponentTypes
     children: React.ReactNode
     size?: 'caption' | 'copy' | 'body' | 'subtitle'
+    lineHeight?: 'paragraph' | 'unset'
     weight?: 'regular' | 'semibold' | 'bold'
     tone?: Tone
     lineClamp?: 1 | 2 | 3 | 4 | 5 | '1' | '2' | '3' | '4' | '5'
@@ -21,6 +22,7 @@ const Text = forwardRefWithAs<TextProps>(function Text(
         component = 'span',
         size = 'body',
         weight = 'regular',
+        lineHeight = 'unset',
         tone = 'normal',
         children,
         lineClamp,
@@ -39,6 +41,9 @@ const Text = forwardRefWithAs<TextProps>(function Text(
                 styles.text,
                 size !== 'body' ? getClassNames(styles, 'size', size) : null,
                 weight !== 'regular' ? getClassNames(styles, 'weight', weight) : null,
+                lineHeight !== 'unset'
+                    ? getClassNames(styles, 'lineHeight', `${size}-${lineHeight}`)
+                    : null,
                 tone !== 'normal' ? getClassNames(styles, 'tone', tone) : null,
                 lineClampMultipleLines ? styles.lineClamp : null,
                 lineClamp ? getClassNames(styles, 'line-clamp', lineClamp.toString()) : null,


### PR DESCRIPTION
## Short description

This adds a "default" line-height to the Text component's various sizes. While there is only one value available for each size, it's not applied by default unless the `lineHeight="paragraph"` prop is provided so as to not introduce a breaking change and affect existing layouts. 

Line height values are from [Figma](https://www.figma.com/file/LYlWNzvhMDh907l07mPPQk/Product---Web?node-id=239%3A26&viewport=579%2C485%2C1) and also as requested by Alex at https://github.com/Doist/todoist-web/pull/3213

A similar change is added to Todoist's implementation without introducing the new `size` values at [`2729a83` (#3213)](https://github.com/Doist/todoist-web/pull/3213/commits/2729a83f4c74756e505b6ec3f99e70aad2f3506a)

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Next beta version
