### PR TITLE
Add tests for the layout-related components

### DIFF
--- a/src/new-components/box/box.test.tsx
+++ b/src/new-components/box/box.test.tsx
@@ -1,0 +1,151 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Box, BoxProps } from './'
+
+describe('Box', () => {
+    it('renders its children as its content', () => {
+        render(
+            <Box data-testid="box">
+                Hello <strong>world</strong>!
+            </Box>,
+        )
+        expect(screen.getByTestId('box').innerHTML).toMatchInlineSnapshot(
+            `"Hello <strong>world</strong>!"`,
+        )
+    })
+
+    it('can be rendered as any HTML element', () => {
+        render(<Box data-testid="box" as="section" />)
+        expect(screen.getByTestId('box').tagName).toBe('SECTION')
+    })
+
+    it('applies any extra className given to it', () => {
+        render(<Box data-testid="box" className="custom" />)
+        expect(screen.getByTestId('box')).toHaveClass('custom')
+    })
+
+    it('applies some extra class names corresponding to other styling props', () => {
+        render(
+            <Box
+                data-testid="box"
+                display="inlineBlock"
+                maxWidth="xlarge"
+                minWidth="xsmall"
+                border="standard"
+                borderRadius="full"
+                background="aside"
+                overflow="hidden"
+            />,
+        )
+        expect(screen.getByTestId('box')).toHaveClass(
+            'box',
+            'display-inlineBlock',
+            'minWidth-xsmall',
+            'maxWidth-xlarge',
+            'bg-aside',
+            'borderRadius-full',
+            'border-standard',
+            'overflow-hidden',
+        )
+    })
+
+    it('only applies flex-related styles if display="flex" or display="inlineFlex" is given', () => {
+        const flexProps: Partial<BoxProps> = {
+            flexDirection: 'column',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            justifyContent: 'center',
+        }
+        const classNames = [
+            'flexDirection-column',
+            'flexWrap-wrap',
+            'alignItems-center',
+            'justifyContent-center',
+        ]
+        const { rerender } = render(<Box data-testid="box" display="flex" {...flexProps} />)
+        expect(screen.getByTestId('box')).toHaveClass('box', 'display-flex', ...classNames)
+
+        rerender(<Box data-testid="box" display="inlineFlex" {...flexProps} />)
+        expect(screen.getByTestId('box')).toHaveClass('box', 'display-inlineFlex', ...classNames)
+
+        rerender(<Box data-testid="box" display="inline" {...flexProps} />)
+        expect(screen.getByTestId('box')).toHaveClass('display-inline')
+        expect(screen.getByTestId('box')).not.toHaveClass('display-flex', ...classNames)
+    })
+
+    it('applies different class names when a responsive prop is given', () => {
+        render(<Box data-testid="box" display={['none', 'block', 'inline']} />)
+        expect(screen.getByTestId('box')).toHaveClass(
+            'display-none',
+            'tablet-display-block',
+            'desktop-display-inline',
+        )
+    })
+
+    describe('padding', () => {
+        it('allows to apply padding in all directions at once', () => {
+            render(<Box data-testid="box" padding="small" />)
+            expect(screen.getByTestId('box')).toHaveClass(
+                'paddingTop-small',
+                'paddingRight-small',
+                'paddingBottom-small',
+                'paddingLeft-small',
+            )
+        })
+
+        it('allows to apply padding to the horizontal and vertical directions separately', () => {
+            render(<Box data-testid="box" paddingX="xlarge" paddingY="xsmall" />)
+            expect(screen.getByTestId('box')).toHaveClass(
+                'paddingTop-xsmall',
+                'paddingRight-xlarge',
+                'paddingBottom-xsmall',
+                'paddingLeft-xlarge',
+            )
+        })
+
+        it('allows to apply padding to each direction individually', () => {
+            render(
+                <Box
+                    data-testid="box"
+                    paddingTop="xsmall"
+                    paddingRight="small"
+                    paddingBottom="medium"
+                    paddingLeft="large"
+                />,
+            )
+            expect(screen.getByTestId('box')).toHaveClass(
+                'paddingTop-xsmall',
+                'paddingRight-small',
+                'paddingBottom-medium',
+                'paddingLeft-large',
+            )
+        })
+
+        it('overrides more general padding settings with individual ones when given', () => {
+            const { rerender } = render(
+                <Box
+                    data-testid="box"
+                    padding="medium"
+                    paddingX="large"
+                    paddingY="small"
+                    paddingTop="xsmall"
+                    paddingRight="xlarge"
+                />,
+            )
+            expect(screen.getByTestId('box')).toHaveClass(
+                'paddingTop-xsmall', // set via paddingTop explicitly, overrides paddingY and padding
+                'paddingRight-xlarge', // set via paddingRight explicitly, overrides paddingX and padding
+                'paddingBottom-small', // set via paddingY
+                'paddingLeft-large', // set via paddingX
+            )
+
+            rerender(<Box data-testid="box" padding="medium" paddingRight="xsmall" />)
+            expect(screen.getByTestId('box')).toHaveClass(
+                'paddingTop-medium',
+                'paddingRight-xsmall', // set via paddingRight explicitly, overrides padding
+                'paddingBottom-medium',
+                'paddingLeft-medium',
+            )
+        })
+    })
+})

--- a/src/new-components/columns/columns.test.tsx
+++ b/src/new-components/columns/columns.test.tsx
@@ -1,0 +1,309 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { runSpaceTests } from '../test-helpers'
+import { Columns, Column, ColumnWidth } from './'
+
+const columnWidths: Array<ColumnWidth> = [
+    '1/2',
+    '1/3',
+    '1/4',
+    '1/5',
+    '2/3',
+    '2/5',
+    '3/4',
+    '3/5',
+    '4/5',
+    'auto',
+    'content',
+]
+
+describe('Columns', () => {
+    it('can be rendered as any HTML element', () => {
+        render(<Columns data-testid="container" as="label" />)
+        expect(screen.getByTestId('container').tagName).toBe('LABEL')
+    })
+
+    it('renders its child Column elements as its content', () => {
+        render(
+            <Columns data-testid="container">
+                {columnWidths.map((width) => (
+                    <Column key={width} width={width}>
+                        {width}
+                    </Column>
+                ))}
+            </Columns>,
+        )
+        expect(screen.getByTestId('container').childNodes).toHaveLength(columnWidths.length)
+        expect(screen.getByTestId('container')).toHaveTextContent(columnWidths.join(''))
+    })
+
+    it('does not acknowledge the className prop, but exceptionallySetClassName instead', () => {
+        render(
+            <Columns
+                data-testid="container"
+                // @ts-expect-error
+                className="wrong"
+                exceptionallySetClassName="right"
+            />,
+        )
+        expect(screen.getByTestId('container')).not.toHaveClass('wrong')
+        expect(screen.getByTestId('container')).toHaveClass('right')
+    })
+
+    it('renders as a flex row container that grows to fill the width if inside a flex parent', () => {
+        render(<Columns data-testid="container" />)
+        expect(screen.getByTestId('container')).toHaveClass(
+            'display-flex',
+            'flexDirection-row',
+            'flexGrow-1',
+        )
+    })
+
+    it('sets the columns horizontal alignment', () => {
+        // test with no explicit alignment first
+        const { rerender } = render(<Columns data-testid="container" />)
+        expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexStart')
+
+        // left-aligned horizontally
+        rerender(<Columns data-testid="container" align="left" />)
+        expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexStart')
+
+        // centered horizontally
+        rerender(<Columns data-testid="container" align="center" />)
+        expect(screen.getByTestId('container')).toHaveClass('justifyContent-center')
+
+        // right-aligned horizontally
+        rerender(<Columns data-testid="container" align="right" />)
+        expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexEnd')
+    })
+
+    it('sets the columns vertical alignment', () => {
+        // test with no explicit alignment first
+        const { rerender } = render(<Columns data-testid="container" />)
+        expect(screen.getByTestId('container')).toHaveClass('alignItems-flexStart')
+
+        // top-aligned vertically
+        rerender(<Columns data-testid="container" alignY="top" />)
+        expect(screen.getByTestId('container')).toHaveClass('alignItems-flexStart')
+
+        // centered vertically
+        rerender(<Columns data-testid="container" alignY="center" />)
+        expect(screen.getByTestId('container')).toHaveClass('alignItems-center')
+
+        // bottom-aligned vertically
+        rerender(<Columns data-testid="container" alignY="bottom" />)
+        expect(screen.getByTestId('container')).toHaveClass('alignItems-flexEnd')
+    })
+
+    it('is set to render stacked when instructed to collapse below a certain responsive viewport width', () => {
+        const { rerender } = render(<Columns data-testid="container" />)
+        const container = screen.getByTestId('container')
+
+        // never collapses by default
+        expect(container).toHaveClass('display-flex', 'flexDirection-row')
+        expect(container).not.toHaveClass('flexDirection-column')
+        expect(container).not.toHaveClass('tablet-flexDirection-row')
+        expect(container).not.toHaveClass('tablet-flexDirection-column')
+        expect(container).not.toHaveClass('desktop-flexDirection-row')
+        expect(container).not.toHaveClass('desktop-flexDirection-column')
+
+        // collapses on screens of tablet-like sizes or smaller
+        rerender(<Columns data-testid="container" collapseBelow="tablet" />)
+        expect(container).toHaveClass(
+            'display-flex',
+            'flexDirection-column',
+            'tablet-flexDirection-row',
+        )
+        expect(container).not.toHaveClass('flexDirection-row')
+        expect(container).not.toHaveClass('tablet-flexDirection-column')
+        expect(container).not.toHaveClass('desktop-flexDirection-row')
+        expect(container).not.toHaveClass('desktop-flexDirection-column')
+
+        // collapses on screens of tablet-like sizes or smaller
+        rerender(<Columns data-testid="container" collapseBelow="desktop" />)
+        expect(container).toHaveClass(
+            'display-flex',
+            'flexDirection-column',
+            'tablet-flexDirection-column',
+            'desktop-flexDirection-row',
+        )
+        expect(container).not.toHaveClass('flexDirection-row')
+        expect(container).not.toHaveClass('tablet-flexDirection-row')
+        expect(container).not.toHaveClass('desktop-flexDirection-column')
+    })
+
+    it('applies some extra class names corresponding to other layout-related props', () => {
+        render(
+            <Columns
+                data-testid="container"
+                maxWidth="large"
+                minWidth="small"
+                padding="medium"
+                border="standard"
+                borderRadius="standard"
+                background="highlight"
+            />,
+        )
+        expect(screen.getByTestId('container')).toHaveClass(
+            'box',
+            'minWidth-small',
+            'maxWidth-large',
+            'paddingTop-medium',
+            'paddingRight-medium',
+            'paddingBottom-medium',
+            'paddingLeft-medium',
+            'bg-highlight',
+            'borderRadius-standard',
+            'border-standard',
+        )
+    })
+
+    describe('space', () => {
+        it('applies the class names to space child elements out', () => {
+            render(<Columns data-testid="stack" space="medium" />)
+            expect(screen.getByTestId('stack')).toHaveClass('space-medium')
+        })
+    })
+
+    runSpaceTests(Columns)
+})
+
+describe('Column', () => {
+    it('renders its children as its content', () => {
+        render(
+            <Columns>
+                <Column data-testid="column">
+                    Hello <strong>world</strong>!
+                </Column>
+            </Columns>,
+        )
+        expect(screen.getByTestId('column').innerHTML).toMatchInlineSnapshot(
+            `"Hello <strong>world</strong>!"`,
+        )
+    })
+
+    it('can be rendered as any HTML element', () => {
+        render(
+            <Columns>
+                <Column data-testid="column" as="li" />
+            </Columns>,
+        )
+        expect(screen.getByTestId('column').tagName).toBe('LI')
+    })
+
+    it('does not acknowledge the className prop, but exceptionallySetClassName instead', () => {
+        render(
+            <Columns>
+                <Column
+                    data-testid="column"
+                    // @ts-expect-error
+                    className="bad"
+                    exceptionallySetClassName="good"
+                />
+            </Columns>,
+        )
+        expect(screen.getByTestId('column')).not.toHaveClass('bad')
+        expect(screen.getByTestId('column')).toHaveClass('good')
+    })
+
+    it('is set to width auto by default', () => {
+        render(
+            <Columns>
+                <Column data-testid="column" />
+            </Columns>,
+        )
+        const column = screen.getByTestId('column')
+        expect(column).toHaveClass('columnWidth-auto')
+        for (const width of columnWidths) {
+            if (width === 'auto') continue
+            expect(column).not.toHaveClass(`columnWidth-${width.replace('/', '-')}`)
+        }
+    })
+
+    it('is set to zero mininum width regardless of the width prop value', () => {
+        const { rerender } = render(
+            <Columns>
+                <Column data-testid="column" width="content" />
+            </Columns>,
+        )
+        const column = screen.getByTestId('column')
+
+        for (const width of columnWidths) {
+            rerender(
+                <Columns>
+                    <Column data-testid="column" width={width} />
+                </Columns>,
+            )
+            expect(column).toHaveClass('minWidth-0')
+        }
+    })
+
+    it('is set to the specified width', () => {
+        const { rerender } = render(
+            <Columns>
+                <Column data-testid="column" width="content" />
+            </Columns>,
+        )
+        const column = screen.getByTestId('column')
+
+        // for width="content" no css class is added
+        for (const width of columnWidths) {
+            expect(column).not.toHaveClass(`columnWidth-${width.replace('/', '-')}`)
+        }
+
+        // for all non-content widths, a single corresponding css class is added
+        for (const actualWidth of columnWidths) {
+            if (actualWidth === 'content') continue
+            rerender(
+                <Columns>
+                    <Column data-testid="column" width={actualWidth} />
+                </Columns>,
+            )
+            for (const width of columnWidths) {
+                if (width === actualWidth) continue
+                expect(column).not.toHaveClass(`columnWidth-${width.replace('/', '-')}`)
+            }
+            expect(column).toHaveClass(`columnWidth-${actualWidth.replace('/', '-')}`)
+        }
+    })
+
+    it('is set to fill the available width unless width="content"', () => {
+        const { rerender } = render(
+            <Columns>
+                <Column data-testid="column" width="content" />
+            </Columns>,
+        )
+        const column = screen.getByTestId('column')
+        expect(column).not.toHaveClass('width-full')
+
+        for (const width of columnWidths) {
+            if (width === 'content') continue
+            rerender(
+                <Columns>
+                    <Column data-testid="column" width={width} />
+                </Columns>,
+            )
+            expect(column).toHaveClass('width-full')
+        }
+    })
+
+    it('is set to shrink only if width="content"', () => {
+        const { rerender } = render(
+            <Columns>
+                <Column data-testid="column" width="content" />
+            </Columns>,
+        )
+        const column = screen.getByTestId('column')
+        expect(column).toHaveClass('flexShrink-0')
+
+        for (const width of columnWidths) {
+            if (width === 'content') continue
+            rerender(
+                <Columns>
+                    <Column data-testid="column" width={width} />
+                </Columns>,
+            )
+            expect(column).not.toHaveClass('flexShrink-0')
+        }
+    })
+})

--- a/src/new-components/columns/columns.tsx
+++ b/src/new-components/columns/columns.tsx
@@ -62,7 +62,15 @@ interface ColumnsProps extends ReusableBoxProps {
 }
 
 const Columns = polymorphicComponent<'div', ColumnsProps>(function Columns(
-    { space, align, alignY, collapseBelow, children, exceptionallySetClassName, ...props },
+    {
+        space,
+        align = 'left',
+        alignY = 'top',
+        collapseBelow,
+        children,
+        exceptionallySetClassName,
+        ...props
+    },
     ref,
 ) {
     return (
@@ -77,24 +85,11 @@ const Columns = polymorphicComponent<'div', ColumnsProps>(function Columns(
                     : 'row'
             }
             display="flex"
-            alignItems={mapResponsiveProp(alignY, (alignY) => {
-                switch (alignY) {
-                    case 'top':
-                        return 'flexStart'
-
-                    case 'bottom':
-                        return 'flexEnd'
-
-                    case 'baseline':
-                        return 'baseline'
-
-                    case 'center':
-                    default:
-                        return 'center'
-                }
-            })}
+            alignItems={mapResponsiveProp(alignY, (alignY) =>
+                alignY === 'top' ? 'flexStart' : alignY === 'bottom' ? 'flexEnd' : alignY,
+            )}
             justifyContent={mapResponsiveProp(align, (align) =>
-                align === 'left' ? 'flexStart' : align === 'right' ? 'flexEnd' : 'center',
+                align === 'left' ? 'flexStart' : align === 'right' ? 'flexEnd' : align,
             )}
             flexGrow={1}
             ref={ref}

--- a/src/new-components/inline/inline.test.tsx
+++ b/src/new-components/inline/inline.test.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { runSpaceTests } from '../test-helpers'
+import { Inline } from './'
+
+describe('Inline', () => {
+    it('does not acknowledge the className prop, but exceptionallySetClassName instead', () => {
+        render(
+            <Inline
+                data-testid="inline"
+                // @ts-expect-error
+                className="wrong"
+                exceptionallySetClassName="right"
+            />,
+        )
+        expect(screen.getByTestId('inline')).toHaveClass('right')
+        expect(screen.getByTestId('inline')).not.toHaveClass('wrong')
+    })
+
+    it('can be rendered as any HTML element', () => {
+        render(<Inline data-testid="inline" as="nav" />)
+        expect(screen.getByTestId('inline').tagName).toBe('NAV')
+    })
+
+    it('renders its children as its content', () => {
+        render(
+            <Inline data-testid="inline">
+                <div>one</div>
+                <div>two</div>
+            </Inline>,
+        )
+        expect(screen.getByTestId('inline').innerHTML).toMatchInlineSnapshot(
+            `"<div>one</div><div>two</div>"`,
+        )
+    })
+
+    it('applies some extra class names corresponding to other layout-related props', () => {
+        render(
+            <Inline
+                data-testid="inline"
+                maxWidth="large"
+                minWidth="small"
+                padding="medium"
+                border="standard"
+                borderRadius="standard"
+                background="highlight"
+            />,
+        )
+        expect(screen.getByTestId('inline')).toHaveClass(
+            'box',
+            'minWidth-small',
+            'maxWidth-large',
+            'paddingTop-medium',
+            'paddingRight-medium',
+            'paddingBottom-medium',
+            'paddingLeft-medium',
+            'bg-highlight',
+            'borderRadius-standard',
+            'border-standard',
+        )
+    })
+
+    runSpaceTests(Inline)
+})

--- a/src/new-components/stack/__snapshots__/stack.test.tsx.snap
+++ b/src/new-components/stack/__snapshots__/stack.test.tsx.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Stack renders dividers when instructed to do so: dividers="regular" 1`] = `
+<div
+  class="box display-block"
+  data-testid="stack"
+>
+  <div>
+    one
+  </div>
+  <hr
+    class="divider box display-block"
+  />
+  <div>
+    two
+  </div>
+  <hr
+    class="divider box display-block"
+  />
+  <div>
+    three
+  </div>
+</div>
+`;
+
+exports[`Stack renders dividers when instructed to do so: dividers="strong" 1`] = `
+<div
+  class="box display-block"
+  data-testid="stack"
+>
+  <div>
+    one
+  </div>
+  <hr
+    class="divider weight-strong box display-block"
+  />
+  <div>
+    two
+  </div>
+  <hr
+    class="divider weight-strong box display-block"
+  />
+  <div>
+    three
+  </div>
+</div>
+`;
+
+exports[`Stack renders dividers when instructed to do so: dividers={true} 1`] = `
+<div
+  class="box display-block"
+  data-testid="stack"
+>
+  <div>
+    one
+  </div>
+  <hr
+    class="divider box display-block"
+  />
+  <div>
+    two
+  </div>
+  <hr
+    class="divider box display-block"
+  />
+  <div>
+    three
+  </div>
+</div>
+`;

--- a/src/new-components/stack/stack.test.tsx
+++ b/src/new-components/stack/stack.test.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { runSpaceTests } from '../test-helpers'
+import { Stack } from './'
+
+describe('Stack', () => {
+    it('does not acknowledge the className prop, but exceptionallySetClassName instead', () => {
+        render(
+            <Stack
+                data-testid="stack"
+                // @ts-expect-error
+                className="wrong"
+                exceptionallySetClassName="right"
+            />,
+        )
+        expect(screen.getByTestId('stack')).toHaveClass('right')
+        expect(screen.getByTestId('stack')).not.toHaveClass('wrong')
+    })
+
+    it('can be rendered as any HTML element', () => {
+        render(<Stack data-testid="stack" as="nav" />)
+        expect(screen.getByTestId('stack').tagName).toBe('NAV')
+    })
+
+    it('renders its children as its content', () => {
+        render(
+            <Stack data-testid="stack">
+                <div>one</div>
+                <div>two</div>
+            </Stack>,
+        )
+        expect(screen.getByTestId('stack').innerHTML).toMatchInlineSnapshot(
+            `"<div>one</div><div>two</div>"`,
+        )
+    })
+
+    it('renders dividers when instructed to do so', () => {
+        const { rerender } = render(
+            <Stack data-testid="stack" dividers>
+                <div>one</div>
+                <div>two</div>
+                <div>three</div>
+            </Stack>,
+        )
+        expect(screen.getByTestId('stack')).toMatchSnapshot('dividers={true}')
+
+        // regular dividers
+        rerender(
+            <Stack data-testid="stack" dividers="regular">
+                <div>one</div>
+                <div>two</div>
+                <div>three</div>
+            </Stack>,
+        )
+        expect(screen.getByTestId('stack')).toMatchSnapshot('dividers="regular"')
+
+        // strong dividers
+        rerender(
+            <Stack data-testid="stack" dividers="strong">
+                <div>one</div>
+                <div>two</div>
+                <div>three</div>
+            </Stack>,
+        )
+        expect(screen.getByTestId('stack')).toMatchSnapshot('dividers="strong"')
+    })
+
+    it('applies some extra class names corresponding to other layout-related props', () => {
+        render(
+            <Stack
+                data-testid="stack"
+                maxWidth="large"
+                minWidth="small"
+                padding="medium"
+                border="standard"
+                borderRadius="standard"
+                background="highlight"
+            />,
+        )
+        expect(screen.getByTestId('stack')).toHaveClass(
+            'box',
+            'minWidth-small',
+            'maxWidth-large',
+            'paddingTop-medium',
+            'paddingRight-medium',
+            'paddingBottom-medium',
+            'paddingLeft-medium',
+            'bg-highlight',
+            'borderRadius-standard',
+            'border-standard',
+        )
+    })
+
+    runSpaceTests(Stack)
+})

--- a/src/new-components/test-helpers.tsx
+++ b/src/new-components/test-helpers.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable jest/no-export */
+/* eslint-disable jest/valid-title */
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { ResponsiveProp } from './responsive-props'
+import { Space } from './common-types'
+
+type PropsWithSpace = { space?: ResponsiveProp<Space>; 'data-testid'?: string }
+
+const spaceValues: Array<Space> = ['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge']
+const testCases = spaceValues.map((space) => [space])
+
+function getSpaceClassNames(element: HTMLElement) {
+    return Array.from(element.classList).filter((className) => className.includes('space-'))
+}
+
+function runSpaceTests<Props extends PropsWithSpace>(Component: React.ComponentType<Props>) {
+    function renderTestCase(space: ResponsiveProp<Space>) {
+        // @ts-expect-error not sure how to properly type the Component argument above
+        render(<Component data-testid="subject" space={space} />)
+        return screen.getByTestId('subject')
+    }
+
+    describe('space', () => {
+        test.each(testCases)('it applies the styles needed for space="%s"', (space) => {
+            const subject = renderTestCase(space)
+            expect(getSpaceClassNames(subject)).toEqual([`space-${space}`])
+        })
+
+        it('allows to specify different spacing rules for different screen sizes', () => {
+            const subject = renderTestCase(['small', 'medium', 'large'])
+            expect(getSpaceClassNames(subject)).toEqual([
+                'space-small',
+                'tablet-space-medium',
+                'desktop-space-large',
+            ])
+        })
+    })
+}
+
+export { runSpaceTests }


### PR DESCRIPTION
## Short description

Adds the first new set of tests for the new design system components. I left it short, focusing on the layout components mostly, to make it easier to digest. And also to validate the approach.

Granted, most of these tests are not giving us the full confidence we'd expect. It all works by validating that certain class names are being added to the components, but we could still break things when touching the CSS files. My aim is to eventually add either visual regression tests, or Cypress component tests. I experimented with the latter, but I was not able to make it work in the short term. These tests are still valuable as they validate the logic inside JS code that decides what class names to apply.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

This is not going to be released yet. This is going to be merged in a PR where I'm gathering lots of tests.