### PR TITLE
feat: Support polymorphism with `TabPanel` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+## v10.0.0-beta.2
+
+-   [Feature] All the tab components are now polymorphic (i.e. they can use the `as="element"` prop).
+
 ## v10.0.0-beta.1
 
 -   [Build] The project now requires node v16.0.0+ and npm v7.0.0+ to install and run.

--- a/src/new-components/tabs/tabs.stories.mdx
+++ b/src/new-components/tabs/tabs.stories.mdx
@@ -4,10 +4,7 @@ import { Box } from '../box'
 import { Text } from '../text'
 import { Columns, Column } from '../columns'
 
-<Meta
-    title="Design system/Tabs"
-    component={Tabs}
-/>
+<Meta title="Design system/Tabs" component={Tabs} />
 
 # Tabs
 
@@ -24,14 +21,10 @@ export const Template = ({
     selectedId,
     render,
     'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabelledby
+    'aria-labelledby': ariaLabelledby,
 }) => (
     <Tabs color={color} variant={variant} selectedId={selectedId}>
-        <TabList
-            aria-label={ariaLabel}
-            aria-labelledby={ariaLabelledby}
-            space={space}
-        >
+        <TabList aria-label={ariaLabel} aria-labelledby={ariaLabelledby} space={space}>
             <Tab id="tab1">Tab 1</Tab>
             <Tab id="tab2">Tab 2</Tab>
             <Tab id="tab3">Tab 3</Tab>
@@ -61,26 +54,26 @@ export const Template = ({
             'aria-label': 'Main demo for Tabs',
         }}
         argTypes={{
-          selectedId: {
-              options: ['tab1', 'tab2', 'tab3', null, undefined],
-              control: { type: 'inline-radio' },
-          },
-          variant: {
-              options: ['normal', 'plain'],
-              control: { type: 'inline-radio' },
-          },
-          color: {
-              options: ['primary', 'secondary', 'tertiary'],
-              control: { type: 'inline-radio' },
-          },
-          space: {
-              options: ['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge'],
-              control: { type: 'inline-radio' },
-          },
-          render: {
-              options: ['always', 'active', 'lazy'],
-              control: { type: 'inline-radio' },
-          },
+            selectedId: {
+                options: ['tab1', 'tab2', 'tab3', null, undefined],
+                control: { type: 'inline-radio' },
+            },
+            variant: {
+                options: ['normal', 'plain'],
+                control: { type: 'inline-radio' },
+            },
+            color: {
+                options: ['primary', 'secondary', 'tertiary'],
+                control: { type: 'inline-radio' },
+            },
+            space: {
+                options: ['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge'],
+                control: { type: 'inline-radio' },
+            },
+            render: {
+                options: ['always', 'active', 'lazy'],
+                control: { type: 'inline-radio' },
+            },
         }}
         name="Main demo"
     >
@@ -107,7 +100,6 @@ export const Template = ({
 
 <Description of={TabPanel} />
 <ArgsTable of={TabPanel} />
-
 
 ## `<TabAwareSlot>`
 
@@ -203,7 +195,7 @@ The following CSS custom properties are available so that the tabs' colors can b
         <Tabs>
             <Columns>
                 <Column width="content">
-                    <TabList  aria-label="TabAwareSlot example tabs">
+                    <TabList aria-label="TabAwareSlot example tabs">
                         <Tab id="tab1">Tab 1</Tab>
                         <Tab id="tab2">Tab 2</Tab>
                         <Tab id="tab3">Tab 3</Tab>
@@ -248,10 +240,7 @@ The following CSS custom properties are available so that the tabs' colors can b
 As long as they exist within the same `<Tabs>` component tree, multiple `<TabList>` instances can be rendered.
 
 <Canvas withToolbar>
-    <Story
-        parameters={{ docs: { source: { type: 'code' } } }}
-        name="Multiple TabList instances"
-    >
+    <Story parameters={{ docs: { source: { type: 'code' } } }} name="Multiple TabList instances">
         <Tabs>
             <TabList aria-label="Multiple tablist example tabs">
                 <Tab id="tab1">Tab 1</Tab>
@@ -278,6 +267,39 @@ As long as they exist within the same `<Tabs>` component tree, multiple `<TabLis
                 <Tab id="tab2">Tab 2</Tab>
                 <Tab id="tab3">Tab 3</Tab>
             </TabList>
+        </Tabs>
+    </Story>
+</Canvas>
+
+### Polymorphism
+
+By default, the `TabPanel` renders an unstyled div. When more control is needed, an element type or component
+can be specified with the `as` prop.
+
+Note that when combined with the `render="active"` prop, only the tabpanel's
+children are prevented from rendering, and not the actual polymorphic component/element itself.
+
+<Canvas withToolbar>
+    <Story parameters={{ docs: { source: { type: 'code' } } }} name="Polymorphism">
+        <Tabs>
+            <TabList aria-label="Multiple tablist example tabs">
+                <Tab id="tab1">Tab 1</Tab>
+                <Tab id="tab2">Tab 2</Tab>
+                <Tab id="tab3">Tab 3</Tab>
+            </TabList>
+            <TabPanel id="tab1" as={Box} paddingX="small" paddingY="xlarge" render="active">
+                <Text>Content of tab 1</Text>
+            </TabPanel>
+            <TabPanel id="tab2" as="section" render="active">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 2</Text>
+                </Box>
+            </TabPanel>
+            <TabPanel id="tab3" as={Columns} paddingX="small" paddingY="xlarge" render="active">
+                <Column>Column 1</Column>
+                <Column>Column 2</Column>
+                <Column>Column 3</Column>
+            </TabPanel>
         </Tabs>
     </Story>
 </Canvas>

--- a/src/new-components/tabs/tabs.test.tsx
+++ b/src/new-components/tabs/tabs.test.tsx
@@ -222,4 +222,23 @@ describe('Tabs', () => {
         )
         expect(screen.getByText('Content of tab 2')).toBeVisible()
     })
+
+    // eslint-disable-next-line jest/expect-expect
+    it('disallows className prop on TabPanel', () => {
+        render(
+            <Tabs>
+                <TabList aria-label="test-tabs">
+                    <Tab id="tab1">Tab 1</Tab>
+                    <Tab id="tab2">Tab 2</Tab>
+                    <Tab id="tab3">Tab 3</Tab>
+                </TabList>
+                {/* @ts-expect-error */}
+                <TabPanel id="tab1" className="foo">
+                    Content of tab 1
+                </TabPanel>
+                <TabPanel id="tab2">Content of tab 2</TabPanel>
+                <TabPanel id="tab3">Content of tab 3</TabPanel>
+            </Tabs>,
+        )
+    })
 })

--- a/src/new-components/tabs/tabs.test.tsx
+++ b/src/new-components/tabs/tabs.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { screen, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+
+import { LoadingSpinner } from '../loading-spinner'
 import { Tabs, Tab, TabList, TabPanel, TabAwareSlot } from './'
 
 describe('Tabs', () => {
@@ -190,5 +192,34 @@ describe('Tabs', () => {
 
         userEvent.click(screen.getByRole('tab', { name: 'Tab 3' }))
         expect(screen.getByText('Currently rendering tab3')).toBeVisible()
+    })
+
+    it('allows different elements to be rendered in place of the TabPanel', () => {
+        render(
+            <Tabs>
+                <TabList aria-label="Multiple tablist example tabs">
+                    <Tab id="tab1">Tab 1</Tab>
+                    <Tab id="tab2">Tab 2</Tab>
+                </TabList>
+                <TabPanel id="tab1" as={LoadingSpinner} label="Loading">
+                    It makes no sense to render a loading spinner here, but it's an easier component
+                    to query for to make sure we're rendering our custom element
+                </TabPanel>
+                <TabPanel id="tab2" as="section">
+                    Content of tab 2
+                </TabPanel>
+            </Tabs>,
+        )
+
+        // The LoadingSpinner doesn't allow its role to be overridden nor render children
+        expect(screen.getByRole('alert', { name: 'Loading' })).toBeVisible()
+        expect(screen.queryByText(/It makes no sense/)).not.toBeInTheDocument()
+
+        userEvent.click(screen.getByRole('tab', { name: 'Tab 2' }))
+        expect(screen.getByRole('tabpanel', { name: 'Tab 2' })).toBeVisible()
+        expect(screen.getByRole('tabpanel', { name: 'Tab 2' })).toBe(
+            document.querySelector('section'),
+        )
+        expect(screen.getByText('Content of tab 2')).toBeVisible()
     })
 })

--- a/src/new-components/tabs/tabs.tsx
+++ b/src/new-components/tabs/tabs.tsx
@@ -39,7 +39,7 @@ type TabsProps = {
 /**
  * Used to group components that compose a set of tabs. There can only be one active tab within the same `<Tabs>` group.
  */
-function Tabs({
+export function Tabs({
     children,
     selectedId,
     color = 'primary',
@@ -90,7 +90,7 @@ type TabProps = {
 /**
  * Represents the individual tab elements within the group. Each `<Tab>` must have a corresponding `<TabPanel>` component.
  */
-function Tab({ children, id }: TabProps): React.ReactElement | null {
+export function Tab({ children, id }: TabProps): React.ReactElement | null {
     const tabContextValue = React.useContext(TabsContext)
 
     if (!tabContextValue) {
@@ -147,7 +147,7 @@ type TabListProps = (
 /**
  * A component used to group `<Tab>` elements together.
  */
-function TabList({
+export function TabList({
     children,
     space = 'medium',
     ...props
@@ -185,37 +185,39 @@ type TabPanelProps = {
 /**
  * Used to define the content to be rendered when a tab is active. Each `<TabPanel>` must have a corresponding `<Tab>` component.
  */
-const TabPanel = polymorphicComponent<'div', TabPanelProps, 'omitClassName'>(function TabPanel(
-    { children, id, as, render = 'always', ...props },
-    ref,
-): React.ReactElement | null {
-    const tabContextValue = React.useContext(TabsContext)
-    const [tabRendered, setTabRendered] = React.useState(false)
-    const tabIsActive = tabContextValue?.selectedId === id
+export const TabPanel = polymorphicComponent<'div', TabPanelProps, 'omitClassName'>(
+    function TabPanel(
+        { children, id, as, render = 'always', ...props },
+        ref,
+    ): React.ReactElement | null {
+        const tabContextValue = React.useContext(TabsContext)
+        const [tabRendered, setTabRendered] = React.useState(false)
+        const tabIsActive = tabContextValue?.selectedId === id
 
-    React.useEffect(
-        function trackTabRenderedState() {
-            if (!tabRendered && tabIsActive) {
-                setTabRendered(true)
-            }
-        },
-        [tabRendered, tabIsActive],
-    )
+        React.useEffect(
+            function trackTabRenderedState() {
+                if (!tabRendered && tabIsActive) {
+                    setTabRendered(true)
+                }
+            },
+            [tabRendered, tabIsActive],
+        )
 
-    if (!tabContextValue) {
-        return null
-    }
+        if (!tabContextValue) {
+            return null
+        }
 
-    const { color, variant, ...tabState } = tabContextValue
+        const { color, variant, ...tabState } = tabContextValue
 
-    return (
-        <BaseTabPanel tabId={id} {...tabState} {...props} as={as} ref={ref}>
-            {render === 'always' ? children : null}
-            {render === 'active' && tabIsActive ? children : null}
-            {render === 'lazy' && (tabIsActive || tabRendered) ? children : null}
-        </BaseTabPanel>
-    )
-})
+        return (
+            <BaseTabPanel tabId={id} {...tabState} {...props} as={as} ref={ref}>
+                {render === 'always' ? children : null}
+                {render === 'active' && tabIsActive ? children : null}
+                {render === 'lazy' && (tabIsActive || tabRendered) ? children : null}
+            </BaseTabPanel>
+        )
+    },
+)
 
 type TabAwareSlotProps = {
     /**
@@ -229,10 +231,8 @@ type TabAwareSlotProps = {
  * Allows content to be rendered based on the current tab being selected while outside of the TabPanel
  * component. Can be placed freely within the main `<Tabs>` component.
  */
-function TabAwareSlot({ children }: TabAwareSlotProps): React.ReactElement | null {
+export function TabAwareSlot({ children }: TabAwareSlotProps): React.ReactElement | null {
     const tabContextValue = React.useContext(TabsContext)
 
     return tabContextValue ? children({ selectedId: tabContextValue.selectedId }) : null
 }
-
-export { Tabs, TabList, Tab, TabPanel, TabAwareSlot }

--- a/src/new-components/tabs/tabs.tsx
+++ b/src/new-components/tabs/tabs.tsx
@@ -9,6 +9,7 @@ import {
 } from 'reakit/Tab'
 import { Inline } from '../inline'
 import { usePrevious } from '../../hooks/use-previous'
+import { polymorphicComponent } from '../../utils/polymorphism'
 import type { ResponsiveProp } from '../responsive-props'
 import type { Space } from '../common-types'
 
@@ -184,7 +185,10 @@ type TabPanelProps = {
 /**
  * Used to define the content to be rendered when a tab is active. Each `<TabPanel>` must have a corresponding `<Tab>` component.
  */
-function TabPanel({ children, id, render = 'always' }: TabPanelProps): React.ReactElement | null {
+const TabPanel = polymorphicComponent<'div', TabPanelProps, 'omitClassName'>(function TabPanel(
+    { children, id, as, render = 'always', ...props },
+    ref,
+): React.ReactElement | null {
     const tabContextValue = React.useContext(TabsContext)
     const [tabRendered, setTabRendered] = React.useState(false)
     const tabIsActive = tabContextValue?.selectedId === id
@@ -205,13 +209,13 @@ function TabPanel({ children, id, render = 'always' }: TabPanelProps): React.Rea
     const { color, variant, ...tabState } = tabContextValue
 
     return (
-        <BaseTabPanel tabId={id} {...tabState}>
+        <BaseTabPanel tabId={id} {...tabState} {...props} as={as} ref={ref}>
             {render === 'always' ? children : null}
             {render === 'active' && tabIsActive ? children : null}
             {render === 'lazy' && (tabIsActive || tabRendered) ? children : null}
         </BaseTabPanel>
     )
-}
+})
 
 type TabAwareSlotProps = {
     /**


### PR DESCRIPTION

## Short description

This uses Ernesto's new `polymorphicComponent` helper (which works awesome 👏) to add support for an `as` prop to `TabPanel`, which allows it to render any element/component users specify.

Example taken from the new story - `TabPanel` being rendered as a `Box` and a `section`:

![image](https://user-images.githubusercontent.com/8531248/130990163-6f87a6a5-1e30-420f-9703-19ce049228d7.png)

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Next beta
