### PR TITLE
New components for hiding content in various ways

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './new-components/divider'
 export * from './new-components/inline'
 export * from './new-components/stack'
 export * from './new-components/hidden'
+export * from './new-components/hidden-visually'
 
 // alerts, notifications, etc.
 export * from './new-components/alert'

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './new-components/columns'
 export * from './new-components/divider'
 export * from './new-components/inline'
 export * from './new-components/stack'
+export * from './new-components/hidden'
 
 // alerts, notifications, etc.
 export * from './new-components/alert'

--- a/src/new-components/checkbox-field/checkbox-field.tsx
+++ b/src/new-components/checkbox-field/checkbox-field.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
-import { VisuallyHidden } from 'reakit/VisuallyHidden'
 import { useForkRef } from 'reakit-utils'
+import { HiddenVisually } from '../hidden-visually'
 import { Box } from '../box'
 import { CheckboxIcon } from './checkbox-icon'
 
@@ -53,7 +53,7 @@ const CheckboxField = React.forwardRef<HTMLInputElement, CheckboxFieldProps>(fun
                 'focus-marker-enabled-within',
             ]}
         >
-            <VisuallyHidden>
+            <HiddenVisually>
                 <input
                     {...props}
                     ref={combinedRef}
@@ -67,7 +67,7 @@ const CheckboxField = React.forwardRef<HTMLInputElement, CheckboxFieldProps>(fun
                         }
                     }}
                 />
-            </VisuallyHidden>
+            </HiddenVisually>
             <CheckboxIcon
                 aria-hidden
                 checked={isChecked}

--- a/src/new-components/hidden-visually/hidden-visually.module.css
+++ b/src/new-components/hidden-visually/hidden-visually.module.css
@@ -1,0 +1,6 @@
+.hiddenVisually {
+    width: 1px;
+    height: 1px;
+    clip: rect(1px, 1px, 1px, 1px);
+    white-space: nowrap;
+}

--- a/src/new-components/hidden-visually/hidden-visually.test.tsx
+++ b/src/new-components/hidden-visually/hidden-visually.test.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { HiddenVisually } from './hidden-visually'
+
+describe('HiddenVisually', () => {
+    it('can be rendered as any HTML element', () => {
+        render(
+            <HiddenVisually data-testid="hidden-element" as="p">
+                Something
+            </HiddenVisually>,
+        )
+        expect(screen.getByTestId('hidden-element').tagName).toBe('P')
+    })
+
+    it('renders its children as its content', () => {
+        render(
+            <HiddenVisually data-testid="hidden-element">
+                <div>one</div>
+                <div>two</div>
+            </HiddenVisually>,
+        )
+        expect(screen.getByTestId('hidden-element').innerHTML).toMatchInlineSnapshot(
+            `"<div>one</div><div>two</div>"`,
+        )
+    })
+
+    it('gets applied the expected class names', () => {
+        render(<HiddenVisually data-testid="hidden-element">Something</HiddenVisually>)
+        const hiddenElement = screen.getByTestId('hidden-element')
+        expect(hiddenElement).toHaveClass('hiddenVisually', 'position-absolute', 'overflow-hidden')
+    })
+})

--- a/src/new-components/hidden-visually/hidden-visually.tsx
+++ b/src/new-components/hidden-visually/hidden-visually.tsx
@@ -9,6 +9,8 @@ type Props = {
 
 /**
  * Provides content to assistive technologies while hiding it from the screen.
+ *
+ * @see Hidden for fully hiding content, and only under certain conditions.
  */
 const HiddenVisually = polymorphicComponent<'div', Props, 'omitClassName'>(function HiddenVisually(
     props,

--- a/src/new-components/hidden-visually/hidden-visually.tsx
+++ b/src/new-components/hidden-visually/hidden-visually.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { polymorphicComponent } from '../../utils/polymorphism'
+import { Box } from '../box'
+import styles from './hidden-visually.module.css'
+
+type Props = {
+    children: React.ReactNode
+}
+
+/**
+ * Provides content to assistive technologies while hiding it from the screen.
+ */
+const HiddenVisually = polymorphicComponent<'div', Props, 'omitClassName'>(function HiddenVisually(
+    props,
+    ref,
+) {
+    return (
+        <Box
+            {...props}
+            ref={ref}
+            position="absolute"
+            overflow="hidden"
+            className={styles.hiddenVisually}
+        />
+    )
+})
+
+export { HiddenVisually }

--- a/src/new-components/hidden-visually/index.ts
+++ b/src/new-components/hidden-visually/index.ts
@@ -1,0 +1,1 @@
+export * from './hidden-visually'

--- a/src/new-components/hidden/hidden.module.css
+++ b/src/new-components/hidden/hidden.module.css
@@ -1,0 +1,5 @@
+@media print {
+    .hiddenOnPrint {
+        display: none;
+    }
+}

--- a/src/new-components/hidden/hidden.stories.tsx
+++ b/src/new-components/hidden/hidden.stories.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+import { Placeholder, ResponsiveWidthRef } from '../storybook-helper'
+import { Stack } from '../stack'
+import { Hidden } from './hidden'
+
+export default {
+    title: 'Design system/Hidden',
+    component: Hidden,
+}
+
+export function ResponsiveStory() {
+    return (
+        <>
+            <ResponsiveWidthRef />
+            <Stack space="medium">
+                <Placeholder label="Always visible 📱💻🖥" />
+
+                <Hidden above="mobile">
+                    <Placeholder label="Visible only on mobile 📱" height={30} />
+                </Hidden>
+
+                <Hidden below="desktop">
+                    <Placeholder label="Visible only on desktop 🖥" height={75} />
+                </Hidden>
+
+                <Hidden below="tablet">
+                    <Placeholder label="Visible in tablet and desktop 💻🖥" height={60} />
+                </Hidden>
+
+                <Hidden above="tablet">
+                    <Placeholder label="Visible in mobile and tablet 📱💻" height={45} />
+                </Hidden>
+
+                <Hidden above="tablet">
+                    <Placeholder label="Does not make sense" />
+                </Hidden>
+            </Stack>
+        </>
+    )
+}

--- a/src/new-components/hidden/hidden.test.tsx
+++ b/src/new-components/hidden/hidden.test.tsx
@@ -1,0 +1,162 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Hidden } from './hidden'
+
+describe('Hidden', () => {
+    it('does not acknowledge the className prop, but exceptionallySetClassName instead', () => {
+        render(
+            <Hidden
+                print
+                data-testid="hidden-element"
+                // @ts-expect-error
+                className="wrong"
+                exceptionallySetClassName="right"
+            >
+                Something
+            </Hidden>,
+        )
+        expect(screen.getByTestId('hidden-element')).toHaveClass('right')
+        expect(screen.getByTestId('hidden-element')).not.toHaveClass('wrong')
+    })
+
+    it('can be rendered as any HTML element', () => {
+        render(
+            <Hidden print data-testid="hidden-element" as="main">
+                Something
+            </Hidden>,
+        )
+        expect(screen.getByTestId('hidden-element').tagName).toBe('MAIN')
+    })
+
+    it('renders its children as its content', () => {
+        render(
+            <Hidden print data-testid="hidden-element">
+                <div>one</div>
+                <div>two</div>
+            </Hidden>,
+        )
+        expect(screen.getByTestId('hidden-element').innerHTML).toMatchInlineSnapshot(
+            `"<div>one</div><div>two</div>"`,
+        )
+    })
+
+    it('requires receiving some criteria to hide itself', () => {
+        /* eslint-disable no-console */
+        const originalConsoleWarn = console.warn
+        console.warn = jest.fn()
+
+        render(
+            // @ts-expect-error requires receiving some prop that instructs under which condition to hide
+            <Hidden data-testid="hidden-element">Something</Hidden>,
+        )
+        const hiddenElement = screen.getByTestId('hidden-element')
+        expect(hiddenElement).not.toHaveClass('hiddenOnPrint')
+        expect(hiddenElement.className).not.toMatch('display-none')
+
+        console.warn = originalConsoleWarn
+        /* eslint-enable no-console */
+    })
+
+    describe('print={true}', () => {
+        it('hides the element in print mode', () => {
+            render(
+                <Hidden print data-testid="hidden-element">
+                    Something
+                </Hidden>,
+            )
+            expect(screen.getByTestId('hidden-element')).toHaveClass('hiddenOnPrint')
+        })
+    })
+
+    describe('above="…"', () => {
+        it('works as expected', () => {
+            const { rerender } = render(
+                <Hidden data-testid="hidden-element" above="mobile">
+                    Something
+                </Hidden>,
+            )
+            const hiddenElement = screen.getByTestId('hidden-element')
+            expect(hiddenElement).toHaveClass('display-block')
+            expect(hiddenElement).toHaveClass('tablet-display-none')
+            expect(hiddenElement).toHaveClass('desktop-display-none')
+
+            rerender(
+                <Hidden data-testid="hidden-element" above="tablet">
+                    Something
+                </Hidden>,
+            )
+            expect(hiddenElement).toHaveClass('display-block')
+            expect(hiddenElement).toHaveClass('tablet-display-block')
+            expect(hiddenElement).toHaveClass('desktop-display-none')
+        })
+
+        it('works alongside print={true}', () => {
+            render(
+                <Hidden above="mobile" print data-testid="hidden-element">
+                    Something
+                </Hidden>,
+            )
+            const hiddenElement = screen.getByTestId('hidden-element')
+            expect(hiddenElement).toHaveClass('hiddenOnPrint')
+            expect(hiddenElement).toHaveClass('display-block')
+            expect(hiddenElement).toHaveClass('tablet-display-none')
+            expect(hiddenElement).toHaveClass('desktop-display-none')
+        })
+    })
+
+    describe('below="…"', () => {
+        it('works as expected', () => {
+            const { rerender } = render(
+                <Hidden below="tablet" data-testid="hidden-element">
+                    Something
+                </Hidden>,
+            )
+            const hiddenElement = screen.getByTestId('hidden-element')
+            expect(hiddenElement).toHaveClass('display-none')
+            expect(hiddenElement).toHaveClass('tablet-display-block')
+            expect(hiddenElement).toHaveClass('desktop-display-block')
+
+            rerender(<Hidden below="desktop">Something</Hidden>)
+            expect(hiddenElement).toHaveClass('display-none')
+            expect(hiddenElement).toHaveClass('tablet-display-none')
+            expect(hiddenElement).toHaveClass('desktop-display-block')
+        })
+
+        it('works alongside print={true}', () => {
+            render(
+                <Hidden below="desktop" print data-testid="hidden-element">
+                    Something
+                </Hidden>,
+            )
+            const hiddenElement = screen.getByTestId('hidden-element')
+            expect(hiddenElement).toHaveClass('hiddenOnPrint')
+            expect(hiddenElement).toHaveClass('display-none')
+            expect(hiddenElement).toHaveClass('tablet-display-none')
+            expect(hiddenElement).toHaveClass('desktop-display-block')
+        })
+    })
+
+    describe('above="…" and below="…" at the same time', () => {
+        it('is not allowed', () => {
+            /* eslint-disable no-console */
+            const originalConsoleWarn = console.warn
+            console.warn = jest.fn()
+
+            render(
+                // @ts-expect-error
+                <Hidden above="tablet" below="tablet" data-testid="hidden-element">
+                    Something
+                </Hidden>,
+            )
+
+            expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/but not both/))
+
+            const hiddenElement = screen.getByTestId('hidden-element')
+            expect(hiddenElement).toHaveClass('display-none')
+            expect(hiddenElement.className).not.toMatch(/(tablet|desktop)-display/)
+
+            console.warn = originalConsoleWarn
+            /* eslint-enable no-console */
+        })
+    })
+})

--- a/src/new-components/hidden/hidden.tsx
+++ b/src/new-components/hidden/hidden.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react'
+import { Box } from '../box'
+import styles from './hidden.module.css'
+import type { ResponsiveBreakpoints } from '../responsive-props'
+import { polymorphicComponent } from '../../utils/polymorphism'
+
+type AboveProp = {
+    /**
+     * Hides the element on viewport sizes equal or larger to the one given.
+     *
+     * It is not supported to pass it alongside `below`, and the resulting behavior is undefined
+     * (most likely itʼll hide the element all the time to make it apparent that there's a problem).
+     *
+     * @see below
+     */
+    above: Exclude<ResponsiveBreakpoints, 'desktop'>
+    below?: never
+}
+
+type BelowProp = {
+    /**
+     * Hides the element on viewport sizes equal or smaller to the one given.
+     *
+     * It is not supported to pass it alongside `above`, and the resulting behavior is undefined
+     * (most likely itʼll hide the element all the time to make it apparent that there's a problem).
+     *
+     * @see above
+     */
+    below: Exclude<ResponsiveBreakpoints, 'mobile'>
+    above?: never
+}
+
+type CommonProps = {
+    children: React.ReactNode
+    /**
+     * hides the element when on print media.
+     */
+    print?: boolean
+    /**
+     * Useful if you want the element to be an inline element when it is visible.
+     */
+    display?: 'inline' | 'block'
+}
+
+type HiddenProps = CommonProps & (AboveProp | BelowProp | Required<Pick<CommonProps, 'print'>>)
+
+/**
+ * A component that allows to specify how to hide itself on certain responsive screen sizes, or on
+ * print media.
+ *
+ * @see HiddenProps
+ */
+const Hidden = polymorphicComponent<'div', HiddenProps>(function Hidden(
+    { display = 'block', children, exceptionallySetClassName, ...props },
+    ref,
+) {
+    const hiddenOnPrint = 'print' in props && props.print
+
+    const hiddenOnDesktop = 'above' in props
+    const hiddenOnMobile = 'below' in props
+    const hiddenOnTablet =
+        ('below' in props && props.below === 'desktop') ||
+        ('above' in props && props.above === 'mobile')
+
+    if (hiddenOnDesktop && hiddenOnMobile) {
+        // eslint-disable-next-line no-console
+        console.warn('<Hidden /> should receive either above="…" or below="…" but not both')
+    }
+
+    if (!hiddenOnDesktop && !hiddenOnMobile && !hiddenOnPrint) {
+        // eslint-disable-next-line no-console
+        console.warn('<Hidden /> did not receive any criteria to hide itself')
+    }
+
+    // We need to delete these so they do not get forwarded to the Box
+    if ('above' in props) delete props['above']
+    if ('below' in props) delete props['below']
+    if ('print' in props) delete props['print']
+
+    return (
+        <Box
+            {...props}
+            ref={ref}
+            className={[exceptionallySetClassName, hiddenOnPrint ? styles.hiddenOnPrint : null]}
+            display={
+                hiddenOnDesktop && hiddenOnMobile
+                    ? 'none'
+                    : {
+                          mobile: hiddenOnMobile ? 'none' : display,
+                          tablet: hiddenOnTablet ? 'none' : display,
+                          desktop: hiddenOnDesktop ? 'none' : display,
+                      }
+            }
+        >
+            {children}
+        </Box>
+    )
+})
+
+export { Hidden }
+export type { HiddenProps }

--- a/src/new-components/hidden/hidden.tsx
+++ b/src/new-components/hidden/hidden.tsx
@@ -49,6 +49,8 @@ type HiddenProps = CommonProps & (AboveProp | BelowProp | Required<Pick<CommonPr
  * print media.
  *
  * @see HiddenProps
+ * @see HiddenVisually for hiding content only visually, while keeping it available for assistive
+ *   technologies.
  */
 const Hidden = polymorphicComponent<'div', HiddenProps>(function Hidden(
     { display = 'block', children, exceptionallySetClassName, ...props },

--- a/src/new-components/hidden/index.ts
+++ b/src/new-components/hidden/index.ts
@@ -1,0 +1,1 @@
+export * from './hidden'

--- a/src/new-components/switch-field/switch-field.tsx
+++ b/src/new-components/switch-field/switch-field.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
-import { VisuallyHidden } from 'reakit/VisuallyHidden'
 import { Box } from '../box'
-import { FieldComponentProps, FieldHint } from '../base-field'
-import styles from './switch-field.module.css'
-import { useId } from '../common-helpers'
 import { Stack } from '../stack'
+import { HiddenVisually } from '../hidden-visually'
+import { FieldComponentProps, FieldHint } from '../base-field'
+import { useId } from '../common-helpers'
+import styles from './switch-field.module.css'
 
 type SwitchFieldProps = Omit<
     FieldComponentProps<HTMLInputElement>,
@@ -50,7 +50,7 @@ const SwitchField = React.forwardRef<HTMLInputElement, SwitchFieldProps>(functio
                     flexShrink={0}
                     className={styles.toggle}
                 >
-                    <VisuallyHidden>
+                    <HiddenVisually>
                         <input
                             {...props}
                             id={id}
@@ -66,7 +66,7 @@ const SwitchField = React.forwardRef<HTMLInputElement, SwitchFieldProps>(functio
                                 }
                             }}
                         />
-                    </VisuallyHidden>
+                    </HiddenVisually>
                     <span className={styles.handle} />
                 </Box>
                 <span className={styles.label}>{label}</span>


### PR DESCRIPTION
## Short description

Adds a couple new components to hide content in a declarative way:

- `Hidden` used to hide content on certain responsive screen sizes, and/or in print mode.
- `HiddenVisually` used to visually hide content from the screen while still having it available for assistive technologies.

## PR Checklist

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

To be released soon in bulk with other changes being gathered in this PRs base branch.