### PR TITLE
feat: Allow columns to customize their height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 -   [Feat] Allow buttons to have fully rounded/circular corners.
 -   [Fix] Only apply full width labels when the button is full width
+-   [Feat] Allow columns to customize their height
 
 # v12.1.1
 

--- a/src/new-components/columns/columns.test.tsx
+++ b/src/new-components/columns/columns.test.tsx
@@ -194,9 +194,7 @@ describe('Columns', () => {
     describe('a11y', () => {
         it('renders with no a11y violations', async () => {
             const { container } = render(<Columns />)
-            const results = await axe(container)
-
-            expect(results).toHaveNoViolations()
+            expect(await axe(container)).toHaveNoViolations()
         })
     })
 })
@@ -340,6 +338,33 @@ describe('Column', () => {
         }
     })
 
+    it('allows to set the height to full to expand vertically', () => {
+        const { rerender } = render(
+            <Columns>
+                <Column data-testid="column" height="full" />
+            </Columns>,
+        )
+        const column = screen.getByTestId('column')
+        expect(column).toHaveClass('height-full')
+        expect(column.className).toContain('height')
+
+        rerender(
+            <Columns>
+                <Column data-testid="column" height="content" />
+            </Columns>,
+        )
+        expect(column).not.toHaveClass('height-full')
+        expect(column.className).not.toContain('height')
+
+        rerender(
+            <Columns>
+                <Column data-testid="column" />
+            </Columns>,
+        )
+        expect(column).not.toHaveClass('height-full')
+        expect(column.className).not.toContain('height')
+    })
+
     describe('a11y', () => {
         it('renders with no a11y violations', async () => {
             const { container } = render(
@@ -347,9 +372,7 @@ describe('Column', () => {
                     <Column>Test</Column>
                 </Columns>,
             )
-            const results = await axe(container)
-
-            expect(results).toHaveNoViolations()
+            expect(await axe(container)).toHaveNoViolations()
         })
     })
 })

--- a/src/new-components/columns/columns.tsx
+++ b/src/new-components/columns/columns.tsx
@@ -23,11 +23,12 @@ type ColumnWidth =
     | '4/5'
 
 interface ColumnProps {
+    height?: 'full' | 'content'
     width?: ColumnWidth
 }
 
 const Column = polymorphicComponent<'div', ColumnProps>(function Column(
-    { width = 'auto', children, exceptionallySetClassName, ...props },
+    { width = 'auto', height = 'content', children, exceptionallySetClassName, ...props },
     ref,
 ) {
     return (
@@ -42,7 +43,7 @@ const Column = polymorphicComponent<'div', ColumnProps>(function Column(
             ]}
             minWidth={0}
             width={width !== 'content' ? 'full' : undefined}
-            height="full"
+            height={height === 'full' ? 'full' : undefined}
             flexShrink={width === 'content' ? 0 : undefined}
             ref={ref}
         >

--- a/src/new-components/modal/modal.stories.mdx
+++ b/src/new-components/modal/modal.stories.mdx
@@ -135,7 +135,7 @@ behaviour, see [ARIA: dialog role](https://developer.mozilla.org/en-US/docs/Web/
             <Button variant="primary">Open modal</Button>
             <Modal aria-label="Modal with a settings-like custom layout">
                 <Columns height="full">
-                    <Column width="content">
+                    <Column width="content" height="full">
                         <Box height="full" background="selected">
                             <Box padding="medium">
                                 <Heading level="1">Settings</Heading>


### PR DESCRIPTION
## Short description

One issue I found while creating the demo for my Doistalk about the design system components. Having all columns to automatically fill in the entire height is not desirable. It can cause issues when used alongside `<Columns alignY="center" />`. Take the following scenario:

```jsx
<Columns alignY="center">
  <Column><Placeholder height="100" /></Column>
  <Column><Placeholder height="200" /></Column>
</Columns>
```

Since the columns expand their height fully, the `alignY` ceases to have the desired effect, because the columns are all the same height. However, their content will move towards the top, thus not being aligned vertically towards the centre. This can be seen below. The placeholders are not of the same height, so they should align by the centre. However, since the columns are filling in the full height, the `alignY="center"` effect is lost. The columns shield the placeholder elements from aligning vertically as intended.

<img width="581" alt="image" src="https://user-images.githubusercontent.com/15199/155380731-5e386992-062a-4452-a195-ceacfa28bd6d.png">

This is currently the cause of misaligned content in the Twist settings:

<img width="252" alt="image" src="https://user-images.githubusercontent.com/15199/155381164-ccb7ab24-53e8-43c0-a42e-09be4f58f2bd.png">

## PR Checklist

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Not urgent. To be merged and queued for an upcoming release to include it.