### PR TITLE
style: Update default medium font-weight to 600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # next
 
+-   [Tweak] Tabs now are styled with medium font-weight
+-   [Tweak] Updates the default medium font-weight from `500` to `600`
 -   [Fix] `ModalActions` now ignores `null` child elements
 -   [Fix] `ModalActions` no longer wraps each child element inside a wrapper `div`
 -   [Fix] `ModalActions` flattens children inside React fragments

--- a/src/new-components/default-styles.less
+++ b/src/new-components/default-styles.less
@@ -45,7 +45,7 @@
 
     /* font weight */
     --reactist-font-weight-regular: 400;
-    --reactist-font-weight-medium: 500;
+    --reactist-font-weight-medium: 600;
     --reactist-font-weight-strong: 700;
 
     /* standard divider colors */

--- a/src/new-components/tabs/tabs.module.css
+++ b/src/new-components/tabs/tabs.module.css
@@ -20,6 +20,7 @@
     border-radius: var(--reactist-border-radius-small);
     background: none;
     cursor: pointer;
+    font-weight: var(--reactist-font-weight-medium);
 }
 
 /*


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

## Short description

Recently it came to light, on https://github.com/Doist/Polish/issues/622, that the default medium font-weight (`500`) doesn't match the `600` value defined in the design system mockups.
Furthermore, the `Text` component defines `semibold` as reactistis medium font-weight:

https://github.com/Doist/reactist/blob/4d7c3a2646e634d5ceb75f02752ad812a2ee7ee4/src/new-components/text/text.module.css#L18-L20

Although `semibold` is commonly attributed to a font-weight value of `600` and not `500`.

This PR normalizes this mismatch by bumping the value to `600`. The `Text` and `Button` components are affected by this change.

Additionally, as per the [Tabs spec](https://www.figma.com/file/LYlWNzvhMDh907l07mPPQk/Product---Web?node-id=4693%3A175143), tabs should have `medium` font-weight and not `normal`. This PR also addresses it.


## Test plan

1. Run storybook
   - [x] Buttons have their font-weight value set to `600`.
   - [x] The `Text` component has a font-weight value of `600` when the `weight` prop is set to `semibold`.
   - [x] The `Tabs` component tabs font-weight is set to `600`.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->

@gnapse, I see that https://github.com/Doist/reactist/pull/617 is close to being released. Can we include these PR updates there?
