### PR TITLE
Remove unused CSS variables

### DIFF
--- a/src/new-components/default-styles.less
+++ b/src/new-components/default-styles.less
@@ -59,75 +59,39 @@
 
     /* background color */
     --reactist-bg-default: rgb(255, 255, 255);
-    --reactist-bg-brand: var(--reactist-chromatic-fill-blue);
+    --reactist-bg-brand: rgb(36, 111, 224);
     --reactist-bg-aside: rgb(250, 250, 250);
     --reactist-bg-highlight: rgb(242, 242, 242);
     --reactist-bg-selected: rgb(230, 230, 230);
 
     /* colors */
-    --reactist-framework-fill-accent: rgb(224, 237, 255);
-    --reactist-framework-fill-aside: rgb(250, 250, 250);
     --reactist-framework-fill-background: rgb(250, 250, 250);
-    --reactist-framework-fill-base: rgb(255, 255, 255);
-    --reactist-framework-fill-crater: rgb(242, 242, 242);
     --reactist-framework-fill-crest: rgb(230, 230, 230);
-    --reactist-framework-fill-elevated: rgb(255, 255, 255);
     --reactist-framework-fill-selected: rgb(236, 236, 236);
-    --reactist-framework-fill-highlight: rgb(242, 242, 242);
-    --reactist-framework-fill-ledge: rgb(224, 224, 224);
-    --reactist-framework-fill-peak: rgb(61, 61, 61);
-    --reactist-framework-fill-pinnacle: rgb(235, 235, 235);
-    --reactist-framework-fill-ridge: rgb(242, 242, 242);
     --reactist-framework-fill-summit: rgb(214, 214, 214);
 
     --reactist-content-primary: rgba(0, 0, 0, 0.88);
     --reactist-content-secondary: rgba(0, 0, 0, 0.56);
     --reactist-content-tertiary: rgba(0, 0, 0, 0.4);
-    --reactist-content-quaternary: rgba(0, 0, 0, 0.24);
     --reactist-content-light-on-dark: rgb(255, 255, 255);
 
-    --reactist-chromatic-fill-red: rgb(209, 69, 59);
-    --reactist-chromatic-fill-orange: rgb(235, 141, 19);
-    --reactist-chromatic-fill-green: rgb(5, 133, 39);
-    --reactist-chromatic-fill-teal: rgb(0, 126, 158);
-    --reactist-chromatic-fill-blue: rgb(36, 111, 224);
-    --reactist-chromatic-fill-purple: rgb(105, 47, 194);
-    --reactist-chromatic-fill-charcoal: rgb(82, 82, 82);
-    --reactist-chromatic-fill-grey: rgb(128, 128, 128);
-    --reactist-chromatic-fill-midnight: rgb(76, 91, 112);
-
-    --reactist-chromatic-content-red: rgb(209, 69, 59);
-    --reactist-chromatic-content-orange: rgb(235, 141, 19);
-    --reactist-chromatic-content-green: rgb(5, 133, 39);
-    --reactist-chromatic-content-green-background: rgba(5, 133, 39, 0.05);
-    --reactist-chromatic-content-green-background-highlight: rgba(5, 133, 39, 0.1);
-    --reactist-chromatic-content-teal: rgb(0, 126, 158);
-    --reactist-chromatic-content-blue: rgb(36, 111, 224);
-    --reactist-chromatic-content-purple: rgb(105, 47, 194);
-    --reactist-chromatic-content-charcoal: rgb(82, 82, 82);
-    --reactist-chromatic-content-grey: rgb(128, 128, 128);
-
-    --reactist-chromatic-highlight-blue: rgb(88, 93, 100);
-    --reactist-chromatic-highlight-green: rgb(216, 235, 221);
-    --reactist-chromatic-highlight-red: rgb(252, 242, 242);
-
     /* component-specific */
-    --reactist-switch-checked: var(--reactist-chromatic-content-green);
+    --reactist-switch-checked: rgb(5, 133, 39);
 
     /* alerts */
     --reactist-alert-tone-info-icon: #1d438c;
-    --reactist-alert-tone-info-border: var(--reactist-chromatic-content-blue);
+    --reactist-alert-tone-info-border: rgb(36, 111, 224);
     --reactist-alert-tone-info-background: rgba(36, 111, 224, 0.1);
 
     --reactist-alert-tone-positive-icon: #035017;
-    --reactist-alert-tone-positive-border: var(--reactist-chromatic-content-green);
+    --reactist-alert-tone-positive-border: rgb(5, 133, 39);
     --reactist-alert-tone-positive-background: rgba(5, 133, 39, 0.1);
 
     --reactist-alert-tone-caution-icon: #5e3704;
-    --reactist-alert-tone-caution-border: var(--reactist-chromatic-content-orange);
+    --reactist-alert-tone-caution-border: rgb(235, 141, 19);
     --reactist-alert-tone-caution-background: rgba(235, 141, 19, 0.2);
 
     --reactist-alert-tone-critical-icon: #b03d32;
-    --reactist-alert-tone-critical-border: var(--reactist-chromatic-content-red);
+    --reactist-alert-tone-critical-border: rgb(209, 69, 59);
     --reactist-alert-tone-critical-background: rgba(209, 69, 59, 0.1);
 }

--- a/src/new-components/heading/heading.module.css
+++ b/src/new-components/heading/heading.module.css
@@ -14,7 +14,7 @@
     color: var(--reactist-content-secondary);
 }
 .tone-danger {
-    color: var(--reactist-chromatic-content-red);
+    color: rgb(209, 69, 59);
 }
 
 /* font size */

--- a/src/new-components/tabs/tabs.module.css
+++ b/src/new-components/tabs/tabs.module.css
@@ -3,13 +3,13 @@
     * These are not the actual colours defined in the mocks. Until we have a colour system aligned with
     * our product libraries, these variables should be documented and customized in the consuming apps.
     */
-    --reactist-tab-primary-background: var(--reactist-chromatic-fill-blue);
+    --reactist-tab-primary-background: rgb(36, 111, 224);
     --reactist-tab-primary-foreground: var(--reactist-content-light-on-dark);
-    --reactist-tab-primary-unselected: var(--reactist-chromatic-content-blue);
+    --reactist-tab-primary-unselected: rgb(36, 111, 224);
     --reactist-tab-secondary-background: var(--reactist-framework-fill-selected);
-    --reactist-tab-secondary-foreground: var(--reactist-chromatic-content-blue);
-    --reactist-tab-secondary-unselected: var(--reactist-chromatic-content-blue);
-    --reactist-tab-tertiary-background: var(--reactist-chromatic-fill-grey);
+    --reactist-tab-secondary-foreground: rgb(36, 111, 224);
+    --reactist-tab-secondary-unselected: rgb(36, 111, 224);
+    --reactist-tab-tertiary-background: rgb(128, 128, 128);
     --reactist-tab-tertiary-foreground: var(--reactist-content-light-on-dark);
     --reactist-tab-tertiary-unselected: var(--reactist-content-tertiary);
 }

--- a/src/new-components/text-link/text-link.module.css
+++ b/src/new-components/text-link/text-link.module.css
@@ -3,7 +3,7 @@
     font-weight: inherit;
     font-family: inherit;
     text-decoration: none;
-    color: var(--reactist-chromatic-content-blue);
+    color: rgb(36, 111, 224);
     cursor: pointer;
 }
 

--- a/src/new-components/text/text.module.css
+++ b/src/new-components/text/text.module.css
@@ -26,7 +26,7 @@
     color: var(--reactist-content-secondary);
 }
 .tone-danger {
-    color: var(--reactist-chromatic-content-red);
+    color: rgb(209, 69, 59);
 }
 
 /* truncated text */

--- a/stories/components/color.stories.tsx
+++ b/stories/components/color.stories.tsx
@@ -11,19 +11,9 @@ export default {
 }
 
 const frameworkFillColors = [
-    '--reactist-framework-fill-accent',
-    '--reactist-framework-fill-aside',
     '--reactist-framework-fill-background',
-    '--reactist-framework-fill-base',
-    '--reactist-framework-fill-crater',
     '--reactist-framework-fill-crest',
-    '--reactist-framework-fill-elevated',
     '--reactist-framework-fill-selected',
-    '--reactist-framework-fill-highlight',
-    '--reactist-framework-fill-ledge',
-    '--reactist-framework-fill-peak',
-    '--reactist-framework-fill-pinnacle',
-    '--reactist-framework-fill-ridge',
     '--reactist-framework-fill-summit',
 ]
 
@@ -37,39 +27,7 @@ const contentColors = [
     '--reactist-content-primary',
     '--reactist-content-secondary',
     '--reactist-content-tertiary',
-    '--reactist-content-quaternary',
     '--reactist-content-light-on-dark',
-]
-
-const chromaticFillColors = [
-    '--reactist-chromatic-fill-red',
-    '--reactist-chromatic-fill-orange',
-    '--reactist-chromatic-fill-green',
-    '--reactist-chromatic-fill-teal',
-    '--reactist-chromatic-fill-blue',
-    '--reactist-chromatic-fill-purple',
-    '--reactist-chromatic-fill-charcoal',
-    '--reactist-chromatic-fill-grey',
-    '--reactist-chromatic-fill-midnight',
-]
-
-const chromaticContentColors = [
-    '--reactist-chromatic-content-red',
-    '--reactist-chromatic-content-orange',
-    '--reactist-chromatic-content-green',
-    '--reactist-chromatic-content-green-background',
-    '--reactist-chromatic-content-green-background-highlight',
-    '--reactist-chromatic-content-teal',
-    '--reactist-chromatic-content-blue',
-    '--reactist-chromatic-content-purple',
-    '--reactist-chromatic-content-charcoal',
-    '--reactist-chromatic-content-grey',
-]
-
-const chromaticHighlightColors = [
-    '--reactist-chromatic-highlight-blue',
-    '--reactist-chromatic-highlight-green',
-    '--reactist-chromatic-highlight-red',
 ]
 
 function Swatch({ color }: { color: string }) {
@@ -111,31 +69,6 @@ export function Colors() {
             </Heading>
             <Stack space="small">
                 {contentColors.map((color) => (
-                    <Swatch color={color} key={color} />
-                ))}
-            </Stack>
-
-            <Heading level={1} size="larger">
-                Chromatic
-            </Heading>
-
-            <Heading level={2}>Chromatic-Fill</Heading>
-            <Stack space="small">
-                {chromaticFillColors.map((color) => (
-                    <Swatch color={color} key={color} />
-                ))}
-            </Stack>
-
-            <Heading level={2}>Chromatic-Content</Heading>
-            <Stack space="small">
-                {chromaticContentColors.map((color) => (
-                    <Swatch color={color} key={color} />
-                ))}
-            </Stack>
-
-            <Heading level={2}>Chromatic-Highlight</Heading>
-            <Stack space="small">
-                {chromaticHighlightColors.map((color) => (
                     <Swatch color={color} key={color} />
                 ))}
             </Stack>


### PR DESCRIPTION
## Short description

Title says it all.

These variables were unused for the most part. They are not used in Twist. And most uses here were only the declaration and the mention in the documentation. The handful of cases in which they were used elsewhere, were to declare the value of some other variable. I copied the literal value to those other variable declarations, removing the middle man.

The new colour naming scheme does not use these variables anyway, hence my reasoning to do this.

## PR Checklist

Not much of the entries below apply to this PR. Probably none.

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Will be merged without a release. To be included in an upcoming release.