### PR TITLE
Button style improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 -   [Fix] Better adjust spacing inside buttons, so that the side with an icon has a similar padding
     than the side with no icon.
+-   [Tweak] Button hover styles are now also used when the button is focused, or it is expanded
+    (e.g. in the case of menu buttons).
 
 ## v10.0.0-beta.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
     than the side with no icon.
 -   [Tweak] Button hover styles are now also used when the button is focused, or it is expanded
     (e.g. in the case of menu buttons).
+-   [Tweak] Make button colors transition smoothly.
 
 ## v10.0.0-beta.7
 

--- a/src/new-components/base-button/base-button.module.css
+++ b/src/new-components/base-button/base-button.module.css
@@ -126,6 +126,8 @@
     background-color: var(--reactist-btn-idle-fill);
 }
 
+.baseButton[aria-expanded='true'],
+.baseButton:focus:not([aria-disabled='true']),
 .baseButton:hover:not([aria-disabled='true']) {
     color: var(--reactist-btn-hover-tint);
     background-color: var(--reactist-btn-hover-fill);

--- a/src/new-components/base-button/base-button.module.css
+++ b/src/new-components/base-button/base-button.module.css
@@ -82,6 +82,11 @@
     text-decoration: none;
     /* border is always on, but transparent, so that it does not enlarge buttons when we actually color it */
     border: 1px solid transparent;
+
+    /* smooth color transitions */
+    transition-duration: 0.3s;
+    transition-property: color, background-color;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* nice little animation when clicked to give some visual feedback */


### PR DESCRIPTION
## Short description

- I realized while using the new snooze menu button in twist that the new button component should stay highlighted (as if it were hovered) when used as a menu button and that menu is expanded.
- Another improvement here is borrowed from Twist buttons in the onboarding pages: the colour changes now feature a transition. It is a very slight effect, but it's a nice touch. For instance, when the button's background colour changes when hovered, the button colour changes.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

To be merged only, without a release. It will go out in the next beta release, possibly gathered alongside other changes.