### PR TITLE
Button min width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
     (e.g. in the case of menu buttons).
 -   [Tweak] Make button colors transition smoothly.
 -   [Tweak] Adjust modal widths to the new design system defaults.
+-   [Tweak] Buttons with a visual text label (i.e. buttons that are not icon-only buttons) now have
+    a minimum width set, so they don't get too small for extremely short labels.
 
 ## v10.0.0-beta.7
 

--- a/src/new-components/base-button/base-button.module.css
+++ b/src/new-components/base-button/base-button.module.css
@@ -146,6 +146,10 @@
 
 /* icons */
 
+.baseButton:not(.iconButton) {
+    min-width: 68px;
+}
+
 .baseButton.iconButton {
     width: var(--reactist-btn-height);
     height: var(--reactist-btn-height);

--- a/src/new-components/button-link/button-link.stories.mdx
+++ b/src/new-components/button-link/button-link.stories.mdx
@@ -491,19 +491,19 @@ export function Template({ label, variant, tone, size }) {
             <Heading level="2">Click on the buttons to see the loading state</Heading>
             <Inline space="large">
                 <Stack space="large">
-                    <Box>
+                    <Box maxWidth="xsmall">
                         <LoadingButtonLink variant={variant} tone={tone} size={size}>
                             {label}
                         </LoadingButtonLink>
                     </Box>
-                    <Box>
+                    <Box maxWidth="xsmall">
                         <LoadingButtonLink variant={variant} tone={tone} size={size} disabled>
                             {label}
                         </LoadingButtonLink>
                     </Box>
                 </Stack>
                 <Stack space="large">
-                    <Box>
+                    <Box maxWidth="xsmall">
                         <LoadingButtonLink
                             variant={variant}
                             tone={tone}
@@ -513,7 +513,7 @@ export function Template({ label, variant, tone, size }) {
                             {label}
                         </LoadingButtonLink>
                     </Box>
-                    <Box>
+                    <Box maxWidth="xsmall">
                         <LoadingButtonLink
                             variant={variant}
                             tone={tone}
@@ -526,7 +526,7 @@ export function Template({ label, variant, tone, size }) {
                     </Box>
                 </Stack>
                 <Stack space="large">
-                    <Box>
+                    <Box maxWidth="xsmall">
                         <LoadingButtonLink
                             variant={variant}
                             tone={tone}
@@ -536,7 +536,7 @@ export function Template({ label, variant, tone, size }) {
                             {label}
                         </LoadingButtonLink>
                     </Box>
-                    <Box>
+                    <Box maxWidth="xsmall">
                         <LoadingButtonLink
                             variant={variant}
                             tone={tone}
@@ -583,10 +583,12 @@ export function Template({ label, variant, tone, size }) {
             label: {
                 control: { type: 'select' },
                 options: [
+                    'OK',
                     'Submit',
                     'Mark as done',
                     'Yes, cancel my subscription',
                     'Click me <em>now</em>',
+                    'If you click me now, youʼll take away the biggest part of me',
                 ],
                 defaultValue: 'Submit',
             },
@@ -610,6 +612,10 @@ export function Template({ label, variant, tone, size }) {
             endIcon: { control: false },
             icon: { control: false },
             tooltip: { control: false },
+            openInNewTab: { control: false },
+            target: { control: false },
+            rel: { control: false },
+            as: { control: false },
             exceptionallySetClassName: { control: false },
         }}
         name="Playground"

--- a/src/new-components/button/button.stories.mdx
+++ b/src/new-components/button/button.stories.mdx
@@ -567,6 +567,7 @@ export function Template({ label, variant, tone, size }) {
             label: {
                 control: { type: 'select' },
                 options: [
+                    'OK',
                     'Submit',
                     'Mark as done',
                     'Yes, cancel my subscription',


### PR DESCRIPTION
## Short description

Buttons with a visual text label (i.e. buttons that are not icon-only buttons) now have a minimum width set, so they don't get too small for extremely short labels.

## PR Checklist

-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`

## Versioning

To be merged as is. It will be included in an upcoming release that we'll prepare soon, but not in this PR.