### PR TITLE
fix: Add prop table for modal story

### DIFF
--- a/stories/components/Modal.stories.mdx
+++ b/stories/components/Modal.stories.mdx
@@ -151,47 +151,67 @@ The **Modal.Actions** displays an action bar on the bottom of the Modal. It work
 
 <!-- Helpers -->
 
-export const renderModal = (modal) => {
+export function renderModal(modal) {
     ReactDOM.render(modal, document.getElementById('modal_box'))
 }
-export const getStory = (text, modal, title) => (
-    <section className="story">
-        <p>{title}</p>
-        <div id="modal_box" />
-        <Button variant="primary" onClick={() => renderModal(modal)}>
-            {text}
-        </Button>
-    </section>
-)
+
+export function getStory(text, modal, title) {
+    return (
+        <section className="story">
+            <p>{title}</p>
+            <div id="modal_box" />
+            <Button variant="primary" onClick={() => renderModal(modal)}>
+                {text}
+            </Button>
+        </section>
+    )
+}
 
 <!-- Templates -->
 
-export const WithPlaygroundTemplate = ({ ...args }) => (
-    <section>
-        <Modal.Box {...args} closeOnOverlayClick>
-            <Modal.Header {...args} />
-            <Modal.Body {...args}>Some Content</Modal.Body>
-            <Modal.Actions>
-                <Button variant="secondary">Action 1</Button>
-                <Button variant="primary">Action 2</Button>
-            </Modal.Actions>
-        </Modal.Box>
-    </section>
-)
+export function WithPlaygroundTemplate(args) {
+    const { title, subtitle, plain, medium, large, showCloseIcon, closeOnOverlayClick } = args
+    return (
+        <section>
+            <Modal.Box large={large} medium={medium} closeOnOverlayClick={closeOnOverlayClick}>
+                <Modal.Header title={title} subtitle={subtitle} />
+                <Modal.Body plain={plain} showCloseIcon={showCloseIcon}>
+                    Some Content
+                </Modal.Body>
+                <Modal.Actions>
+                    <Button variant="secondary">Action 1</Button>
+                    <Button variant="primary">Action 2</Button>
+                </Modal.Actions>
+            </Modal.Box>
+        </section>
+    )
+}
 
-export const ModalTemplate = (args) => {
+export function ModalTemplate(args) {
+    const {
+        title,
+        subtitle,
+        body,
+        buttonTitle,
+        buttonText,
+        medium,
+        plain,
+        large,
+        showCloseIcon,
+        closeOnOverlayClick,
+    } = args
     const modal = (
-        <Modal.Box {...args} closeOnOverlayClick>
-            <Modal.Header {...args} />
-            <Modal.Body {...args}>
-                <ReactMarkdown children={args.body} />
+        <Modal.Box large={large} medium={medium} closeOnOverlayClick={closeOnOverlayClick}>
+            <Modal.Header title={title} subtitle={subtitle} />
+            <Modal.Body plain={plain} showCloseIcon={showCloseIcon}>
+                <ReactMarkdown children={body} />
             </Modal.Body>
         </Modal.Box>
     )
-    return getStory(args.buttonText, modal, args.buttonTitle)
+    return getStory(buttonText, modal, buttonTitle)
 }
 
-export const WithActionsTemplate = () => {
+export function WithActionsTemplate() {
     const modal = (
         <Modal.Box closeOnOverlayClick>
             <Modal.Header title="Header of Modal" subtitle="This is a smaller description" />

--- a/stories/components/Modal.stories.mdx
+++ b/stories/components/Modal.stories.mdx
@@ -10,14 +10,76 @@ import './styles/modal_story.less'
     title="Modal"
     component={Modal}
     argTypes={{
-        text: {
+        title: {
+            name: 'title',
+            description: "The modal's title",
             control: {
-                type: null,
+                type: 'text',
+            },
+            table: {
+                type: {
+                    summary: 'string',
+                },
             },
         },
-        body: {
+        subtitle: {
+            name: 'subtitle',
+            description: "The modal's subtitle",
             control: {
-                type: null,
+                type: 'text',
+            },
+            table: {
+                type: {
+                    summary: 'string',
+                },
+            },
+        },
+        showCloseIcon: {
+            name: 'showCloseIcon',
+            description: "The modal's close icon",
+            control: {
+                type: 'boolean',
+            },
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+            },
+        },
+        medium: {
+            name: 'medium',
+            description: 'Medium sized modal',
+            control: {
+                type: 'boolean',
+            },
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+            },
+        },
+        large: {
+            name: 'large',
+            description: 'Large sized modal',
+            control: {
+                type: 'boolean',
+            },
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+            },
+        },
+        plain: {
+            name: 'plain',
+            description: 'A plain modal without styles',
+            control: {
+                type: 'boolean',
+            },
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
             },
         },
     }}
@@ -117,25 +179,16 @@ export const WithPlaygroundTemplate = ({ ...args }) => (
     </section>
 )
 
-export const ModalTemplate = ({
-    body = '',
-    title,
-    subtitle = '',
-    buttonTitle,
-    buttonText,
-    medium = false,
-    plain = false,
-    large = false,
-}) => {
+export const ModalTemplate = (args) => {
     const modal = (
-        <Modal.Box medium={medium} closeOnOverlayClick>
-            <Modal.Header title={title} subtitle={subtitle} />
-            <Modal.Body plain={plain}>
-                <ReactMarkdown children={body} />
+        <Modal.Box {...args} closeOnOverlayClick>
+            <Modal.Header {...args} />
+            <Modal.Body {...args}>
+                <ReactMarkdown children={args.body} />
             </Modal.Body>
         </Modal.Box>
     )
-    return getStory(buttonText, modal, buttonTitle)
+    return getStory(args.buttonText, modal, args.buttonTitle)
 }
 
 export const WithActionsTemplate = () => {
@@ -229,18 +282,9 @@ export const PlainMediumText = `The Body of a Modal can contain whatever you lik
                 with desktop publishing software like Aldus PageMaker including versions of Lorem
                 Ipsum.`
 
-<!-- Prop type tables -->
-<!--
-Modal story is made up of several components, each with their own arguments,
-so <ArgsTable of={Modal} /> wouldn't work in this case. Instead, we specify the
-props of one story i.e. Playground
--->
-
-<ArgsTable story="Playground" />
-
 <!-- Stories -->
 
-<Preview withToolbar>
+<Canvas withToolbar>
     <Story
         parameters={{ docs: { source: { type: 'code' } } }}
         name="Playground"
@@ -255,9 +299,11 @@ props of one story i.e. Playground
     >
         {WithPlaygroundTemplate.bind({})}
     </Story>
-</Preview>
+</Canvas>
 
-<Preview withToolbar>
+<ArgsTable story="Playground" />
+
+<Canvas withToolbar>
     <Story
         parameters={{ docs: { source: { type: 'code' } } }}
         name="Modal header"
@@ -269,9 +315,9 @@ props of one story i.e. Playground
     >
         {ModalTemplate.bind({})}
     </Story>
-</Preview>
+</Canvas>
 
-<Preview withToolbar>
+<Canvas withToolbar>
     <Story
         parameters={{ docs: { source: { type: 'code' } } }}
         name="Modal header and body"
@@ -285,18 +331,18 @@ props of one story i.e. Playground
     >
         {ModalTemplate.bind({})}
     </Story>
-</Preview>
+</Canvas>
 
-<Preview withToolbar>
+<Canvas withToolbar>
     <Story
         parameters={{ docs: { source: { type: 'code' } } }}
         name="Modal header body with actions"
     >
         {WithActionsTemplate.bind({})}
     </Story>
-</Preview>
+</Canvas>
 
-<Preview withToolbar>
+<Canvas withToolbar>
     <Story
         parameters={{ docs: { source: { type: 'code' } } }}
         name="Modal scrollable body"
@@ -306,12 +352,16 @@ props of one story i.e. Playground
             buttonTitle: 'Scrollable Body',
             buttonText: 'Click me to launch a Modal with Scrollable Body',
         }}
+        table={{
+            type: { summary: 'string' },
+            defaultValue: { summary: 'Hello' },
+        }}
     >
         {ModalTemplate.bind({})}
     </Story>
-</Preview>
+</Canvas>
 
-<Preview withToolbar>
+<Canvas withToolbar>
     <Story
         parameters={{ docs: { source: { type: 'code' } } }}
         name="Plain medium modal"
@@ -326,4 +376,4 @@ props of one story i.e. Playground
     >
         {ModalTemplate.bind({})}
     </Story>
-</Preview>
+</Canvas>


### PR DESCRIPTION
## Short description

During the upgrade to Storybook 6 and the shift to MDX stories, we noticed that the prop types for the `Modal` story weren't inferred due to its structure (a component with subcomponents with their own props and types as its type). 
After a lot of researching online and creating a discussion in [Storybook's repo](https://github.com/storybookjs/storybook/discussions/15573), we have yet to find a way to automatically infer prop types of this component. Two workarounds were: **a)** inferring prop types from one of the actual stories i.e. Playground and not the component or **b)** manually set these props and their descriptions (the former wouldn't handle this). In this PR, I've attempted option **b.** 

Granted it may not be the best solution, as any changes made to the `Modal` component will mean inconsistent prop types between itself and the story. But I'm struggling to see how we can get these inferred without completely changing the structure of our `Modal` component so that it's no longer a component made up of [types](https://github.com/Doist/reactist/blob/main/src/components/modal/modal.tsx#L228).

This PR can serve as a bit of an exploratory area if we're not happy with this approach. Feel free to suggest alternative ways to achieve this or even contribute to this branch.

## PR Checklist

- Run storybook 
- Visit the modal story and click on it's Docs tab
	- [ ] Make sure you see a prop table with all the same Modal props we see under the Control tab
	- [ ] Make sure all props under this table have descriptions
	- [ ] Make sure that changing the prop's controls changes the Playground story.