### PR TITLE
Better adjust a modal's vertical position when in fitContent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+## next
+
+-   [Fix] Modals that fit their content's height now expand their height only downwards, and are not
+    kept vertically centered, but slightly towards the top of the screen.
+
 ## v10.0.0-beta.6
 
 -   [Feature] Add a new `loading` prop for `Button` and `ButtonLink`, to set them as busy, and

--- a/src/new-components/modal/modal.module.css
+++ b/src/new-components/modal/modal.module.css
@@ -10,6 +10,7 @@
 :root {
     --reach-dialog: 1;
     --reactist-modal-overlay-fill: rgba(0, 0, 0, 0.5);
+    --reactist-modal-padding-top: 13vh;
 }
 
 .reach-portal {
@@ -41,6 +42,13 @@
     height: 100%;
     box-sizing: border-box;
     padding: var(--reactist-spacing-xxlarge);
+}
+
+[data-reach-dialog-overlay].fitContent > [data-focus-lock-disabled] {
+    padding-top: var(--reactist-modal-padding-top);
+}
+[data-reach-dialog-overlay].fitContent > [data-focus-lock-disabled] .container {
+    max-height: calc(100vh - 2 * var(--reactist-modal-padding-top));
 }
 
 [data-reach-dialog-content] {


### PR DESCRIPTION
## Short description

There are two modes by which modals handle vertical space (not introduced in this PR, is what we've already have):

1. Some modals expand to fill most of the viewport height (`height="expand"`).
2. Other modals fit their content's height (`height="fitContent"`).

> **Note:** in both cases the modal body's content is set to scroll if it becomes larger than the larger height they can fill.

### What's changing

This PR does not change what modes we have. It only changes how the mode `height="fitContent"` positions the modal vertically.

- **Before this PR**, these `fitContent` modals were vertically centred all the time. This caused a problem with modals that have content that causes them to change their height dynamically. These modals would then jump in both directions, shrinking and expanding as the content height changed.
- **With this PR**, the modal is kept at a fixed separation from the top of the viewport, and the bottom edge is the only one that will expand and shrink up and down as the content height changes.
    - In case the modal height expands too much, we also make sure that the bottom edge keeps separated from the bottom viewport edge at least the same amount of space we leave at the top.

Relevant thread: https://twist.com/a/1585/ch/81455/t/2755963/

### Demo

![CleanShot 2021-09-10 at 16 48 56](https://user-images.githubusercontent.com/15199/132910949-36214db2-ca32-4145-9207-197984885b17.gif)

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

I'll merge this, but will not release it on its own, as it is not urgent. It will get combined with future PRs into the next beta patch release.