### PR TITLE
fix: Hide Modal Header close button column when the button is not rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # next
 
+-   [Fix] Hidding `ModalHeader` close button no longer renders the button wrapper column
 -   [Fix] Using `start` as a value for `Box`'s `textAlign` now adds a class to properly set the `text-align` value
 -   [Fix] `TextArea`'s `rows` prop is not added to the component's type definition
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # next
 
--   [Fix] Hidding `ModalHeader` close button no longer renders the button wrapper column
+-   [Fix] Hiding `ModalHeader` close button no longer renders the button wrapper column
 -   [Fix] Using `start` as a value for `Box`'s `textAlign` now adds a class to properly set the `text-align` value
 -   [Fix] `TextArea`'s `rows` prop is not added to the component's type definition
 

--- a/src/new-components/modal/modal.test.tsx
+++ b/src/new-components/modal/modal.test.tsx
@@ -140,6 +140,15 @@ describe('ModalHeader', () => {
         expect(screen.getByRole('link', { name: 'Help' })).toBeInTheDocument()
     })
 
+    it('hides the button if its content is set to `false` or `null`', () => {
+        const { rerender } = render(<ModalHeader button={false}>Hello</ModalHeader>)
+        expect(screen.queryByRole('button', { name: 'Close modal' })).not.toBeInTheDocument()
+        expect(screen.queryByTestId('button-container')).not.toBeInTheDocument()
+        rerender(<ModalHeader button={null}>Hello</ModalHeader>)
+        expect(screen.queryByRole('button', { name: 'Close modal' })).not.toBeInTheDocument()
+        expect(screen.queryByTestId('button-container')).not.toBeInTheDocument()
+    })
+
     it('optionally renders a divider', () => {
         const { rerender } = render(<ModalHeader>Hello</ModalHeader>)
         expect(screen.queryByRole('separator')).not.toBeInTheDocument()

--- a/src/new-components/modal/modal.tsx
+++ b/src/new-components/modal/modal.tsx
@@ -248,13 +248,15 @@ export function ModalHeader({
             >
                 <Columns space="large" alignY="center">
                     <Column width="auto">{children}</Column>
-                    <Column width="content" exceptionallySetClassName={styles.buttonContainer}>
-                        {typeof button !== 'boolean' ? (
-                            button
-                        ) : button === true ? (
-                            <ModalCloseButton aria-label="Close modal" autoFocus={false} />
-                        ) : null}
-                    </Column>
+                    {button === false || button === null || button === undefined ? null : (
+                        <Column width="content" exceptionallySetClassName={styles.buttonContainer}>
+                            {typeof button === 'boolean' ? (
+                                <ModalCloseButton aria-label="Close modal" autoFocus={false} />
+                            ) : (
+                                button
+                            )}
+                        </Column>
+                    )}
                 </Columns>
             </Box>
             {withDivider ? <Divider /> : null}

--- a/src/new-components/modal/modal.tsx
+++ b/src/new-components/modal/modal.tsx
@@ -248,8 +248,12 @@ export function ModalHeader({
             >
                 <Columns space="large" alignY="center">
                     <Column width="auto">{children}</Column>
-                    {button === false || button === null || button === undefined ? null : (
-                        <Column width="content" exceptionallySetClassName={styles.buttonContainer}>
+                    {button === false || button === null ? null : (
+                        <Column
+                            width="content"
+                            exceptionallySetClassName={styles.buttonContainer}
+                            data-testid="button-container"
+                        >
                             {typeof button === 'boolean' ? (
                                 <ModalCloseButton aria-label="Close modal" autoFocus={false} />
                             ) : (


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

## Short description

This PR doesn't implement any functional change, only updates the Modal Header layout. The problem that it solves is that when the close button is hidden (its prop set `false`/`null`/`undefined`), the button column is rendered, although the button isn't. The column follows the parent `Columns` component spacing specification and renders a `large` spacing, even though there's isn't actual content rendered inside it.

The following screenshot exemplifies the problem, marking the extra column in a different color.

<a href="https://codesandbox.io/s/clever-yalow-675wis">
  <img src="https://user-images.githubusercontent.com/3800074/154125273-eb6442cc-fcee-4917-8d3c-480da5881c19.png"
       alt="extra-spacing" class="screenshot">
</a>

[^1]

[^1]: https://codesandbox.io/s/clever-yalow-675wis

The solution is to not render the column when the button is hidden.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [X] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [X] Executed `npm run validate` and made sure no errors / warnings were shown
-   [X] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->

Won't be deployed for now. To be included in an upcoming release.
