### PR TITLE
fix: [Box] Using "start" as a value for textAlign doesn't add text alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # next
 
+-   [Fix] Using `start` as a value for `Box`'s `textAlign` now adds a class to properly set the text-align value
 -   [Fix] `TextArea`'s `rows` prop is not added to the component's type definition
 
 # v11.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # next
 
--   [Fix] Using `start` as a value for `Box`'s `textAlign` now adds a class to properly set the text-align value
+-   [Fix] Using `start` as a value for `Box`'s `textAlign` now adds a class to properly set the `text-align` value
 -   [Fix] `TextArea`'s `rows` prop is not added to the component's type definition
 
 # v11.1.0

--- a/src/new-components/box/box.stories.tsx
+++ b/src/new-components/box/box.stories.tsx
@@ -25,6 +25,7 @@ import type {
     BoxJustifyContent,
     BoxMarginProps,
     BoxPaddingProps,
+    BoxTextAlign,
 } from './'
 import type { Space, SpaceWithNegatives } from '../common-types'
 
@@ -60,6 +61,7 @@ InteractivePropsStory.argTypes = {
         ['center', 'flexEnd', 'flexStart', 'spaceBetween'],
         'none',
     ),
+    textAlign: selectWithNone<BoxTextAlign>(['start', 'center', 'end', 'justify'], 'none'),
     ...reusableBoxProps(),
 }
 

--- a/src/new-components/box/box.test.tsx
+++ b/src/new-components/box/box.test.tsx
@@ -93,14 +93,14 @@ describe('Box', () => {
 
     describe('textAlign="…"', () => {
         it('adds the appropriate class names', () => {
-            const { rerender } = render(<Box data-testid="box" textAlign="start" />)
+            const { rerender } = render(<Box data-testid="box" />)
             const boxElement = screen.getByTestId('box')
             expect(boxElement).not.toHaveClass('textAlign-start')
             expect(boxElement).not.toHaveClass('textAlign-center')
             expect(boxElement).not.toHaveClass('textAlign-end')
             expect(boxElement).not.toHaveClass('textAlign-justify')
 
-            for (const align of ['center', 'end', 'justify'] as const) {
+            for (const align of ['start', 'center', 'end', 'justify'] as const) {
                 rerender(<Box data-testid="box" textAlign={align} />)
                 expect(boxElement).toHaveClass(`textAlign-${align}`)
             }

--- a/src/new-components/box/box.tsx
+++ b/src/new-components/box/box.tsx
@@ -69,6 +69,7 @@ interface ReusableBoxProps extends BorderProps, BoxPaddingProps {
 }
 
 type BoxPosition = 'absolute' | 'fixed' | 'relative' | 'static' | 'sticky'
+type BoxTextAlign = 'start' | 'center' | 'end' | 'justify'
 
 interface BoxProps extends WithEnhancedClassName, ReusableBoxProps, BoxMarginProps {
     position?: ResponsiveProp<BoxPosition>
@@ -79,7 +80,7 @@ interface BoxProps extends WithEnhancedClassName, ReusableBoxProps, BoxMarginPro
     justifyContent?: ResponsiveProp<BoxJustifyContent>
     overflow?: BoxOverflow
     height?: 'full'
-    textAlign?: ResponsiveProp<'start' | 'center' | 'end' | 'justify'>
+    textAlign?: ResponsiveProp<BoxTextAlign>
 }
 
 const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
@@ -101,7 +102,7 @@ const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
         borderRadius,
         minWidth,
         maxWidth,
-        textAlign = 'start',
+        textAlign,
         padding,
         paddingY,
         paddingX,
@@ -149,7 +150,7 @@ const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
                         ? getClassNames(widthStyles, 'minWidth', String(minWidth))
                         : null,
                     getClassNames(widthStyles, 'maxWidth', maxWidth),
-                    textAlign !== 'start' ? getClassNames(styles, 'textAlign', textAlign) : null,
+                    getClassNames(styles, 'textAlign', textAlign),
                     // padding
                     getClassNames(paddingStyles, 'paddingTop', resolvedPaddingTop),
                     getClassNames(paddingStyles, 'paddingRight', resolvedPaddingRight),
@@ -199,6 +200,7 @@ export type {
     BoxAlignItems,
     BoxJustifyContent,
     BoxOverflow,
+    BoxTextAlign,
 }
 
 export { Box }

--- a/src/new-components/heading/heading.stories.tsx
+++ b/src/new-components/heading/heading.stories.tsx
@@ -123,7 +123,7 @@ HeadingPlaygroundStory.argTypes = {
     weight: select(['regular', 'light'], 'regular'),
     lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
     tone: select(['normal', 'secondary', 'danger'], 'normal'),
-    align: select(['start', 'center', 'end', 'justify'], 'start'),
+    align: selectWithNone(['start', 'center', 'end', 'justify'], 'none'),
     children: {
         control: { type: 'text' },
         defaultValue: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit',

--- a/src/new-components/heading/heading.test.tsx
+++ b/src/new-components/heading/heading.test.tsx
@@ -118,7 +118,7 @@ describe('Heading', () => {
     describe('align="…"', () => {
         it('adds the appropriate class names', () => {
             const { rerender } = render(
-                <Heading level="1" data-testid="heading-element" align="start">
+                <Heading level="1" data-testid="heading-element">
                     Heading
                 </Heading>,
             )
@@ -128,7 +128,7 @@ describe('Heading', () => {
             expect(textElement).not.toHaveClass('textAlign-end')
             expect(textElement).not.toHaveClass('textAlign-justify')
 
-            for (const align of ['center', 'end', 'justify'] as const) {
+            for (const align of ['start', 'center', 'end', 'justify'] as const) {
                 rerender(
                     <Heading level="1" data-testid="heading-element" align={align}>
                         Heading

--- a/src/new-components/text/text.stories.tsx
+++ b/src/new-components/text/text.stories.tsx
@@ -152,7 +152,7 @@ TextPlaygroundStory.argTypes = {
     weight: select(['regular', 'semibold', 'bold'], 'regular'),
     lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
     tone: select(['normal', 'secondary', 'danger'], 'normal'),
-    align: select(['start', 'center', 'end', 'justify'], 'start'),
+    align: selectWithNone(['start', 'center', 'end', 'justify'], 'none'),
     children: {
         control: { type: 'text' },
         defaultValue: 'Lorem ipsum dolor sit amet consectetur, adipisicing elit',

--- a/src/new-components/text/text.test.tsx
+++ b/src/new-components/text/text.test.tsx
@@ -110,18 +110,14 @@ describe('Text', () => {
 
     describe('align="…"', () => {
         it('adds the appropriate class names', () => {
-            const { rerender } = render(
-                <Text data-testid="text-element" align="start">
-                    Text
-                </Text>,
-            )
+            const { rerender } = render(<Text data-testid="text-element">Text</Text>)
             const textElement = screen.getByTestId('text-element')
             expect(textElement).not.toHaveClass('textAlign-start')
             expect(textElement).not.toHaveClass('textAlign-center')
             expect(textElement).not.toHaveClass('textAlign-end')
             expect(textElement).not.toHaveClass('textAlign-justify')
 
-            for (const align of ['center', 'end', 'justify'] as const) {
+            for (const align of ['start', 'center', 'end', 'justify'] as const) {
                 rerender(
                     <Text data-testid="text-element" align={align}>
                         Text


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Closes https://github.com/Doist/reactist/issues/618

## Short description

The current behaviour of the text align prop is that it defaults to `start` when not provided, and does not apply a CSS class to the element when text align is equal to `start`. This generally works as expected for the default case, however it makes it impossible to actually add the CSS property `text-align: start;` to these box elements.

The solution for this was to remove the default value of the `textAlign` prop, and to also remove the special handling for the `start` value. This results in the same default behaviour as previously (no class is added to the element), while ensuring that providing the value "start" adds the CSS class and resulting property as expected.

This change also influences the `Heading` and `Text` components `align` prop.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

This is a bug fix that maintains the same default behaviour as previous. I believe a patch release should be fine for it.
