### PR TITLE
Change how responsive props are provided

### DIFF
--- a/src/new-components/box/box.stories.tsx
+++ b/src/new-components/box/box.stories.tsx
@@ -56,7 +56,7 @@ export function ResponsiveStory() {
             <ResponsiveWidthRef />
             <Stack space="large" dividers>
                 <Wrapper title="Stacks elements on mobile">
-                    <Box display="flex" flexDirection={['column', 'row']}>
+                    <Box display="flex" flexDirection={{ mobile: 'column', tablet: 'row' }}>
                         <Placeholder label="One" height={30} />
                         <Placeholder label="Two" height={30} />
                         <Placeholder label="Three" height={30} />
@@ -66,7 +66,11 @@ export function ResponsiveStory() {
                     <Box
                         style={{ backgroundColor: 'lightgreen' }}
                         display="flex"
-                        justifyContent={['flexStart', 'center', 'flexEnd']}
+                        justifyContent={{
+                            mobile: 'flexStart',
+                            tablet: 'center',
+                            desktop: 'flexEnd',
+                        }}
                     >
                         <div>One</div>
                         <div>Two</div>
@@ -77,7 +81,11 @@ export function ResponsiveStory() {
                     <Box
                         style={{ height: '120px' }}
                         display="flex"
-                        alignItems={['flexEnd', 'center', 'flexStart']}
+                        alignItems={{
+                            mobile: 'flexEnd',
+                            tablet: 'center',
+                            desktop: 'flexStart',
+                        }}
                     >
                         <Placeholder label="One" height={30} />
                         <Placeholder label="Two" height={60} />

--- a/src/new-components/box/box.test.tsx
+++ b/src/new-components/box/box.test.tsx
@@ -70,11 +70,19 @@ describe('Box', () => {
 
         rerender(<Box data-testid="box" display="inline" {...flexProps} />)
         expect(screen.getByTestId('box')).toHaveClass('display-inline')
-        expect(screen.getByTestId('box')).not.toHaveClass('display-flex', ...classNames)
+        expect(screen.getByTestId('box')).not.toHaveClass('display-flex')
+        for (const className of classNames) {
+            expect(screen.getByTestId('box')).not.toHaveClass(className)
+        }
     })
 
     it('applies different class names when a responsive prop is given', () => {
-        render(<Box data-testid="box" display={['none', 'block', 'inline']} />)
+        render(
+            <Box
+                data-testid="box"
+                display={{ mobile: 'none', tablet: 'block', desktop: 'inline' }}
+            />,
+        )
         expect(screen.getByTestId('box')).toHaveClass(
             'display-none',
             'tablet-display-block',

--- a/src/new-components/columns/columns.stories.tsx
+++ b/src/new-components/columns/columns.stories.tsx
@@ -245,8 +245,20 @@ export function ResponsiveStory(args: PartialProps<typeof Columns>) {
         <>
             <ResponsiveWidthRef />
             <Stack space="large" dividers>
+                <Wrapper title="Columns alignment changes as the viewport size changes">
+                    <Columns
+                        space="medium"
+                        align={{ mobile: 'left', tablet: 'center', desktop: 'right' }}
+                    >
+                        {times(5).map((i) => (
+                            <Column width="content" key={i}>
+                                <Placeholder label={i + 1} height={50} />
+                            </Column>
+                        ))}
+                    </Columns>
+                </Wrapper>
                 <Wrapper title="Space between columns reduces on smaller screen sizes">
-                    <Columns space={['xsmall', 'medium', 'xlarge']}>
+                    <Columns space={{ mobile: 'xsmall', tablet: 'medium', desktop: 'xlarge' }}>
                         {times(5).map((i) => (
                             <Column key={i}>
                                 <Placeholder label={i + 1} height={50} />

--- a/src/new-components/columns/columns.test.tsx
+++ b/src/new-components/columns/columns.test.tsx
@@ -59,79 +59,6 @@ describe('Columns', () => {
         )
     })
 
-    it('sets the columns horizontal alignment', () => {
-        // test with no explicit alignment first
-        const { rerender } = render(<Columns data-testid="container" />)
-        expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexStart')
-
-        // left-aligned horizontally
-        rerender(<Columns data-testid="container" align="left" />)
-        expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexStart')
-
-        // centered horizontally
-        rerender(<Columns data-testid="container" align="center" />)
-        expect(screen.getByTestId('container')).toHaveClass('justifyContent-center')
-
-        // right-aligned horizontally
-        rerender(<Columns data-testid="container" align="right" />)
-        expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexEnd')
-    })
-
-    it('sets the columns vertical alignment', () => {
-        // test with no explicit alignment first
-        const { rerender } = render(<Columns data-testid="container" />)
-        expect(screen.getByTestId('container')).toHaveClass('alignItems-flexStart')
-
-        // top-aligned vertically
-        rerender(<Columns data-testid="container" alignY="top" />)
-        expect(screen.getByTestId('container')).toHaveClass('alignItems-flexStart')
-
-        // centered vertically
-        rerender(<Columns data-testid="container" alignY="center" />)
-        expect(screen.getByTestId('container')).toHaveClass('alignItems-center')
-
-        // bottom-aligned vertically
-        rerender(<Columns data-testid="container" alignY="bottom" />)
-        expect(screen.getByTestId('container')).toHaveClass('alignItems-flexEnd')
-    })
-
-    it('is set to render stacked when instructed to collapse below a certain responsive viewport width', () => {
-        const { rerender } = render(<Columns data-testid="container" />)
-        const container = screen.getByTestId('container')
-
-        // never collapses by default
-        expect(container).toHaveClass('display-flex', 'flexDirection-row')
-        expect(container).not.toHaveClass('flexDirection-column')
-        expect(container).not.toHaveClass('tablet-flexDirection-row')
-        expect(container).not.toHaveClass('tablet-flexDirection-column')
-        expect(container).not.toHaveClass('desktop-flexDirection-row')
-        expect(container).not.toHaveClass('desktop-flexDirection-column')
-
-        // collapses on screens of tablet-like sizes or smaller
-        rerender(<Columns data-testid="container" collapseBelow="tablet" />)
-        expect(container).toHaveClass(
-            'display-flex',
-            'flexDirection-column',
-            'tablet-flexDirection-row',
-        )
-        expect(container).not.toHaveClass('flexDirection-row')
-        expect(container).not.toHaveClass('tablet-flexDirection-column')
-        expect(container).not.toHaveClass('desktop-flexDirection-row')
-        expect(container).not.toHaveClass('desktop-flexDirection-column')
-
-        // collapses on screens of tablet-like sizes or smaller
-        rerender(<Columns data-testid="container" collapseBelow="desktop" />)
-        expect(container).toHaveClass(
-            'display-flex',
-            'flexDirection-column',
-            'tablet-flexDirection-column',
-            'desktop-flexDirection-row',
-        )
-        expect(container).not.toHaveClass('flexDirection-row')
-        expect(container).not.toHaveClass('tablet-flexDirection-row')
-        expect(container).not.toHaveClass('desktop-flexDirection-column')
-    })
-
     it('applies some extra class names corresponding to other layout-related props', () => {
         render(
             <Columns
@@ -158,10 +85,110 @@ describe('Columns', () => {
         )
     })
 
-    describe('space', () => {
-        it('applies the class names to space child elements out', () => {
-            render(<Columns data-testid="stack" space="medium" />)
-            expect(screen.getByTestId('stack')).toHaveClass('space-medium')
+    describe('align', () => {
+        it('sets the columns horizontal alignment', () => {
+            // test with no explicit alignment first
+            const { rerender } = render(<Columns data-testid="container" />)
+            expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexStart')
+
+            // left-aligned horizontally
+            rerender(<Columns data-testid="container" align="left" />)
+            expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexStart')
+
+            // centered horizontally
+            rerender(<Columns data-testid="container" align="center" />)
+            expect(screen.getByTestId('container')).toHaveClass('justifyContent-center')
+
+            // right-aligned horizontally
+            rerender(<Columns data-testid="container" align="right" />)
+            expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexEnd')
+        })
+
+        it('supports specifying a responsive value', () => {
+            render(
+                <Columns
+                    data-testid="container"
+                    align={{ mobile: 'left', tablet: 'center', desktop: 'right' }}
+                />,
+            )
+            expect(screen.getByTestId('container')).toHaveClass(
+                'justifyContent-flexStart',
+                'tablet-justifyContent-center',
+                'desktop-justifyContent-flexEnd',
+            )
+        })
+    })
+
+    describe('alignY', () => {
+        it('sets the columns vertical alignment', () => {
+            // test with no explicit alignment first
+            const { rerender } = render(<Columns data-testid="container" />)
+            expect(screen.getByTestId('container')).toHaveClass('alignItems-flexStart')
+
+            // top-aligned vertically
+            rerender(<Columns data-testid="container" alignY="top" />)
+            expect(screen.getByTestId('container')).toHaveClass('alignItems-flexStart')
+
+            // centered vertically
+            rerender(<Columns data-testid="container" alignY="center" />)
+            expect(screen.getByTestId('container')).toHaveClass('alignItems-center')
+
+            // bottom-aligned vertically
+            rerender(<Columns data-testid="container" alignY="bottom" />)
+            expect(screen.getByTestId('container')).toHaveClass('alignItems-flexEnd')
+        })
+
+        it('supports specifying a responsive value', () => {
+            render(
+                <Columns
+                    data-testid="container"
+                    alignY={{ mobile: 'top', tablet: 'center', desktop: 'bottom' }}
+                />,
+            )
+            expect(screen.getByTestId('container')).toHaveClass(
+                'alignItems-flexStart',
+                'tablet-alignItems-center',
+                'desktop-alignItems-flexEnd',
+            )
+        })
+    })
+
+    describe('collapseBellow', () => {
+        it('is set to render stacked when instructed to collapse below a certain responsive viewport width', () => {
+            const { rerender } = render(<Columns data-testid="container" />)
+            const container = screen.getByTestId('container')
+
+            // never collapses by default
+            expect(container).toHaveClass('display-flex', 'flexDirection-row')
+            expect(container).not.toHaveClass('flexDirection-column')
+            expect(container).not.toHaveClass('tablet-flexDirection-row')
+            expect(container).not.toHaveClass('tablet-flexDirection-column')
+            expect(container).not.toHaveClass('desktop-flexDirection-row')
+            expect(container).not.toHaveClass('desktop-flexDirection-column')
+
+            // collapses on screens of tablet-like sizes or smaller
+            rerender(<Columns data-testid="container" collapseBelow="tablet" />)
+            expect(container).toHaveClass(
+                'display-flex',
+                'flexDirection-column',
+                'tablet-flexDirection-row',
+            )
+            expect(container).not.toHaveClass('flexDirection-row')
+            expect(container).not.toHaveClass('tablet-flexDirection-column')
+            expect(container).not.toHaveClass('desktop-flexDirection-row')
+            expect(container).not.toHaveClass('desktop-flexDirection-column')
+
+            // collapses on screens of tablet-like sizes or smaller
+            rerender(<Columns data-testid="container" collapseBelow="desktop" />)
+            expect(container).toHaveClass(
+                'display-flex',
+                'flexDirection-column',
+                'tablet-flexDirection-column',
+                'desktop-flexDirection-row',
+            )
+            expect(container).not.toHaveClass('flexDirection-row')
+            expect(container).not.toHaveClass('tablet-flexDirection-row')
+            expect(container).not.toHaveClass('desktop-flexDirection-column')
         })
     })
 

--- a/src/new-components/columns/columns.tsx
+++ b/src/new-components/columns/columns.tsx
@@ -52,7 +52,7 @@ const Column = polymorphicComponent<'div', ColumnProps>(function Column(
 
 type ColumnsHorizontalAlignment = 'left' | 'center' | 'right'
 type ColumnsVerticalAlignment = 'top' | 'center' | 'bottom' | 'baseline'
-type ColumnsCollapseBelow = ResponsiveBreakpoints
+type ColumnsCollapseBelow = Exclude<ResponsiveBreakpoints, 'mobile'>
 
 interface ColumnsProps extends ReusableBoxProps {
     space?: ResponsiveProp<Space>
@@ -79,9 +79,9 @@ const Columns = polymorphicComponent<'div', ColumnsProps>(function Columns(
             className={[exceptionallySetClassName, getClassNames(styles, 'space', space)]}
             flexDirection={
                 collapseBelow === 'desktop'
-                    ? ['column', 'column', 'row']
+                    ? { mobile: 'column', tablet: 'column', desktop: 'row' }
                     : collapseBelow === 'tablet'
-                    ? ['column', 'row']
+                    ? { mobile: 'column', tablet: 'row' }
                     : 'row'
             }
             display="flex"

--- a/src/new-components/inline/inline.stories.tsx
+++ b/src/new-components/inline/inline.stories.tsx
@@ -56,13 +56,18 @@ export function ResponsiveStory() {
             <ResponsiveWidthRef />
             <Stack space="medium">
                 <Wrapper title="Change the viewport width to see how spacing changes" border={true}>
-                    <Inline space={['xsmall', 'medium', 'xlarge']}>{renderInlineContent()}</Inline>
+                    <Inline space={{ mobile: 'xsmall', tablet: 'medium', desktop: 'xlarge' }}>
+                        {renderInlineContent()}
+                    </Inline>
                 </Wrapper>
                 <Wrapper
                     title="Change the viewport width to see how alignment changes"
                     border={true}
                 >
-                    <Inline space="xsmall" align={['left', 'center', 'right']}>
+                    <Inline
+                        space="xsmall"
+                        align={{ mobile: 'left', tablet: 'center', desktop: 'right' }}
+                    >
                         {renderInlineContent()}
                     </Inline>
                 </Wrapper>

--- a/src/new-components/inline/inline.test.tsx
+++ b/src/new-components/inline/inline.test.tsx
@@ -60,5 +60,73 @@ describe('Inline', () => {
         )
     })
 
+    describe('align', () => {
+        it('specifies how to align items horizontally', () => {
+            // test with no explicit alignment first
+            const { rerender } = render(<Inline data-testid="container" />)
+            expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexStart')
+
+            // left-aligned horizontally
+            rerender(<Inline data-testid="container" align="left" />)
+            expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexStart')
+
+            // centered horizontally
+            rerender(<Inline data-testid="container" align="center" />)
+            expect(screen.getByTestId('container')).toHaveClass('justifyContent-center')
+
+            // right-aligned horizontally
+            rerender(<Inline data-testid="container" align="right" />)
+            expect(screen.getByTestId('container')).toHaveClass('justifyContent-flexEnd')
+        })
+
+        it('supports specifying a responsive value', () => {
+            render(
+                <Inline
+                    data-testid="container"
+                    align={{ mobile: 'left', tablet: 'center', desktop: 'right' }}
+                />,
+            )
+            expect(screen.getByTestId('container')).toHaveClass(
+                'justifyContent-flexStart',
+                'tablet-justifyContent-center',
+                'desktop-justifyContent-flexEnd',
+            )
+        })
+    })
+
+    describe('alignY', () => {
+        it('specifies how to align items vertically', () => {
+            // test with no explicit alignment first
+            const { rerender } = render(<Inline data-testid="container" />)
+            expect(screen.getByTestId('container')).toHaveClass('alignItems-center')
+
+            // top-aligned vertically
+            rerender(<Inline data-testid="container" alignY="top" />)
+            expect(screen.getByTestId('container')).toHaveClass('alignItems-flexStart')
+
+            // centered vertically
+            rerender(<Inline data-testid="container" alignY="center" />)
+            expect(screen.getByTestId('container')).toHaveClass('alignItems-center')
+
+            // bottom-aligned vertically
+            rerender(<Inline data-testid="container" alignY="bottom" />)
+            expect(screen.getByTestId('container')).toHaveClass('alignItems-flexEnd')
+        })
+
+        it('supports specifying a responsive value', () => {
+            render(
+                <Inline
+                    data-testid="container"
+                    alignY={{ mobile: 'top', tablet: 'center', desktop: 'bottom' }}
+                />,
+            )
+            expect(screen.getByTestId('container')).toHaveClass(
+                'alignItems-flexStart',
+                'tablet-alignItems-center',
+                'desktop-alignItems-flexEnd',
+            )
+        })
+    })
+
     runSpaceTests(Inline)
 })

--- a/src/new-components/stack/stack.stories.tsx
+++ b/src/new-components/stack/stack.stories.tsx
@@ -61,7 +61,10 @@ export function ResponsiveStory({ itemCount }: { itemCount: number }) {
         <>
             <ResponsiveWidthRef />
             <Wrapper border title="Alignment and spacing changes as the viewport width changes">
-                <Stack space={['xsmall', 'medium', 'xxlarge']} align={['left', 'center', 'right']}>
+                <Stack
+                    space={{ mobile: 'xsmall', tablet: 'medium', desktop: 'xlarge' }}
+                    align={{ mobile: 'left', tablet: 'center', desktop: 'right' }}
+                >
                     {times(itemCount).map((i) => (
                         <Placeholder key={i} label={i + 1} {...size(i)} />
                     ))}
@@ -81,26 +84,24 @@ ResponsiveStory.argTypes = {
 
 export function NestedStacksStory(args: PartialProps<typeof Stack>) {
     return (
-        <>
-            <Stack {...args}>
-                <Heading level="1">
-                    Parent stack with space=&ldquo;{args.space ?? 'none'}&rdquo;
-                </Heading>
-                <Stack space="xsmall">
-                    <Heading level="2">Nested stack with space=&ldquo;xsmall&rdquo;</Heading>
-                    <Placeholder />
-                    <Placeholder />
-                    <Placeholder />
-                </Stack>
-                <Stack space="xsmall">
-                    <Heading level="2">Nested stack with space=&ldquo;xsmall&rdquo;</Heading>
-                    <Placeholder />
-                    <Placeholder />
-                    <Placeholder />
-                    <Placeholder />
-                </Stack>
+        <Stack {...args}>
+            <Heading level="1">
+                Parent stack with space=&ldquo;{args.space ?? 'none'}&rdquo;
+            </Heading>
+            <Stack space="xsmall">
+                <Heading level="2">Nested stack with space=&ldquo;xsmall&rdquo;</Heading>
+                <Placeholder />
+                <Placeholder />
+                <Placeholder />
             </Stack>
-        </>
+            <Stack space="xsmall">
+                <Heading level="2">Nested stack with space=&ldquo;xsmall&rdquo;</Heading>
+                <Placeholder />
+                <Placeholder />
+                <Placeholder />
+                <Placeholder />
+            </Stack>
+        </Stack>
     )
 }
 

--- a/src/new-components/stack/stack.test.tsx
+++ b/src/new-components/stack/stack.test.tsx
@@ -123,7 +123,12 @@ describe('Stack', () => {
         })
 
         it('supports specifying alignment based on viewport size', () => {
-            render(<Stack data-testid="stack" align={['left', 'center', 'right']} />)
+            render(
+                <Stack
+                    data-testid="stack"
+                    align={{ mobile: 'left', tablet: 'center', desktop: 'right' }}
+                />,
+            )
             expect(screen.getByTestId('stack')).toHaveClass('display-flex')
             expect(screen.getByTestId('stack')).toHaveClass('flexDirection-column')
             expect(screen.getByTestId('stack')).toHaveClass('alignItems-flexStart')

--- a/src/new-components/test-helpers.tsx
+++ b/src/new-components/test-helpers.tsx
@@ -28,7 +28,7 @@ function runSpaceTests<Props extends PropsWithSpace>(Component: React.ComponentT
         })
 
         it('allows to specify different spacing rules for different screen sizes', () => {
-            const subject = renderTestCase(['small', 'medium', 'large'])
+            const subject = renderTestCase({ mobile: 'small', tablet: 'medium', desktop: 'large' })
             expect(getSpaceClassNames(subject)).toEqual([
                 'space-small',
                 'tablet-space-medium',


### PR DESCRIPTION
## Short description

Changes how we provide responsive props, from this:

```jsx
<Component prop={[mobileValue, tabletOrLargerValue, desktopOrLargerValue]} />
```

to an object-like notation instead:

```jsx
<Component prop={{ mobile: '…', tablet: '…', desktop: '…' }} />
```

See https://twist.com/a/1585/ch/190200/t/2693346/c/69556610

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)
