### PR TITLE
Text and Heading tests, new stories and improvements

### DIFF
--- a/src/new-components/box/box.module.css
+++ b/src/new-components/box/box.module.css
@@ -328,3 +328,45 @@
 .border-standard {
     border: 1px solid var(--reactist-framework-border);
 }
+
+/* text-align */
+.textAlign-start {
+    text-align: start;
+}
+.textAlign-center {
+    text-align: center;
+}
+.textAlign-end {
+    text-align: end;
+}
+.textAlign-justify {
+    text-align: justify;
+}
+@media (min-width: 768px /* --reactist-breakpoint-tablet */) {
+    .tablet-textAlign-start {
+        text-align: start;
+    }
+    .tablet-textAlign-center {
+        text-align: center;
+    }
+    .tablet-textAlign-end {
+        text-align: end;
+    }
+    .tablet-textAlign-justify {
+        text-align: justify;
+    }
+}
+@media (min-width: 992px /* --reactist-breakpoint-desktop */) {
+    .desktop-textAlign-start {
+        text-align: start;
+    }
+    .desktop-textAlign-center {
+        text-align: center;
+    }
+    .desktop-textAlign-end {
+        text-align: end;
+    }
+    .desktop-textAlign-justify {
+        text-align: justify;
+    }
+}

--- a/src/new-components/box/box.test.tsx
+++ b/src/new-components/box/box.test.tsx
@@ -90,6 +90,35 @@ describe('Box', () => {
         )
     })
 
+    describe('textAlign="…"', () => {
+        it('adds the appropriate class names', () => {
+            const { rerender } = render(<Box data-testid="box" textAlign="start" />)
+            const boxElement = screen.getByTestId('box')
+            expect(boxElement).not.toHaveClass('textAlign-start')
+            expect(boxElement).not.toHaveClass('textAlign-center')
+            expect(boxElement).not.toHaveClass('textAlign-end')
+            expect(boxElement).not.toHaveClass('textAlign-justify')
+
+            for (const align of ['center', 'end', 'justify'] as const) {
+                rerender(<Box data-testid="box" textAlign={align} />)
+                expect(boxElement).toHaveClass(`textAlign-${align}`)
+            }
+        })
+
+        it('supports responsive values', () => {
+            render(
+                <Box
+                    data-testid="box"
+                    textAlign={{ mobile: 'start', tablet: 'center', desktop: 'end' }}
+                />,
+            )
+            const boxElement = screen.getByTestId('box')
+            expect(boxElement).toHaveClass('textAlign-start')
+            expect(boxElement).toHaveClass('tablet-textAlign-center')
+            expect(boxElement).toHaveClass('desktop-textAlign-end')
+        })
+    })
+
     describe('padding', () => {
         it('allows to apply padding in all directions at once', () => {
             render(<Box data-testid="box" padding="small" />)

--- a/src/new-components/box/box.tsx
+++ b/src/new-components/box/box.tsx
@@ -63,6 +63,7 @@ interface BoxProps extends WithEnhancedClassName, ReusableBoxProps, BoxMarginPro
     overflow?: BoxOverflow
     width?: 'full'
     height?: 'full'
+    textAlign?: ResponsiveProp<'start' | 'center' | 'end' | 'justify'>
 }
 
 const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
@@ -84,6 +85,7 @@ const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
         borderRadius,
         minWidth,
         maxWidth,
+        textAlign = 'start',
         padding,
         paddingY,
         paddingX,
@@ -128,6 +130,7 @@ const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
                     position !== 'static' ? getClassNames(styles, 'position', position) : null,
                     minWidth != null ? getClassNames(styles, 'minWidth', String(minWidth)) : null,
                     getClassNames(styles, 'maxWidth', maxWidth),
+                    textAlign !== 'start' ? getClassNames(styles, 'textAlign', textAlign) : null,
                     // padding
                     getClassNames(paddingStyles, 'paddingTop', resolvedPaddingTop),
                     getClassNames(paddingStyles, 'paddingRight', resolvedPaddingRight),

--- a/src/new-components/heading/heading.module.css
+++ b/src/new-components/heading/heading.module.css
@@ -83,27 +83,27 @@ h6.size-larger {
 
 /* truncated text */
 
-.line-clamp-1 {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-}
-
-.lineClamp {
+.lineClampMultipleLines {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     overflow: hidden;
 }
 
-.line-clamp-2 {
+.lineClamp-1 {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.lineClamp-2 {
     -webkit-line-clamp: 2;
 }
-.line-clamp-3 {
+.lineClamp-3 {
     -webkit-line-clamp: 3;
 }
-.line-clamp-4 {
+.lineClamp-4 {
     -webkit-line-clamp: 4;
 }
-.line-clamp-5 {
+.lineClamp-5 {
     -webkit-line-clamp: 5;
 }

--- a/src/new-components/heading/heading.stories.tsx
+++ b/src/new-components/heading/heading.stories.tsx
@@ -2,24 +2,11 @@ import React from 'react'
 
 import { Stack } from '../stack'
 import { Heading } from './heading'
-import { select, selectWithNone } from '../storybook-helper'
+import { ResponsiveWidthRef, select, selectWithNone } from '../storybook-helper'
 
 export default {
     title: 'Design system/Heading',
     component: Heading,
-    argTypes: {
-        level: select(['1', '2', '3', '4', '5', '6'], '1'),
-        size: selectWithNone(['largest', 'larger', 'smaller']),
-        weight: select(['regular', 'light'], 'regular'),
-        lineClamp: select([1, 2, 3, 4, 5], 1),
-        children: {
-            control: {
-                type: 'text',
-            },
-            defaultValue: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit',
-        },
-        tone: select(['normal', 'secondary', 'danger'], 'normal'),
-    },
 }
 
 export function HeadingStory() {
@@ -79,15 +66,6 @@ export function HeadingStory() {
     )
 }
 
-HeadingStory.argTypes = {
-    level: { control: false },
-    size: { control: false },
-    weight: { control: false },
-    lineClamp: { control: false },
-    children: { control: false },
-    tone: { control: false },
-}
-
 export function TruncatedHeadingStory() {
     return (
         <section className="story">
@@ -106,22 +84,45 @@ export function TruncatedHeadingStory() {
     )
 }
 
-TruncatedHeadingStory.argTypes = {
-    level: { control: false },
-    size: { control: false },
-    weight: { control: false },
-    lineClamp: { control: false },
-    children: { control: false },
-    tone: { control: false },
+export function ResponsiveHeadingStory(props: React.ComponentProps<typeof Heading>) {
+    return (
+        <>
+            <ResponsiveWidthRef />
+            <Heading {...props} align={{ mobile: 'end', tablet: 'center', desktop: 'start' }} />
+        </>
+    )
 }
 
-export function HeadingPlaygroundStory({
-    children,
-    ...args
-}: React.ComponentProps<typeof Heading>) {
+ResponsiveHeadingStory.argTypes = {
+    level: select(['1', '2', '3', '4', '5', '6'], '1'),
+    size: selectWithNone(['largest', 'larger', 'smaller'], 'none'),
+    weight: select(['regular', 'light'], 'regular'),
+    lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
+    tone: select(['normal', 'secondary', 'danger'], 'normal'),
+    align: { control: false },
+    children: {
+        control: { type: 'text' },
+        defaultValue: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit',
+    },
+}
+
+export function HeadingPlaygroundStory(props: React.ComponentProps<typeof Heading>) {
     return (
         <section className="story playground">
-            <Heading {...args}>{children}</Heading>
+            <Heading {...props} />
         </section>
     )
+}
+
+HeadingPlaygroundStory.argTypes = {
+    level: select(['1', '2', '3', '4', '5', '6'], '1'),
+    size: selectWithNone(['largest', 'larger', 'smaller'], 'none'),
+    weight: select(['regular', 'light'], 'regular'),
+    lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
+    tone: select(['normal', 'secondary', 'danger'], 'normal'),
+    align: select(['start', 'center', 'end', 'justify'], 'start'),
+    children: {
+        control: { type: 'text' },
+        defaultValue: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit',
+    },
 }

--- a/src/new-components/heading/heading.test.tsx
+++ b/src/new-components/heading/heading.test.tsx
@@ -1,0 +1,191 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Heading } from './heading'
+
+describe('Heading', () => {
+    it('does not acknowledge the className prop, but exceptionallySetClassName instead', () => {
+        render(
+            <Heading
+                level="1"
+                data-testid="heading-element"
+                // @ts-expect-error
+                className="wrong"
+                exceptionallySetClassName="right"
+            >
+                Heading
+            </Heading>,
+        )
+        expect(screen.getByTestId('heading-element')).toHaveClass('right')
+        expect(screen.getByTestId('heading-element')).not.toHaveClass('wrong')
+    })
+
+    it('renders the expected heading tag name based on the level', () => {
+        const { rerender } = render(
+            <Heading data-testid="heading-element" level="1">
+                Heading
+            </Heading>,
+        )
+        expect(screen.getByTestId('heading-element').tagName).toBe('H1')
+
+        for (const level of [2, 3, 4, 5, 6] as const) {
+            rerender(
+                <Heading data-testid="heading-element" level={level}>
+                    Heading
+                </Heading>,
+            )
+            expect(screen.getByTestId('heading-element').tagName).toBe(`H${level}`)
+        }
+    })
+
+    it('renders its children as its content', () => {
+        render(
+            <Heading level="1" data-testid="heading-element">
+                Hello <strong>world</strong>
+            </Heading>,
+        )
+        expect(screen.getByTestId('heading-element').innerHTML).toMatchInlineSnapshot(
+            `"Hello <strong>world</strong>"`,
+        )
+    })
+
+    describe('size="…"', () => {
+        it('adds the appropriate class names', () => {
+            const { rerender } = render(
+                <Heading level="1" data-testid="heading-element">
+                    Heading
+                </Heading>,
+            )
+            const textElement = screen.getByTestId('heading-element')
+            expect(textElement).not.toHaveClass('size-smaller')
+            expect(textElement).not.toHaveClass('size-larger')
+            expect(textElement).not.toHaveClass('size-largest')
+
+            for (const size of ['smaller', 'larger', 'largest'] as const) {
+                rerender(
+                    <Heading level={1} data-testid="heading-element" size={size}>
+                        Heading
+                    </Heading>,
+                )
+                expect(textElement).toHaveClass(`size-${size}`)
+            }
+        })
+    })
+
+    describe('weight="…"', () => {
+        it('adds the appropriate class names', () => {
+            const { rerender } = render(
+                <Heading level="1" data-testid="heading-element" weight="regular">
+                    Heading
+                </Heading>,
+            )
+            const textElement = screen.getByTestId('heading-element')
+            expect(textElement).not.toHaveClass('weight-regular')
+            expect(textElement).not.toHaveClass('weight-light')
+
+            rerender(
+                <Heading level="1" data-testid="heading-element" weight="light">
+                    Heading
+                </Heading>,
+            )
+            expect(textElement).toHaveClass('weight-light')
+        })
+    })
+
+    describe('tone="…"', () => {
+        it('adds the appropriate class names', () => {
+            const { rerender } = render(
+                <Heading level="1" data-testid="heading-element" tone="normal">
+                    Heading
+                </Heading>,
+            )
+            const textElement = screen.getByTestId('heading-element')
+            expect(textElement).not.toHaveClass('tone-normal')
+            expect(textElement).not.toHaveClass('tone-secondary')
+            expect(textElement).not.toHaveClass('tone-danger')
+
+            for (const tone of ['secondary', 'danger'] as const) {
+                rerender(
+                    <Heading level="1" data-testid="heading-element" tone={tone}>
+                        Heading
+                    </Heading>,
+                )
+                expect(textElement).toHaveClass(`tone-${tone}`)
+            }
+        })
+    })
+
+    describe('align="…"', () => {
+        it('adds the appropriate class names', () => {
+            const { rerender } = render(
+                <Heading level="1" data-testid="heading-element" align="start">
+                    Heading
+                </Heading>,
+            )
+            const textElement = screen.getByTestId('heading-element')
+            expect(textElement).not.toHaveClass('textAlign-start')
+            expect(textElement).not.toHaveClass('textAlign-center')
+            expect(textElement).not.toHaveClass('textAlign-end')
+            expect(textElement).not.toHaveClass('textAlign-justify')
+
+            for (const align of ['center', 'end', 'justify'] as const) {
+                rerender(
+                    <Heading level="1" data-testid="heading-element" align={align}>
+                        Heading
+                    </Heading>,
+                )
+                expect(textElement).toHaveClass(`textAlign-${align}`)
+            }
+        })
+
+        it('supports responsive values', () => {
+            render(
+                <Heading
+                    level="1"
+                    data-testid="heading-element"
+                    align={{ mobile: 'start', tablet: 'center', desktop: 'end' }}
+                >
+                    Heading
+                </Heading>,
+            )
+            const textElement = screen.getByTestId('heading-element')
+            expect(textElement).toHaveClass('textAlign-start')
+            expect(textElement).toHaveClass('tablet-textAlign-center')
+            expect(textElement).toHaveClass('desktop-textAlign-end')
+        })
+    })
+
+    describe('lineClamp="…"', () => {
+        it('adds the expected class names', () => {
+            const { rerender } = render(
+                <Heading level="1" data-testid="heading-element">
+                    Heading
+                </Heading>,
+            )
+            const textElement = screen.getByTestId('heading-element')
+            expect(textElement.className).not.toMatch(/lineClamp/)
+            expect(textElement).not.toHaveClass('paddingRight-xsmall')
+
+            for (const lineClamp of [1, '1'] as const) {
+                rerender(
+                    <Heading level="1" data-testid="heading-element" lineClamp={lineClamp}>
+                        Heading
+                    </Heading>,
+                )
+                expect(textElement).toHaveClass(`lineClamp-${lineClamp}`)
+                expect(textElement).not.toHaveClass(`lineClampMultipleLines`)
+                expect(textElement).toHaveClass('paddingRight-xsmall')
+            }
+
+            for (const lineClamp of [2, 3, 4, 5, '2', '3', '4', '5'] as const) {
+                rerender(
+                    <Heading level="1" data-testid="heading-element" lineClamp={lineClamp}>
+                        Heading
+                    </Heading>,
+                )
+                expect(textElement).toHaveClass(`lineClamp-${lineClamp}`)
+                expect(textElement).toHaveClass(`lineClampMultipleLines`)
+                expect(textElement).toHaveClass('paddingRight-xsmall')
+            }
+        })
+    })
+})

--- a/src/new-components/heading/heading.tsx
+++ b/src/new-components/heading/heading.tsx
@@ -2,7 +2,9 @@ import * as React from 'react'
 import { getClassNames } from '../responsive-props'
 import { Box } from '../box'
 import styles from './heading.module.css'
+import type { ObfuscatedClassName } from '../../utils/polymorphism'
 import type { Tone } from '../common-types'
+import type { BoxProps } from '../box'
 
 type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6 | '1' | '2' | '3' | '4' | '5' | '6'
 type HeadingElement = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
@@ -13,53 +15,104 @@ type SupportedHeadingElementProps = Omit<
 >
 
 type HeadingProps = SupportedHeadingElementProps & {
-    level: HeadingLevel
-    weight?: 'regular' | 'light'
-    size?: 'smaller' | 'larger' | 'largest'
-    tone?: Tone
     children: React.ReactNode
+    /**
+     * The semantic level of the heading.
+     */
+    level: HeadingLevel
+    /**
+     * The weight of the heading. Used to de-emphasize the heading visually when using 'light'.
+     *
+     * @default 'regular'
+     */
+    weight?: 'regular' | 'light'
+    /**
+     * Shifts the default heading visual text size up or down, depending on the original size
+     * imposed by the `level`. The heading continues to be semantically at the given level.
+     *
+     * By default, no value is applied, and the default size from the level is applied. The values
+     * have the following effect:
+     *
+     * - 'smaller' shifts the default level size down in the font-size scale (it tends to make the
+     * level look visually as if it were of the immediately lower level).
+     * - 'larger' has the opposite effect than 'smaller' shifting the visual font size up in the
+     * scale.
+     * - 'largest' can be thought of as applying 'larger' twice.
+     *
+     * @see level
+     * @default undefined
+     */
+    size?: 'smaller' | 'larger' | 'largest'
+    /**
+     * The tone (semantic color) of the heading.
+     *
+     * @default 'normal'
+     */
+    tone?: Tone
+    /**
+     * Used to truncate the heading to a given number of lines.
+     *
+     * It will add an ellipsis (`…`) to the text at the end of the last line, only if the text was
+     * truncated. If the text fits without it being truncated, no ellipsis is added.
+     *
+     * By default, the text is not truncated at all, no matter how many lines it takes to render it.
+     *
+     * @default undefined
+     */
     lineClamp?: 1 | 2 | 3 | 4 | 5 | '1' | '2' | '3' | '4' | '5'
-    exceptionallySetClassName?: string
+    /**
+     * How to align the heading text horizontally.
+     *
+     * @default 'start'
+     */
+    align?: BoxProps['textAlign']
 }
 
-const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(function Heading(
-    {
-        level,
-        weight = 'regular',
-        size,
-        tone = 'normal',
-        children,
-        lineClamp,
-        exceptionallySetClassName,
-        ...props
-    },
-    ref,
-) {
-    // In TypeScript v4.1, this would be properly recognized without needing the type assertion
-    // https://devblogs.microsoft.com/typescript/announcing-typescript-4-1-beta/#template-literal-types
-    const headingElementName = `h${level}` as HeadingElement
-    const lineClampMultipleLines =
-        typeof lineClamp === 'string' ? parseInt(lineClamp, 10) > 1 : (lineClamp || 0) > 1
+const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps & ObfuscatedClassName>(
+    function Heading(
+        {
+            level,
+            weight = 'regular',
+            size,
+            tone = 'normal',
+            children,
+            lineClamp,
+            align,
+            exceptionallySetClassName,
+            ...props
+        },
+        ref,
+    ) {
+        // In TypeScript v4.1, this would be properly recognized without needing the type assertion
+        // https://devblogs.microsoft.com/typescript/announcing-typescript-4-1-beta/#template-literal-types
+        const headingElementName = `h${level}` as HeadingElement
+        const lineClampMultipleLines =
+            typeof lineClamp === 'string' ? parseInt(lineClamp, 10) > 1 : (lineClamp || 0) > 1
 
-    return (
-        <Box
-            {...props}
-            className={[
-                exceptionallySetClassName,
-                styles.heading,
-                weight !== 'regular' ? getClassNames(styles, 'weight', weight) : null,
-                tone !== 'normal' ? getClassNames(styles, 'tone', tone) : null,
-                getClassNames(styles, 'size', size),
-                lineClampMultipleLines ? styles.lineClamp : null,
-                lineClamp ? getClassNames(styles, 'line-clamp', lineClamp.toString()) : null,
-            ]}
-            as={headingElementName}
-            ref={ref}
-        >
-            {children}
-        </Box>
-    )
-})
+        return (
+            <Box
+                {...props}
+                className={[
+                    exceptionallySetClassName,
+                    styles.heading,
+                    weight !== 'regular' ? getClassNames(styles, 'weight', weight) : null,
+                    tone !== 'normal' ? getClassNames(styles, 'tone', tone) : null,
+                    getClassNames(styles, 'size', size),
+                    lineClampMultipleLines ? styles.lineClampMultipleLines : null,
+                    lineClamp ? getClassNames(styles, 'lineClamp', lineClamp.toString()) : null,
+                ]}
+                textAlign={align}
+                // Prevents emojis from being cut-off
+                // See https://github.com/Doist/reactist/pull/528
+                paddingRight={lineClamp ? 'xsmall' : undefined}
+                as={headingElementName}
+                ref={ref}
+            >
+                {children}
+            </Box>
+        )
+    },
+)
 
 export type { HeadingProps, HeadingLevel }
 export { Heading }

--- a/src/new-components/responsive-props.ts
+++ b/src/new-components/responsive-props.ts
@@ -12,17 +12,9 @@ type Atom = string | number | boolean
  */
 type ResponsiveProp<AtomType extends Atom> =
     | AtomType
-    | Readonly<[AtomType, AtomType]>
-    | Readonly<[AtomType, AtomType, AtomType]>
     | Readonly<{ [key in ResponsiveBreakpoints]?: AtomType }>
 
 const DEBUG = process.env.NODE_ENV === 'development'
-
-function isResponsivePropArray<AtomType extends Atom>(
-    responsiveProp: ResponsiveProp<AtomType>,
-): responsiveProp is Readonly<[AtomType, AtomType]> | Readonly<[AtomType, AtomType, AtomType]> {
-    return Array.isArray(responsiveProp)
-}
 
 /**
  * Builds a css module class name for a given prop + prop-value combination.
@@ -51,14 +43,6 @@ function getClassNames(
     }
 
     const classList: string[] = []
-
-    if (isResponsivePropArray(value)) {
-        value = {
-            mobile: value[0],
-            tablet: value[1],
-            desktop: value[2],
-        }
-    }
 
     if (typeof value === 'string') {
         classList.push(styles[`${property}-${value}`])
@@ -96,14 +80,6 @@ function mapResponsiveProp<From extends Atom, To extends Atom>(
 
     if (typeof fromValue !== 'object') {
         return mapper(fromValue)
-    }
-
-    if (isResponsivePropArray(fromValue)) {
-        fromValue = {
-            mobile: fromValue[0],
-            tablet: fromValue[1],
-            desktop: fromValue[2],
-        }
     }
 
     return {

--- a/src/new-components/text/text.module.css
+++ b/src/new-components/text/text.module.css
@@ -10,9 +10,6 @@
 .size-copy {
     font-size: var(--reactist-font-size-copy);
 }
-.size-body {
-    font-size: var(--reactist-font-size-body);
-}
 .size-subtitle {
     font-size: var(--reactist-font-size-subtitle);
 }
@@ -33,27 +30,27 @@
 
 /* truncated text */
 
-.line-clamp-1 {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-}
-
-.lineClamp {
+.lineClampMultipleLines {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     overflow: hidden;
 }
 
-.line-clamp-2 {
+.lineClamp-1 {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.lineClamp-2 {
     -webkit-line-clamp: 2;
 }
-.line-clamp-3 {
+.lineClamp-3 {
     -webkit-line-clamp: 3;
 }
-.line-clamp-4 {
+.lineClamp-4 {
     -webkit-line-clamp: 4;
 }
-.line-clamp-5 {
+.lineClamp-5 {
     -webkit-line-clamp: 5;
 }

--- a/src/new-components/text/text.stories.tsx
+++ b/src/new-components/text/text.stories.tsx
@@ -2,23 +2,11 @@ import React from 'react'
 
 import { Stack } from '../stack'
 import { Text } from './text'
-import { select } from '../storybook-helper'
+import { ResponsiveWidthRef, select, selectWithNone } from '../storybook-helper'
 
 export default {
     title: 'Design system/Text',
     component: Text,
-    argTypes: {
-        size: select(['caption', 'copy', 'body', 'subtitle'], 'body'),
-        weight: select(['regular', 'semibold', 'bold'], 'regular'),
-        lineClamp: select([1, 2, 3, 4, 5], 1),
-        children: {
-            control: {
-                type: 'text',
-            },
-            defaultValue: 'Lorem ipsum dolor sit amet consectetur, adipisicing elit',
-        },
-        tone: select(['normal', 'secondary', 'danger'], 'normal'),
-    },
 }
 
 export function TextStory() {
@@ -127,10 +115,43 @@ export function TruncatedTextStory() {
     )
 }
 
-export function TextPlaygroundStory({ children, ...args }: React.ComponentProps<typeof Text>) {
+export function ResponsiveTextStory(props: React.ComponentProps<typeof Text>) {
+    return (
+        <>
+            <ResponsiveWidthRef />
+            <Text {...props} align={{ mobile: 'end', tablet: 'center', desktop: 'start' }} />
+        </>
+    )
+}
+
+ResponsiveTextStory.argTypes = {
+    size: select(['caption', 'copy', 'body', 'subtitle'], 'body'),
+    weight: select(['regular', 'semibold', 'bold'], 'regular'),
+    lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
+    tone: select(['normal', 'secondary', 'danger'], 'normal'),
+    align: { control: false },
+    children: {
+        control: { type: 'text' },
+        defaultValue: 'Lorem ipsum dolor sit amet consectetur, adipisicing elit',
+    },
+}
+
+export function TextPlaygroundStory(props: React.ComponentProps<typeof Text>) {
     return (
         <section className="story playground">
-            <Text {...args}>{children}</Text>
+            <Text {...props} />
         </section>
     )
+}
+
+TextPlaygroundStory.argTypes = {
+    size: select(['caption', 'copy', 'body', 'subtitle'], 'body'),
+    weight: select(['regular', 'semibold', 'bold'], 'regular'),
+    lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
+    tone: select(['normal', 'secondary', 'danger'], 'normal'),
+    align: select(['start', 'center', 'end', 'justify'], 'start'),
+    children: {
+        control: { type: 'text' },
+        defaultValue: 'Lorem ipsum dolor sit amet consectetur, adipisicing elit',
+    },
 }

--- a/src/new-components/text/text.test.tsx
+++ b/src/new-components/text/text.test.tsx
@@ -1,0 +1,180 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Text } from './text'
+
+describe('Text', () => {
+    it('does not acknowledge the className prop, but exceptionallySetClassName instead', () => {
+        render(
+            <Text
+                data-testid="text-element"
+                // @ts-expect-error
+                className="wrong"
+                exceptionallySetClassName="right"
+            >
+                Text
+            </Text>,
+        )
+        expect(screen.getByTestId('text-element')).toHaveClass('right')
+        expect(screen.getByTestId('text-element')).not.toHaveClass('wrong')
+    })
+
+    it('can be rendered as any HTML element', () => {
+        render(
+            <Text data-testid="text-element" as="nav">
+                Text
+            </Text>,
+        )
+        expect(screen.getByTestId('text-element').tagName).toBe('NAV')
+    })
+
+    it('renders its children as its content', () => {
+        render(
+            <Text data-testid="text-element">
+                Hello <strong>world</strong>
+            </Text>,
+        )
+        expect(screen.getByTestId('text-element').innerHTML).toMatchInlineSnapshot(
+            `"Hello <strong>world</strong>"`,
+        )
+    })
+
+    describe('size="…"', () => {
+        it('adds the appropriate class names', () => {
+            const { rerender } = render(
+                <Text data-testid="text-element" size="body">
+                    Text
+                </Text>,
+            )
+            const textElement = screen.getByTestId('text-element')
+            expect(textElement).not.toHaveClass('size-body')
+            expect(textElement).not.toHaveClass('size-caption')
+            expect(textElement).not.toHaveClass('size-copy')
+            expect(textElement).not.toHaveClass('size-subtitle')
+
+            for (const size of ['caption', 'copy', 'subtitle'] as const) {
+                rerender(
+                    <Text data-testid="text-element" size={size}>
+                        Text
+                    </Text>,
+                )
+                expect(textElement).toHaveClass(`size-${size}`)
+            }
+        })
+    })
+
+    describe('weight="…"', () => {
+        it('adds the appropriate class names', () => {
+            const { rerender } = render(
+                <Text data-testid="text-element" weight="regular">
+                    Text
+                </Text>,
+            )
+            const textElement = screen.getByTestId('text-element')
+            expect(textElement).not.toHaveClass('weight-regular')
+            expect(textElement).not.toHaveClass('weight-semibold')
+            expect(textElement).not.toHaveClass('weight-bold')
+
+            for (const weight of ['semibold', 'bold'] as const) {
+                rerender(
+                    <Text data-testid="text-element" weight={weight}>
+                        Text
+                    </Text>,
+                )
+                expect(textElement).toHaveClass(`weight-${weight}`)
+            }
+        })
+    })
+
+    describe('tone="…"', () => {
+        it('adds the appropriate class names', () => {
+            const { rerender } = render(
+                <Text data-testid="text-element" tone="normal">
+                    Text
+                </Text>,
+            )
+            const textElement = screen.getByTestId('text-element')
+            expect(textElement).not.toHaveClass('tone-normal')
+            expect(textElement).not.toHaveClass('tone-secondary')
+            expect(textElement).not.toHaveClass('tone-danger')
+
+            for (const tone of ['secondary', 'danger'] as const) {
+                rerender(
+                    <Text data-testid="text-element" tone={tone}>
+                        Text
+                    </Text>,
+                )
+                expect(textElement).toHaveClass(`tone-${tone}`)
+            }
+        })
+    })
+
+    describe('align="…"', () => {
+        it('adds the appropriate class names', () => {
+            const { rerender } = render(
+                <Text data-testid="text-element" align="start">
+                    Text
+                </Text>,
+            )
+            const textElement = screen.getByTestId('text-element')
+            expect(textElement).not.toHaveClass('textAlign-start')
+            expect(textElement).not.toHaveClass('textAlign-center')
+            expect(textElement).not.toHaveClass('textAlign-end')
+            expect(textElement).not.toHaveClass('textAlign-justify')
+
+            for (const align of ['center', 'end', 'justify'] as const) {
+                rerender(
+                    <Text data-testid="text-element" align={align}>
+                        Text
+                    </Text>,
+                )
+                expect(textElement).toHaveClass(`textAlign-${align}`)
+            }
+        })
+
+        it('supports responsive values', () => {
+            render(
+                <Text
+                    data-testid="text-element"
+                    align={{ mobile: 'start', tablet: 'center', desktop: 'end' }}
+                >
+                    Text
+                </Text>,
+            )
+            const textElement = screen.getByTestId('text-element')
+            expect(textElement).toHaveClass('textAlign-start')
+            expect(textElement).toHaveClass('tablet-textAlign-center')
+            expect(textElement).toHaveClass('desktop-textAlign-end')
+        })
+    })
+
+    describe('lineClamp="…"', () => {
+        it('adds the expected class names', () => {
+            const { rerender } = render(<Text data-testid="text-element">Text</Text>)
+            const textElement = screen.getByTestId('text-element')
+            expect(textElement.className).not.toMatch(/lineClamp/)
+            expect(textElement).not.toHaveClass('paddingRight-xsmall')
+
+            for (const lineClamp of [1, '1'] as const) {
+                rerender(
+                    <Text data-testid="text-element" lineClamp={lineClamp}>
+                        Text
+                    </Text>,
+                )
+                expect(textElement).toHaveClass(`lineClamp-${lineClamp}`)
+                expect(textElement).not.toHaveClass(`lineClampMultipleLines`)
+                expect(textElement).toHaveClass('paddingRight-xsmall')
+            }
+
+            for (const lineClamp of [2, 3, 4, 5, '2', '3', '4', '5'] as const) {
+                rerender(
+                    <Text data-testid="text-element" lineClamp={lineClamp}>
+                        Text
+                    </Text>,
+                )
+                expect(textElement).toHaveClass(`lineClamp-${lineClamp}`)
+                expect(textElement).toHaveClass(`lineClampMultipleLines`)
+                expect(textElement).toHaveClass('paddingRight-xsmall')
+            }
+        })
+    })
+})

--- a/src/new-components/text/text.tsx
+++ b/src/new-components/text/text.tsx
@@ -1,26 +1,62 @@
 import * as React from 'react'
 import { getClassNames } from '../responsive-props'
 import { Box } from '../box'
-
 import { polymorphicComponent } from '../../utils/polymorphism'
+
 import type { Tone } from '../common-types'
+import type { BoxProps } from '../box'
 
 import styles from './text.module.css'
 
 type TextProps = {
     children: React.ReactNode
+    /**
+     * The size of the text.
+     *
+     * The supported values, from smaller size to larger size, are:
+     * 'caption', 'copy', 'body', and 'subtitle'
+     *
+     * @default 'body'
+     */
     size?: 'caption' | 'copy' | 'body' | 'subtitle'
+    /**
+     * The weight of the text font.
+     *
+     * @default 'regular'
+     */
     weight?: 'regular' | 'semibold' | 'bold'
+    /**
+     * The tone (semantic color) of the text.
+     *
+     * @default 'normal'
+     */
     tone?: Tone
+    /**
+     * Used to truncate the text to a given number of lines.
+     *
+     * It will add an ellipsis (`…`) to the text at the end of the last line, only if the text was
+     * truncated. If the text fits without it being truncated, no ellipsis is added.
+     *
+     * By default, the text is not truncated at all, no matter how many lines it takes to render it.
+     *
+     * @default undefined
+     */
     lineClamp?: 1 | 2 | 3 | 4 | 5 | '1' | '2' | '3' | '4' | '5'
+    /**
+     * How to align the text horizontally.
+     *
+     * @default 'start'
+     */
+    align?: BoxProps['textAlign']
 }
 
-const Text = polymorphicComponent<'span', TextProps>(function Text(
+const Text = polymorphicComponent<'div', TextProps>(function Text(
     {
-        as = 'span',
+        as,
         size = 'body',
         weight = 'regular',
         tone = 'normal',
+        align,
         children,
         lineClamp,
         exceptionallySetClassName,
@@ -29,7 +65,7 @@ const Text = polymorphicComponent<'span', TextProps>(function Text(
     ref,
 ) {
     const lineClampMultipleLines =
-        typeof lineClamp === 'string' ? parseInt(lineClamp, 10) > 1 : (lineClamp || 0) > 1
+        typeof lineClamp === 'string' ? Number(lineClamp) > 1 : (lineClamp ?? 1) > 1
 
     return (
         <Box
@@ -41,9 +77,10 @@ const Text = polymorphicComponent<'span', TextProps>(function Text(
                 size !== 'body' ? getClassNames(styles, 'size', size) : null,
                 weight !== 'regular' ? getClassNames(styles, 'weight', weight) : null,
                 tone !== 'normal' ? getClassNames(styles, 'tone', tone) : null,
-                lineClampMultipleLines ? styles.lineClamp : null,
-                lineClamp ? getClassNames(styles, 'line-clamp', lineClamp.toString()) : null,
+                lineClampMultipleLines ? styles.lineClampMultipleLines : null,
+                lineClamp ? getClassNames(styles, 'lineClamp', lineClamp.toString()) : null,
             ]}
+            textAlign={align}
             // Prevents emojis from being cut-off
             // See https://github.com/Doist/reactist/pull/528
             paddingRight={lineClamp ? 'xsmall' : undefined}

--- a/src/utils/polymorphism.ts
+++ b/src/utils/polymorphism.ts
@@ -214,5 +214,5 @@ function polymorphicComponent<
     >
 }
 
-export type { PolymorphicComponent }
+export type { PolymorphicComponent, ObfuscatedClassName }
 export { polymorphicComponent }


### PR DESCRIPTION
## Short description

Most notably, this PR adds `textAlign` support for `Box`, and uses it to implement a `align` prop in both `Heading` and `Text`.

In addition to that, it adds tests for both the `Heading` and `Text` components, and new stories to showcase the `align` responsive feature. It also adds jsdoc comments to the props for each of these two components.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

To be released in bulk with other features that have been accumulating in this PR's base branch.

## Demo

https://user-images.githubusercontent.com/15199/130112038-b67ad21f-e085-4bf1-bc0f-122a55820284.mp4
