### PR TITLE
fix: Various fixes to the `ModalActions` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # next
 
+-   [Fix] `ModalActions` now ignores `null` child elements
+-   [Fix] `ModalActions` no longer wraps each child element inside a wrapper `div`
+-   [Fix] `ModalActions` flattens children inside React fragments
+-   [Fix] `Inline` no longer adds an unneeded extra wrapper `div` around it
 -   [Fix] Adds margin to Menu's viewport positioning
 -   [Feat] Updates Avatar to support responsive patterns
 

--- a/src/new-components/inline/inline.tsx
+++ b/src/new-components/inline/inline.tsx
@@ -22,23 +22,21 @@ const Inline = polymorphicComponent<'div', InlineProps>(function Inline(
     ref,
 ) {
     return (
-        <Box>
-            <Box
-                {...props}
-                as={as}
-                display="flex"
-                flexWrap="wrap"
-                className={[exceptionallySetClassName, getClassNames(styles, 'space', space)]}
-                ref={ref}
-                alignItems={mapResponsiveProp(alignY, (alignY) =>
-                    alignY === 'top' ? 'flexStart' : alignY === 'bottom' ? 'flexEnd' : 'center',
-                )}
-                justifyContent={mapResponsiveProp(align, (align) =>
-                    align === 'left' ? 'flexStart' : align === 'right' ? 'flexEnd' : 'center',
-                )}
-            >
-                {children}
-            </Box>
+        <Box
+            {...props}
+            as={as}
+            display="flex"
+            flexWrap="wrap"
+            className={[exceptionallySetClassName, getClassNames(styles, 'space', space)]}
+            ref={ref}
+            alignItems={mapResponsiveProp(alignY, (alignY) =>
+                alignY === 'top' ? 'flexStart' : alignY === 'bottom' ? 'flexEnd' : 'center',
+            )}
+            justifyContent={mapResponsiveProp(align, (align) =>
+                align === 'left' ? 'flexStart' : align === 'right' ? 'flexEnd' : 'center',
+            )}
+        >
+            {children}
         </Box>
     )
 })

--- a/src/new-components/modal/modal.test.tsx
+++ b/src/new-components/modal/modal.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { render, screen, within } from '@testing-library/react'
-import { Modal, ModalHeader, ModalFooter, ModalBody, ModalCloseButton } from './modal'
+import { Modal, ModalHeader, ModalFooter, ModalActions, ModalBody, ModalCloseButton } from './modal'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
 
@@ -189,6 +189,86 @@ describe('ModalFooter', () => {
     })
 })
 
+describe('ModalActions', () => {
+    it('renders a semantic contentinfo', () => {
+        render(<ModalActions data-testid="modal-actions">Hello</ModalActions>)
+        expect(screen.getByRole('contentinfo')).toBe(screen.getByTestId('modal-actions'))
+    })
+
+    it('does not acknowledge the className prop, but exceptionallySetClassName instead', () => {
+        render(
+            <ModalActions
+                data-testid="modal-actions"
+                // @ts-expect-error
+                className="wrong"
+                exceptionallySetClassName="right"
+            >
+                Hello
+            </ModalActions>,
+        )
+        const modalFooter = screen.getByTestId('modal-actions')
+        expect(modalFooter).toHaveClass('right')
+        expect(modalFooter).not.toHaveClass('wrong')
+    })
+
+    it('renders its children inlined inside it', () => {
+        render(
+            <ModalActions data-testid="modal-actions">
+                <button>OK</button>
+                <button>Cancel</button>
+            </ModalActions>,
+        )
+        expect(screen.getByTestId('modal-actions')).toMatchInlineSnapshot(`
+            <footer
+              class="box paddingTop-large paddingRight-large paddingBottom-large paddingLeft-large"
+              data-testid="modal-actions"
+            >
+              <div
+                class="space-large box display-flex flexDirection-row flexWrap-wrap alignItems-center justifyContent-flexEnd"
+              >
+                <button>
+                  OK
+                </button>
+                <button>
+                  Cancel
+                </button>
+              </div>
+            </footer>
+        `)
+    })
+
+    it('optionally renders a divider', () => {
+        const { rerender } = render(<ModalActions>Hello</ModalActions>)
+        expect(screen.queryByRole('separator')).not.toBeInTheDocument()
+        rerender(<ModalActions withDivider>Hello</ModalActions>)
+        expect(screen.getByRole('separator')).toBeInTheDocument()
+    })
+
+    it('ignores null children', () => {
+        render(
+            <ModalActions data-testid="modal-actions">
+                <button>OK</button>
+                <button>Cancel</button>
+                {null}
+            </ModalActions>,
+        )
+        expect(screen.getByTestId('modal-actions').firstChild?.childNodes).toHaveLength(2)
+    })
+
+    it('flattens fragments', () => {
+        render(
+            <ModalActions data-testid="modal-actions">
+                <>
+                    <button>Overwrite</button>
+                    <button>Keep copy</button>
+                </>
+                <button>Cancel</button>
+            </ModalActions>,
+        )
+        expect(screen.getByTestId('modal-actions').firstChild?.childNodes).toHaveLength(3)
+    })
+})
+
 describe('ModalBody', () => {
     it('does not acknowledge the className prop, but exceptionallySetClassName instead', () => {
         render(
@@ -277,6 +357,11 @@ describe('ModalCloseButton', () => {
     it('renders a svg icon as its content', () => {
         const { button } = renderTestCase()
         expect(button.firstElementChild?.tagName).toBe('svg')
+    })
+
+    it('does not get focus initially', () => {
+        const { button } = renderTestCase()
+        expect(button).not.toHaveFocus()
     })
 })
 

--- a/src/new-components/modal/modal.tsx
+++ b/src/new-components/modal/modal.tsx
@@ -172,13 +172,13 @@ export type ModalCloseButtonProps = Omit<
  */
 export function ModalCloseButton(props: ModalCloseButtonProps) {
     const { onDismiss } = React.useContext(ModalContext)
-    const [includeInTabOrder, setincludeInTabOrder] = React.useState(false)
+    const [includeInTabOrder, setIncludeInTabOrder] = React.useState(false)
     const [isMounted, setIsMounted] = React.useState(false)
 
     React.useEffect(
         function skipAutoFocus() {
             if (isMounted) {
-                setincludeInTabOrder(true)
+                setIncludeInTabOrder(true)
             } else {
                 setIsMounted(true)
             }
@@ -350,17 +350,17 @@ export function ModalFooter({
 // ModalActions
 //
 
+export type ModalActionsProps = ModalFooterProps
+
 /**
  * A specific version of the ModalFooter, tailored to showing an inline list of actions (buttons).
  * @see ModalFooter
  */
-export function ModalActions({ children, ...props }: ModalFooterProps) {
+export function ModalActions({ children, ...props }: ModalActionsProps) {
     return (
         <ModalFooter {...props}>
             <Inline align="right" space="large">
-                {React.Children.map(children, (child) => (
-                    <div>{child}</div>
-                ))}
+                {children}
             </Inline>
         </ModalFooter>
     )


### PR DESCRIPTION
Closes #613
Supersedes PR #614 

## Short description

This PR performs the following changes on the `ModalActions` component:

- ignore `null` children
- flatten children wrapped in React fragments
- removes the unneeded extra div wrapping each child element (following the same logic described [here](https://github.com/Doist/reactist/wiki/Simplified-markup-of-the-Stack-and-Inline-components)).

Additionally, this removes an extra `Box` wrapping the main element rendered by `Inline`. I was surprised to see it, and did several manual testing (both in the storybook, and running twist-web with my local version of Reactist with these changes in place) and, as I suspected, this outer `div` is not needed.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Queued, to be included in an upcoming release.