### PR TITLE
fix: Render menu lists in a React portal by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # next
 
+-   [Fix] `MenuList` popovers are now rendered via React portal by default ([#619](https://github.com/Doist/reactist/pull/619))
 -   [Fix] `ModalActions` now ignores `null` child elements
 -   [Fix] `ModalActions` no longer wraps each child element inside a wrapper `div`
 -   [Fix] `ModalActions` flattens children inside React fragments

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
                 "react-focus-lock": "^2.5.2",
                 "react-keyed-flatten-children": "^1.3.0",
                 "react-markdown": "^5.0.3",
-                "reakit": "1.3.0"
+                "reakit": "1.3.11",
+                "reakit-utils": "^0.15.2"
             },
             "devDependencies": {
                 "@babel/core": "^7.9.6",
@@ -24417,51 +24418,55 @@
             }
         },
         "node_modules/reakit": {
-            "version": "1.3.0",
-            "integrity": "sha512-2hTq1VQ8F5hUksyNFgCWhLuBipMlpjOIFfqwbossWgNj36pQQMsvB0kb/+vcvQ0YgS6iXCLFq9lI2O5G4wAkgw==",
+            "version": "1.3.11",
+            "resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.11.tgz",
+            "integrity": "sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==",
             "dependencies": {
-                "@popperjs/core": "^2.4.4",
+                "@popperjs/core": "^2.5.4",
                 "body-scroll-lock": "^3.1.5",
-                "reakit-system": "^0.15.0",
-                "reakit-utils": "^0.15.0",
-                "reakit-warning": "^0.6.0"
+                "reakit-system": "^0.15.2",
+                "reakit-utils": "^0.15.2",
+                "reakit-warning": "^0.6.2"
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/reakit"
+                "url": "https://opencollective.com/ariakit"
             },
             "peerDependencies": {
-                "react": "^16.8.0",
-                "react-dom": "^16.8.0"
-            }
-        },
-        "node_modules/reakit-system": {
-            "version": "0.15.0",
-            "integrity": "sha512-C7b9Jz9sU4qGpSQS5e1aGKJHoajbT3PBk3qDb5hOoc8BEpHEqkceaCH7THtVZze0I7tQUnOM9XL4DL1tO5xCxg==",
-            "dependencies": {
-                "reakit-utils": "^0.15.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0",
-                "react-dom": "^16.8.0"
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
             }
         },
         "node_modules/reakit-utils": {
-            "version": "0.15.0",
-            "integrity": "sha512-c9HWaT9XU8KQWj+dhUG01WD+D4EK5bQHq+wVwRUuTXau0e49i4udNxo/t/4M3lXeOS+WfgJ8aC00/0imgzPLTw==",
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
+            "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
             "peerDependencies": {
-                "react": "^16.8.0",
-                "react-dom": "^16.8.0"
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
             }
         },
-        "node_modules/reakit-warning": {
-            "version": "0.6.0",
-            "integrity": "sha512-D3vMUQ8fFktZ+drs4PuUlwjLanYsc6bRoYQOma2iGTfQtqwQkhFeNMDKxlBQ79GfdQtZF/ECiCaLLjDUsIseWA==",
+        "node_modules/reakit/node_modules/reakit-system": {
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
+            "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
             "dependencies": {
-                "reakit-utils": "^0.15.0"
+                "reakit-utils": "^0.15.2"
             },
             "peerDependencies": {
-                "react": "^16.8.0"
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
+            }
+        },
+        "node_modules/reakit/node_modules/reakit-warning": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
+            "integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
+            "dependencies": {
+                "reakit-utils": "^0.15.2"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0"
             }
         },
         "node_modules/realpath-native": {
@@ -48493,34 +48498,40 @@
             }
         },
         "reakit": {
-            "version": "1.3.0",
-            "integrity": "sha512-2hTq1VQ8F5hUksyNFgCWhLuBipMlpjOIFfqwbossWgNj36pQQMsvB0kb/+vcvQ0YgS6iXCLFq9lI2O5G4wAkgw==",
+            "version": "1.3.11",
+            "resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.11.tgz",
+            "integrity": "sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==",
             "requires": {
-                "@popperjs/core": "^2.4.4",
+                "@popperjs/core": "^2.5.4",
                 "body-scroll-lock": "^3.1.5",
-                "reakit-system": "^0.15.0",
-                "reakit-utils": "^0.15.0",
-                "reakit-warning": "^0.6.0"
-            }
-        },
-        "reakit-system": {
-            "version": "0.15.0",
-            "integrity": "sha512-C7b9Jz9sU4qGpSQS5e1aGKJHoajbT3PBk3qDb5hOoc8BEpHEqkceaCH7THtVZze0I7tQUnOM9XL4DL1tO5xCxg==",
-            "requires": {
-                "reakit-utils": "^0.15.0"
+                "reakit-system": "^0.15.2",
+                "reakit-utils": "^0.15.2",
+                "reakit-warning": "^0.6.2"
+            },
+            "dependencies": {
+                "reakit-system": {
+                    "version": "0.15.2",
+                    "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
+                    "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
+                    "requires": {
+                        "reakit-utils": "^0.15.2"
+                    }
+                },
+                "reakit-warning": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
+                    "integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
+                    "requires": {
+                        "reakit-utils": "^0.15.2"
+                    }
+                }
             }
         },
         "reakit-utils": {
-            "version": "0.15.0",
-            "integrity": "sha512-c9HWaT9XU8KQWj+dhUG01WD+D4EK5bQHq+wVwRUuTXau0e49i4udNxo/t/4M3lXeOS+WfgJ8aC00/0imgzPLTw==",
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
+            "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
             "requires": {}
-        },
-        "reakit-warning": {
-            "version": "0.6.0",
-            "integrity": "sha512-D3vMUQ8fFktZ+drs4PuUlwjLanYsc6bRoYQOma2iGTfQtqwQkhFeNMDKxlBQ79GfdQtZF/ECiCaLLjDUsIseWA==",
-            "requires": {
-                "reakit-utils": "^0.15.0"
-            }
         },
         "realpath-native": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.5",
+        "prop-types": "^15.6.2",
         "react": "^15.5.4 || ^16.2.0 || ^17.0.0",
-        "react-dom": "^15.5.4 || ^16.2.0 || ^17.0.0",
-        "prop-types": "^15.6.2"
+        "react-dom": "^15.5.4 || ^16.2.0 || ^17.0.0"
     },
     "devDependencies": {
         "@babel/core": "^7.9.6",
@@ -135,6 +135,7 @@
         "react-focus-lock": "^2.5.2",
         "react-keyed-flatten-children": "^1.3.0",
         "react-markdown": "^5.0.3",
-        "reakit": "1.3.0"
+        "reakit": "1.3.11",
+        "reakit-utils": "^0.15.2"
     }
 }

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -59,7 +59,12 @@ type MenuProps = Omit<Reakit.MenuInitialState, 'visible'> & {
  * management for the menu components inside it.
  */
 function Menu({ children, onItemSelect, ...props }: MenuProps) {
-    const state = Reakit.useMenuState({ loop: true, unstable_offset: [8, 8], ...props })
+    const state = Reakit.useMenuState({
+        loop: true,
+        modal: true,
+        unstable_offset: [8, 8],
+        ...props,
+    })
 
     const handleItemSelect = React.useCallback(
         function handleItemSelect(value: string | null | undefined) {


### PR DESCRIPTION
## Short description

This PR changes menu popovers so that, by default, they render in a React portal, rather than by the side of the trigger button position in the DOM.

The change in this PR was motivated by a specific issue in Twist (https://github.com/Doist/Issues/issues/4239), where the fix is to make the menu render in a portal. This can be achieved in app code without changing Reactist, by passing the `modal={true}` prop to the top-level `Menu` (i.e. `<Menu modal={true}>`).

However, I think that it is saner to make this the default, as in general, floating elements are better off being rendered near the root of the DOM. Among the reasons, for instance, is the fact that while in a deeper part of the DOM, they could inherit unwanted CSS that affects the way they look.

From [reakit's menu component documentation](https://reakit.io/docs/menu/), these below are the implications of rendering menus in this way, that are IMO also ok and even desired:

> `preventBodyScroll` is automatically enabled, focus is trapped within the dialog and the dialog is rendered within a `Portal` by default.

BTW, this change is not preventing consumers of our menu component from reverting to a non-portal menu if they so wish. They can always do so via `<Menu modal={false}>`.

Last, but not least: doing this required upgrading the Reakit version to the latest, because the menu positioning while in this portal mode was not working correctly, but in the latest version it does.

## Test plan

1. Run storybook
    - [x] see that menus work as usual.

2. Now run twist-web while linked to Reactist locally, following these steps:

    ```shell
    # In reactist's folder under this branch
    npm install
    npm run start # leave it running

    # in another terminal, in twist-web folder under the main branch
    ide twist-web run --link-reactist
    ```

    Now check the following:

    - [ ] Try out various menus all around Twist and see that they work.
    - [ ] Make sure that menus are still rendered floating nearby the button that triggered them.
    - [x] Make sure in the HTML inspector dev tool that the menu is now rendered in a portal div that's mounted right inside the `<body>` element at the bottom (see https://cln.sh/nyXpWq)
    - [ ] Try specifically the menus in the thread list. Make sure that clicking on the outside of the menu to dismiss it does not trigger navigation (see [Valente's description below about this issue](https://github.com/Doist/reactist/pull/619#issuecomment-1012086512), that he experienced during his initial review of this PR).
    - [x] Check that the Firefox-specific bug described in https://github.com/Doist/Issues/issues/4239 is no longer happening when using this setup.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

I will take the opportunity that the new release #617 has not yet been merged, and after this one gets merged, I will update that PR to include this one.