### PR TITLE
Add Stack align prop to align items horizontally

### DIFF
--- a/src/new-components/box/box.tsx
+++ b/src/new-components/box/box.tsx
@@ -89,7 +89,7 @@ const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
     const resolvedPaddingRight = paddingRight ?? paddingX ?? padding
     const resolvedPaddingBottom = paddingBottom ?? paddingY ?? padding
     const resolvedPaddingLeft = paddingLeft ?? paddingX ?? padding
-    const isFlex = display === 'flex' || display === 'inlineFlex'
+    const omitFlex = typeof display === 'string' && display !== 'flex' && display !== 'inlineFlex'
 
     return React.createElement(
         component,
@@ -107,10 +107,10 @@ const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
                     getClassNames(styles, 'paddingRight', resolvedPaddingRight),
                     getClassNames(styles, 'paddingBottom', resolvedPaddingBottom),
                     getClassNames(styles, 'paddingLeft', resolvedPaddingLeft),
-                    isFlex ? getClassNames(styles, 'flexDirection', flexDirection) : null,
-                    isFlex ? getClassNames(styles, 'flexWrap', flexWrap) : null,
-                    isFlex ? getClassNames(styles, 'alignItems', alignItems) : null,
-                    isFlex ? getClassNames(styles, 'justifyContent', justifyContent) : null,
+                    omitFlex ? null : getClassNames(styles, 'flexDirection', flexDirection),
+                    omitFlex ? null : getClassNames(styles, 'flexWrap', flexWrap),
+                    omitFlex ? null : getClassNames(styles, 'alignItems', alignItems),
+                    omitFlex ? null : getClassNames(styles, 'justifyContent', justifyContent),
                     flexShrink != null
                         ? getClassNames(styles, 'flexShrink', String(flexShrink))
                         : null,

--- a/src/new-components/stack/stack.stories.tsx
+++ b/src/new-components/stack/stack.stories.tsx
@@ -21,9 +21,20 @@ export default {
     component: Stack,
     argTypes: {
         space: selectSize(),
+        align: selectWithNone(['left', 'center', 'right']),
         dividers: selectWithNone<DividerWeight>(['regular', 'strong']),
         ...reusableBoxProps(),
     },
+}
+
+const widths = [300, 360, 430, 280, 600, 490, 400]
+const heights = [80, 40, 60, 70, 90, 30, 100]
+
+function size(index: number) {
+    return {
+        width: widths[index % widths.length],
+        height: heights[index % heights.length],
+    }
 }
 
 export function InteractivePropsStory({
@@ -34,7 +45,7 @@ export function InteractivePropsStory({
         <Wrapper border={true}>
             <Stack {...args}>
                 {times(itemCount).map((i) => (
-                    <Placeholder key={i} label={i + 1} />
+                    <Placeholder key={i} label={i + 1} {...size(i)} />
                 ))}
             </Stack>
         </Wrapper>
@@ -49,10 +60,10 @@ export function ResponsiveStory({ itemCount }: { itemCount: number }) {
     return (
         <>
             <ResponsiveWidthRef />
-            <Wrapper>
-                <Stack space={['xsmall', 'medium', 'xlarge']}>
+            <Wrapper border title="Alignment and spacing changes as the viewport width changes">
+                <Stack space={['xsmall', 'medium', 'xxlarge']} align={['left', 'center', 'right']}>
                     {times(itemCount).map((i) => (
-                        <Placeholder key={i} label={i + 1} />
+                        <Placeholder key={i} label={i + 1} {...size(i)} />
                     ))}
                 </Stack>
             </Wrapper>
@@ -63,6 +74,7 @@ export function ResponsiveStory({ itemCount }: { itemCount: number }) {
 ResponsiveStory.argTypes = {
     itemCount: selectCount('Item count'),
     space: { control: false },
+    align: { control: false },
     dividers: { control: false },
     ...disableResponsiveProps,
 }

--- a/src/new-components/stack/stack.test.tsx
+++ b/src/new-components/stack/stack.test.tsx
@@ -91,5 +91,46 @@ describe('Stack', () => {
         )
     })
 
+    describe('align', () => {
+        it('allows to align its children to the left, center or right', () => {
+            // no explicit alignment
+            const { rerender } = render(<Stack data-testid="stack" />)
+            expect(screen.getByTestId('stack')).toHaveClass('display-block')
+            expect(screen.getByTestId('stack')).not.toHaveClass('display-flex')
+            expect(screen.getByTestId('stack')).not.toHaveClass('flexDirection-column')
+            expect(screen.getByTestId('stack')).not.toHaveClass('alignItems-center')
+
+            // aligned to the left (same as when there's no explicit alignment)
+            rerender(<Stack data-testid="stack" align="left" />)
+            expect(screen.getByTestId('stack')).toHaveClass('display-block')
+            expect(screen.getByTestId('stack')).not.toHaveClass('display-flex')
+            expect(screen.getByTestId('stack')).not.toHaveClass('flexDirection-column')
+            expect(screen.getByTestId('stack')).not.toHaveClass('alignItems-center')
+
+            // aligned to the center
+            rerender(<Stack data-testid="stack" align="center" />)
+            expect(screen.getByTestId('stack')).not.toHaveClass('display-block')
+            expect(screen.getByTestId('stack')).toHaveClass('display-flex')
+            expect(screen.getByTestId('stack')).toHaveClass('flexDirection-column')
+            expect(screen.getByTestId('stack')).toHaveClass('alignItems-center')
+
+            // aligned to the right
+            rerender(<Stack data-testid="stack" align="right" />)
+            expect(screen.getByTestId('stack')).not.toHaveClass('display-block')
+            expect(screen.getByTestId('stack')).toHaveClass('display-flex')
+            expect(screen.getByTestId('stack')).toHaveClass('flexDirection-column')
+            expect(screen.getByTestId('stack')).toHaveClass('alignItems-flexEnd')
+        })
+
+        it('supports specifying alignment based on viewport size', () => {
+            render(<Stack data-testid="stack" align={['left', 'center', 'right']} />)
+            expect(screen.getByTestId('stack')).toHaveClass('display-flex')
+            expect(screen.getByTestId('stack')).toHaveClass('flexDirection-column')
+            expect(screen.getByTestId('stack')).toHaveClass('alignItems-flexStart')
+            expect(screen.getByTestId('stack')).toHaveClass('tablet-alignItems-center')
+            expect(screen.getByTestId('stack')).toHaveClass('desktop-alignItems-flexEnd')
+        })
+    })
+
     runSpaceTests(Stack)
 })

--- a/src/new-components/stack/stack.tsx
+++ b/src/new-components/stack/stack.tsx
@@ -1,29 +1,46 @@
 import * as React from 'react'
 import flattenChildren from 'react-keyed-flatten-children'
 import { polymorphicComponent } from '../../utils/polymorphism'
-import { getClassNames } from '../responsive-props'
+import { getClassNames, mapResponsiveProp } from '../responsive-props'
 import { Box } from '../box'
 import { Divider } from '../divider'
 
 import type { ResponsiveProp } from '../responsive-props'
 import type { Space } from '../common-types'
-import type { ReusableBoxProps } from '../box'
+import type { BoxProps, ReusableBoxProps } from '../box'
 import type { DividerWeight } from '../divider'
 
 import styles from './stack.module.css'
 
 interface StackProps extends ReusableBoxProps {
+    /** Space between items */
     space?: ResponsiveProp<Space>
+    /** Align items horizontally */
+    align?: ResponsiveProp<'left' | 'center' | 'right'>
+    /** Add dividers if `true`, or specify the weight of the dividers to add */
     dividers?: boolean | DividerWeight
 }
 
 const Stack = polymorphicComponent<'div', StackProps>(function Stack(
-    { as, space, dividers = false, children, exceptionallySetClassName, ...props },
+    { as, space, align = 'left', dividers = false, children, exceptionallySetClassName, ...props },
     ref,
 ) {
+    const alignProps: BoxProps | undefined =
+        align === 'left'
+            ? undefined
+            : {
+                  width: 'full',
+                  flexDirection: 'column',
+                  display: 'flex',
+                  alignItems: mapResponsiveProp(align, (align) =>
+                      align === 'left' ? 'flexStart' : align === 'right' ? 'flexEnd' : 'center',
+                  ),
+              }
+
     return (
         <Box
             {...props}
+            {...alignProps}
             as={as}
             className={[exceptionallySetClassName, getClassNames(styles, 'space', space)]}
             ref={ref}

--- a/src/new-components/storybook-helper.tsx
+++ b/src/new-components/storybook-helper.tsx
@@ -91,7 +91,9 @@ function Wrapper({
     return (
         <Stack space="small">
             {title ? <Heading level="2">{title}</Heading> : null}
-            <Box style={border ? { border: '1px dotted black' } : undefined}>{children}</Box>
+            <Box width="full" style={border ? { border: '1px dotted black' } : undefined}>
+                {children}
+            </Box>
         </Stack>
     )
 }


### PR DESCRIPTION
## Short description

Adds a new `align: 'left' | 'center' | 'right'` prop to `Stack` to allow horizontally aligning the stack items.

## PR Checklist

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Not to be released yet. This is being merged in a base PR where we're gathering some of the changes these days into a single weekly-ish release schedule.

## Demo

https://user-images.githubusercontent.com/15199/129598982-b14916ec-c1bb-49ba-8eea-898b379a78e3.mp4
