### PR TITLE
Box width/maxWidth/minWidth improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+## next
+
+-   [Feat] Box maxWidth and minWidth are now driven by configurable CSS variables.
+-   [Feat] Box width prop now supports new values (`maxContent`, `minContent`, `fitContent`, `auto`,
+    `full`, and values from `xsmall` to `xlarge`).
+
 ## v10.0.0-beta.12
 
 -   [Tweak] Upgrade Storybook to version v6.3.10

--- a/src/new-components/box/box.module.css
+++ b/src/new-components/box/box.module.css
@@ -120,46 +120,6 @@ pre.box {
     }
 }
 
-/* min-width */
-.minWidth-0 {
-    min-width: 0px;
-}
-.minWidth-xsmall {
-    min-width: 220px;
-}
-.minWidth-small {
-    min-width: 400px;
-}
-.minWidth-medium {
-    min-width: 660px;
-}
-.minWidth-large {
-    max-width: 940px;
-}
-.minWidth-xlarge {
-    min-width: 1280px;
-}
-
-/* max-width */
-.maxWidth-xsmall {
-    max-width: 220px;
-}
-.maxWidth-small {
-    max-width: 400px;
-}
-.maxWidth-medium {
-    max-width: 660px;
-}
-.maxWidth-large {
-    max-width: 940px;
-}
-.maxWidth-xlarge {
-    max-width: 1280px;
-}
-.maxWidth-full {
-    max-width: 100%;
-}
-
 /* flex-direction */
 .flexDirection-column {
     flex-direction: column;

--- a/src/new-components/box/box.module.css
+++ b/src/new-components/box/box.module.css
@@ -281,10 +281,7 @@ pre.box {
     overflow: scroll;
 }
 
-/* full width and height */
-.width-full {
-    width: 100%;
-}
+/* height */
 .height-full {
     height: 100%;
 }

--- a/src/new-components/box/box.stories.tsx
+++ b/src/new-components/box/box.stories.tsx
@@ -15,6 +15,7 @@ import { Box } from './box'
 import { Inline } from '../inline'
 import { Stack } from '../stack'
 import { Text } from '../text'
+import { Heading } from '../heading'
 
 import type {
     BoxDisplay,
@@ -26,7 +27,6 @@ import type {
     BoxPaddingProps,
 } from './'
 import type { Space, SpaceWithNegatives } from '../common-types'
-import { Heading } from '../heading'
 
 export default {
     title: 'Design system/Box',
@@ -36,16 +36,16 @@ export default {
 export function InteractivePropsStory(args: PartialProps<typeof Box>) {
     return (
         <Wrapper border={true}>
-            <Box background="selected" {...args}>
-                <div>One</div>
-                <div>Two</div>
-                <div>Three</div>
-            </Box>
+            <Box background="selected" {...args} />
         </Wrapper>
     )
 }
 
 InteractivePropsStory.argTypes = {
+    children: {
+        control: { type: 'text' },
+        defaultValue: 'The quick brown fox jumps over the lazy dog.',
+    },
     display: select<BoxDisplay>(['block', 'inlineBlock', 'inline', 'flex', 'none'], 'block'),
     flexDirection: selectWithNone<BoxFlexDirection>(['column', 'row'], 'row'),
     flexWrap: selectWithNone<BoxFlexWrap>(['wrap', 'nowrap'], 'nowrap'),

--- a/src/new-components/box/box.tsx
+++ b/src/new-components/box/box.tsx
@@ -14,6 +14,7 @@ import type {
 import styles from './box.module.css'
 import paddingStyles from './padding.module.css'
 import marginStyles from './margin.module.css'
+import widthStyles from './width.module.css'
 
 interface BoxPaddingProps {
     padding?: ResponsiveProp<Space>
@@ -142,8 +143,10 @@ const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
                     styles.box,
                     display ? getClassNames(styles, 'display', display) : null,
                     position !== 'static' ? getClassNames(styles, 'position', position) : null,
-                    minWidth != null ? getClassNames(styles, 'minWidth', String(minWidth)) : null,
-                    getClassNames(styles, 'maxWidth', maxWidth),
+                    minWidth != null
+                        ? getClassNames(widthStyles, 'minWidth', String(minWidth))
+                        : null,
+                    getClassNames(widthStyles, 'maxWidth', maxWidth),
                     textAlign !== 'start' ? getClassNames(styles, 'textAlign', textAlign) : null,
                     // padding
                     getClassNames(paddingStyles, 'paddingTop', resolvedPaddingTop),

--- a/src/new-components/box/box.tsx
+++ b/src/new-components/box/box.tsx
@@ -52,7 +52,7 @@ type BoxOverflow = 'hidden' | 'auto' | 'visible' | 'scroll'
 type BoxMaxMinWidth = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
 type BoxMinWidth = 0 | BoxMaxMinWidth
 type BoxMaxWidth = BoxMaxMinWidth | 'full'
-type BoxWidth = 'full' | 'auto' | 'maxContent' | 'minContent' | 'fitContent'
+type BoxWidth = 0 | BoxMaxMinWidth | 'full' | 'auto' | 'maxContent' | 'minContent' | 'fitContent'
 
 interface BorderProps {
     borderRadius?: 'standard' | 'none' | 'full'
@@ -171,7 +171,7 @@ const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
                     flexGrow != null ? getClassNames(styles, 'flexGrow', String(flexGrow)) : null,
                     // other props
                     getClassNames(styles, 'overflow', overflow),
-                    getClassNames(widthStyles, 'width', width),
+                    width != null ? getClassNames(widthStyles, 'width', String(width)) : null,
                     getClassNames(styles, 'height', height),
                     getClassNames(styles, 'bg', background),
                     borderRadius !== 'none'

--- a/src/new-components/box/box.tsx
+++ b/src/new-components/box/box.tsx
@@ -36,7 +36,6 @@ interface BoxMarginProps {
     marginLeft?: ResponsiveProp<SpaceWithNegatives>
 }
 
-type BoxMaxMinWidth = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
 type BoxDisplay = 'block' | 'flex' | 'inline' | 'inlineBlock' | 'inlineFlex' | 'none'
 type BoxFlexDirection = 'column' | 'row'
 type BoxFlexWrap = 'nowrap' | 'wrap'
@@ -50,14 +49,18 @@ type BoxJustifyContent =
     | 'spaceEvenly'
 type BoxOverflow = 'hidden' | 'auto' | 'visible' | 'scroll'
 
+type BoxMaxMinWidth = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
+type BoxMinWidth = 0 | BoxMaxMinWidth
+type BoxMaxWidth = BoxMaxMinWidth | 'full'
+
 interface BorderProps {
     borderRadius?: 'standard' | 'none' | 'full'
     border?: DividerWeight
 }
 
 interface ReusableBoxProps extends BorderProps, BoxPaddingProps {
-    minWidth?: 0 | BoxMaxMinWidth
-    maxWidth?: BoxMaxMinWidth | 'full'
+    minWidth?: BoxMinWidth
+    maxWidth?: BoxMaxWidth
     background?: 'default' | 'aside' | 'highlight' | 'selected'
     flexGrow?: 0 | 1
     flexShrink?: 0
@@ -188,7 +191,8 @@ export type {
     BoxPaddingProps,
     BoxMarginProps,
     ReusableBoxProps,
-    BoxMaxMinWidth,
+    BoxMinWidth,
+    BoxMaxWidth,
     BoxDisplay,
     BoxPosition,
     BoxFlexDirection,

--- a/src/new-components/box/box.tsx
+++ b/src/new-components/box/box.tsx
@@ -52,6 +52,7 @@ type BoxOverflow = 'hidden' | 'auto' | 'visible' | 'scroll'
 type BoxMaxMinWidth = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
 type BoxMinWidth = 0 | BoxMaxMinWidth
 type BoxMaxWidth = BoxMaxMinWidth | 'full'
+type BoxWidth = 'full' | 'auto' | 'maxContent' | 'minContent' | 'fitContent'
 
 interface BorderProps {
     borderRadius?: 'standard' | 'none' | 'full'
@@ -61,11 +62,10 @@ interface BorderProps {
 interface ReusableBoxProps extends BorderProps, BoxPaddingProps {
     minWidth?: BoxMinWidth
     maxWidth?: BoxMaxWidth
+    width?: BoxWidth
     background?: 'default' | 'aside' | 'highlight' | 'selected'
     flexGrow?: 0 | 1
     flexShrink?: 0
-    width?: 'full'
-    height?: 'full'
 }
 
 type BoxPosition = 'absolute' | 'fixed' | 'relative' | 'static' | 'sticky'
@@ -78,7 +78,6 @@ interface BoxProps extends WithEnhancedClassName, ReusableBoxProps, BoxMarginPro
     alignItems?: ResponsiveProp<BoxAlignItems>
     justifyContent?: ResponsiveProp<BoxJustifyContent>
     overflow?: BoxOverflow
-    width?: 'full'
     height?: 'full'
     textAlign?: ResponsiveProp<'start' | 'center' | 'end' | 'justify'>
 }
@@ -172,7 +171,7 @@ const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
                     flexGrow != null ? getClassNames(styles, 'flexGrow', String(flexGrow)) : null,
                     // other props
                     getClassNames(styles, 'overflow', overflow),
-                    getClassNames(styles, 'width', width),
+                    getClassNames(widthStyles, 'width', width),
                     getClassNames(styles, 'height', height),
                     getClassNames(styles, 'bg', background),
                     borderRadius !== 'none'

--- a/src/new-components/box/width.module.css
+++ b/src/new-components/box/width.module.css
@@ -37,3 +37,23 @@
 .maxWidth-full {
     max-width: 100%;
 }
+
+/* width */
+.width-full {
+    width: 100%;
+}
+.width-auto {
+    width: auto;
+}
+.width-maxContent {
+    width: -moz-max-content;
+    width: max-content;
+}
+.width-minContent {
+    width: -moz-min-content;
+    width: min-content;
+}
+.width-fitContent {
+    width: -moz-fit-content;
+    width: fit-content;
+}

--- a/src/new-components/box/width.module.css
+++ b/src/new-components/box/width.module.css
@@ -3,36 +3,36 @@
     min-width: 0px;
 }
 .minWidth-xsmall {
-    min-width: 220px;
+    min-width: var(--reactist-width-xsmall);
 }
 .minWidth-small {
-    min-width: 400px;
+    min-width: var(--reactist-width-small);
 }
 .minWidth-medium {
-    min-width: 660px;
+    min-width: var(--reactist-width-medium);
 }
 .minWidth-large {
-    max-width: 940px;
+    min-width: var(--reactist-width-large);
 }
 .minWidth-xlarge {
-    min-width: 1280px;
+    min-width: var(--reactist-width-xlarge);
 }
 
 /* max-width */
 .maxWidth-xsmall {
-    max-width: 220px;
+    max-width: var(--reactist-width-xsmall);
 }
 .maxWidth-small {
-    max-width: 400px;
+    max-width: var(--reactist-width-small);
 }
 .maxWidth-medium {
-    max-width: 660px;
+    max-width: var(--reactist-width-medium);
 }
 .maxWidth-large {
-    max-width: 940px;
+    max-width: var(--reactist-width-large);
 }
 .maxWidth-xlarge {
-    max-width: 1280px;
+    max-width: var(--reactist-width-xlarge);
 }
 .maxWidth-full {
     max-width: 100%;

--- a/src/new-components/box/width.module.css
+++ b/src/new-components/box/width.module.css
@@ -39,6 +39,9 @@
 }
 
 /* width */
+.width-0 {
+    width: 0px;
+}
 .width-full {
     width: 100%;
 }
@@ -56,4 +59,19 @@
 .width-fitContent {
     width: -moz-fit-content;
     width: fit-content;
+}
+.width-xsmall {
+    width: var(--reactist-width-xsmall);
+}
+.width-small {
+    width: var(--reactist-width-small);
+}
+.width-medium {
+    width: var(--reactist-width-medium);
+}
+.width-large {
+    width: var(--reactist-width-large);
+}
+.width-xlarge {
+    width: var(--reactist-width-xlarge);
 }

--- a/src/new-components/box/width.module.css
+++ b/src/new-components/box/width.module.css
@@ -1,0 +1,39 @@
+/* min-width */
+.minWidth-0 {
+    min-width: 0px;
+}
+.minWidth-xsmall {
+    min-width: 220px;
+}
+.minWidth-small {
+    min-width: 400px;
+}
+.minWidth-medium {
+    min-width: 660px;
+}
+.minWidth-large {
+    max-width: 940px;
+}
+.minWidth-xlarge {
+    min-width: 1280px;
+}
+
+/* max-width */
+.maxWidth-xsmall {
+    max-width: 220px;
+}
+.maxWidth-small {
+    max-width: 400px;
+}
+.maxWidth-medium {
+    max-width: 660px;
+}
+.maxWidth-large {
+    max-width: 940px;
+}
+.maxWidth-xlarge {
+    max-width: 1280px;
+}
+.maxWidth-full {
+    max-width: 100%;
+}

--- a/src/new-components/default-styles.less
+++ b/src/new-components/default-styles.less
@@ -22,6 +22,13 @@
     --reactist-spacing-xlarge: 24px;
     --reactist-spacing-xxlarge: 32px;
 
+    /* width */
+    --reactist-width-xsmall: 220px;
+    --reactist-width-small: 400px;
+    --reactist-width-medium: 660px;
+    --reactist-width-large: 940px;
+    --reactist-width-xlarge: 1280px;
+
     /* font family */
     --reactist-font-family: -apple-system, system-ui, 'Segoe UI', Roboto, Noto, Oxygen-Sans, Ubuntu,
         Cantrell, 'Helvetica Neue', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',

--- a/src/new-components/password-field/password-field.stories.tsx
+++ b/src/new-components/password-field/password-field.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { selectWithNone, PartialProps } from '../storybook-helper'
 import { PasswordField } from './'
 
-import type { BoxMaxMinWidth } from '../box'
+import type { BoxMaxWidth } from '../box'
 
 export default {
     title: 'Design system/PasswordField',
@@ -56,7 +56,7 @@ InteractivePropsStory.argTypes = {
         control: { type: 'text' },
         defaultValue: 'Type your password',
     },
-    maxWidth: selectWithNone<BoxMaxMinWidth>(
+    maxWidth: selectWithNone<BoxMaxWidth>(
         ['xsmall', 'small', 'medium', 'large', 'xlarge'],
         'small',
     ),

--- a/src/new-components/select-field/select-field.stories.tsx
+++ b/src/new-components/select-field/select-field.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { selectWithNone, PartialProps } from '../storybook-helper'
 import { SelectField } from './'
 
-import type { BoxMaxMinWidth } from '../box'
+import type { BoxMaxWidth } from '../box'
 
 export default {
     title: 'Design system/SelectField',
@@ -65,7 +65,7 @@ InteractivePropsStory.argTypes = {
         defaultValue:
             'The theme you select will be applied immediately. If you upgrade to premium you will have more themes to choose from.',
     },
-    maxWidth: selectWithNone<BoxMaxMinWidth>(
+    maxWidth: selectWithNone<BoxMaxWidth>(
         ['xsmall', 'small', 'medium', 'large', 'xlarge'],
         'small',
     ),

--- a/src/new-components/storybook-helper.tsx
+++ b/src/new-components/storybook-helper.tsx
@@ -64,6 +64,7 @@ function times(count: number): number[] {
 function reusableBoxProps(): Partial<Record<keyof BoxProps, ReturnType<typeof selectWithNone>>> {
     return {
         maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
+        width: selectWithNone(['full', 'auto', 'maxContent', 'minContent', 'fitContent']),
         padding: selectSize(),
         paddingX: selectSize(),
         paddingY: selectSize(),

--- a/src/new-components/storybook-helper.tsx
+++ b/src/new-components/storybook-helper.tsx
@@ -64,7 +64,18 @@ function times(count: number): number[] {
 function reusableBoxProps(): Partial<Record<keyof BoxProps, ReturnType<typeof selectWithNone>>> {
     return {
         maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
-        width: selectWithNone(['full', 'auto', 'maxContent', 'minContent', 'fitContent']),
+        width: selectWithNone([
+            'auto',
+            'maxContent',
+            'minContent',
+            'fitContent',
+            'xsmall',
+            'small',
+            'medium',
+            'large',
+            'xlarge',
+            'full',
+        ]),
         padding: selectSize(),
         paddingX: selectSize(),
         paddingY: selectSize(),

--- a/src/new-components/text-field/text-field.stories.tsx
+++ b/src/new-components/text-field/text-field.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { selectWithNone, PartialProps } from '../storybook-helper'
 import { TextField } from './'
 
-import type { BoxMaxMinWidth } from '../box'
+import type { BoxMaxWidth } from '../box'
 
 export default {
     title: 'Design system/TextField',
@@ -56,7 +56,7 @@ InteractivePropsStory.argTypes = {
         control: { type: 'text' },
         defaultValue: 'Enter your name as it appears in your ID',
     },
-    maxWidth: selectWithNone<BoxMaxMinWidth>(
+    maxWidth: selectWithNone<BoxMaxWidth>(
         ['xsmall', 'small', 'medium', 'large', 'xlarge'],
         'small',
     ),


### PR DESCRIPTION
## Short description

This PR enhances does two main things:

- Introduces CSS variables that control what size is used for the semantic values for a Box's `maxWidth` and `minWidth`.
- Enhances the `width` prop of `Box` with more supported values:
    - The same semantic values from `maxWidth` and `minWidth` (`xsmall` to `xlarge`)
    - Values encoding predefined CSS values for the `width` CSS property (`minContent`, `maxContent`, `fitContent`).

Part of this is prompted by a need that was raised in https://github.com/Doist/todoist-web/pull/3477.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

To be determined.