### PR TITLE
fix: Change how the menu and its backdrop are positioned in the markup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
                 "react-focus-lock": "^2.5.2",
                 "react-keyed-flatten-children": "^1.3.0",
                 "react-markdown": "^5.0.3",
-                "reakit": "1.3.0"
+                "reakit": "1.3.11",
+                "reakit-utils": "^0.15.2"
             },
             "devDependencies": {
                 "@babel/core": "^7.9.6",
@@ -24417,51 +24418,55 @@
             }
         },
         "node_modules/reakit": {
-            "version": "1.3.0",
-            "integrity": "sha512-2hTq1VQ8F5hUksyNFgCWhLuBipMlpjOIFfqwbossWgNj36pQQMsvB0kb/+vcvQ0YgS6iXCLFq9lI2O5G4wAkgw==",
+            "version": "1.3.11",
+            "resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.11.tgz",
+            "integrity": "sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==",
             "dependencies": {
-                "@popperjs/core": "^2.4.4",
+                "@popperjs/core": "^2.5.4",
                 "body-scroll-lock": "^3.1.5",
-                "reakit-system": "^0.15.0",
-                "reakit-utils": "^0.15.0",
-                "reakit-warning": "^0.6.0"
+                "reakit-system": "^0.15.2",
+                "reakit-utils": "^0.15.2",
+                "reakit-warning": "^0.6.2"
             },
             "funding": {
                 "type": "opencollective",
-                "url": "https://opencollective.com/reakit"
+                "url": "https://opencollective.com/ariakit"
             },
             "peerDependencies": {
-                "react": "^16.8.0",
-                "react-dom": "^16.8.0"
-            }
-        },
-        "node_modules/reakit-system": {
-            "version": "0.15.0",
-            "integrity": "sha512-C7b9Jz9sU4qGpSQS5e1aGKJHoajbT3PBk3qDb5hOoc8BEpHEqkceaCH7THtVZze0I7tQUnOM9XL4DL1tO5xCxg==",
-            "dependencies": {
-                "reakit-utils": "^0.15.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0",
-                "react-dom": "^16.8.0"
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
             }
         },
         "node_modules/reakit-utils": {
-            "version": "0.15.0",
-            "integrity": "sha512-c9HWaT9XU8KQWj+dhUG01WD+D4EK5bQHq+wVwRUuTXau0e49i4udNxo/t/4M3lXeOS+WfgJ8aC00/0imgzPLTw==",
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
+            "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
             "peerDependencies": {
-                "react": "^16.8.0",
-                "react-dom": "^16.8.0"
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
             }
         },
-        "node_modules/reakit-warning": {
-            "version": "0.6.0",
-            "integrity": "sha512-D3vMUQ8fFktZ+drs4PuUlwjLanYsc6bRoYQOma2iGTfQtqwQkhFeNMDKxlBQ79GfdQtZF/ECiCaLLjDUsIseWA==",
+        "node_modules/reakit/node_modules/reakit-system": {
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
+            "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
             "dependencies": {
-                "reakit-utils": "^0.15.0"
+                "reakit-utils": "^0.15.2"
             },
             "peerDependencies": {
-                "react": "^16.8.0"
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
+            }
+        },
+        "node_modules/reakit/node_modules/reakit-warning": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
+            "integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
+            "dependencies": {
+                "reakit-utils": "^0.15.2"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0"
             }
         },
         "node_modules/realpath-native": {
@@ -48493,34 +48498,40 @@
             }
         },
         "reakit": {
-            "version": "1.3.0",
-            "integrity": "sha512-2hTq1VQ8F5hUksyNFgCWhLuBipMlpjOIFfqwbossWgNj36pQQMsvB0kb/+vcvQ0YgS6iXCLFq9lI2O5G4wAkgw==",
+            "version": "1.3.11",
+            "resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.11.tgz",
+            "integrity": "sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==",
             "requires": {
-                "@popperjs/core": "^2.4.4",
+                "@popperjs/core": "^2.5.4",
                 "body-scroll-lock": "^3.1.5",
-                "reakit-system": "^0.15.0",
-                "reakit-utils": "^0.15.0",
-                "reakit-warning": "^0.6.0"
-            }
-        },
-        "reakit-system": {
-            "version": "0.15.0",
-            "integrity": "sha512-C7b9Jz9sU4qGpSQS5e1aGKJHoajbT3PBk3qDb5hOoc8BEpHEqkceaCH7THtVZze0I7tQUnOM9XL4DL1tO5xCxg==",
-            "requires": {
-                "reakit-utils": "^0.15.0"
+                "reakit-system": "^0.15.2",
+                "reakit-utils": "^0.15.2",
+                "reakit-warning": "^0.6.2"
+            },
+            "dependencies": {
+                "reakit-system": {
+                    "version": "0.15.2",
+                    "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
+                    "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
+                    "requires": {
+                        "reakit-utils": "^0.15.2"
+                    }
+                },
+                "reakit-warning": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
+                    "integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
+                    "requires": {
+                        "reakit-utils": "^0.15.2"
+                    }
+                }
             }
         },
         "reakit-utils": {
-            "version": "0.15.0",
-            "integrity": "sha512-c9HWaT9XU8KQWj+dhUG01WD+D4EK5bQHq+wVwRUuTXau0e49i4udNxo/t/4M3lXeOS+WfgJ8aC00/0imgzPLTw==",
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
+            "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
             "requires": {}
-        },
-        "reakit-warning": {
-            "version": "0.6.0",
-            "integrity": "sha512-D3vMUQ8fFktZ+drs4PuUlwjLanYsc6bRoYQOma2iGTfQtqwQkhFeNMDKxlBQ79GfdQtZF/ECiCaLLjDUsIseWA==",
-            "requires": {
-                "reakit-utils": "^0.15.0"
-            }
         },
         "realpath-native": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.5",
+        "prop-types": "^15.6.2",
         "react": "^15.5.4 || ^16.2.0 || ^17.0.0",
-        "react-dom": "^15.5.4 || ^16.2.0 || ^17.0.0",
-        "prop-types": "^15.6.2"
+        "react-dom": "^15.5.4 || ^16.2.0 || ^17.0.0"
     },
     "devDependencies": {
         "@babel/core": "^7.9.6",
@@ -135,6 +135,7 @@
         "react-focus-lock": "^2.5.2",
         "react-keyed-flatten-children": "^1.3.0",
         "react-markdown": "^5.0.3",
-        "reakit": "1.3.0"
+        "reakit": "1.3.11",
+        "reakit-utils": "0.15.2"
     }
 }

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -59,7 +59,13 @@ type MenuProps = Omit<Reakit.MenuInitialState, 'visible'> & {
  * management for the menu components inside it.
  */
 function Menu({ children, onItemSelect, ...props }: MenuProps) {
-    const state = Reakit.useMenuState({ loop: true, unstable_offset: [8, 8], ...props })
+    const state = Reakit.useMenuState({
+        loop: true,
+        modal: true,
+        unstable_fixed: true,
+        unstable_offset: [8, 8],
+        ...props,
+    })
 
     const handleItemSelect = React.useCallback(
         function handleItemSelect(value: string | null | undefined) {
@@ -107,9 +113,7 @@ const MenuButton = polymorphicComponent<'button', MenuButtonProps>(function Menu
 // MenuList
 //
 
-type MenuBackdropProps = Reakit.MenuStateReturn & {
-    children: React.ReactNode
-}
+type MenuBackdropProps = Reakit.MenuStateReturn
 
 const BACKDROP_STYLE: React.CSSProperties = {
     width: '100%',
@@ -130,7 +134,6 @@ function MenuBackdrop({
     animating,
     stopAnimation,
     modal,
-    children,
 }: MenuBackdropProps) {
     return (
         <PopoverBackdrop
@@ -141,9 +144,7 @@ function MenuBackdrop({
             stopAnimation={stopAnimation}
             modal={modal}
             style={BACKDROP_STYLE}
-        >
-            {children}
-        </PopoverBackdrop>
+        />
     )
 }
 
@@ -169,14 +170,15 @@ const MenuList = polymorphicComponent<'div', MenuListProps>(function MenuList(
     )
 
     return state.visible ? (
-        <MenuBackdrop {...state}>
+        <>
+            <MenuBackdrop {...state} />
             <Reakit.Menu
                 {...props}
                 {...state}
                 ref={ref}
                 className={classNames('reactist_menulist', exceptionallySetClassName)}
             />
-        </MenuBackdrop>
+        </>
     ) : null
 })
 


### PR DESCRIPTION
Supersedes #619
Related to fixing https://github.com/Doist/Issues/issues/4239

## Short description

This PR performs a change very similar to what I already attempted in #619, but with an added change that apparently contributes to the fix: rendering the menu backdrop (overlay) not as a parent of the menu, but as a sibling instead.

So while #619 attempted to do something like this (tag names are for reference, but they're all divs in reality):

```markup
<react-portal>
  <backdrop-div>
    <menu-popover>…</menu-popover>
  </backdrop-div>
</react-portal>
```

This PR does it like this

```markup
<react-portal>
  <backdrop-div />
</react-portal>
<react-portal>
    <menu-popover>…</menu-popover>
</react-portal>
```

## Test plan

1. Run storybook
    - [ ] see that menus work as usual.

2. In twist-web, remove [this CSS](https://github.com/Doist/twist-web/blob/9daaf17d0094326e0d02af0d46a9502b46af4844/src/components/styles/reactist.less#L255-L257) (which will have to be removed in the PR that ends up upgrading Reactist wit this change in place)

3. Now run twist-web while linked to Reactist locally, following these steps:

    ```shell
    # In reactist's folder under this branch
    npm install
    npm run start # leave it running

    # in another terminal, in twist-web folder under the main branch
    ide twist-web run --link-reactist
    ```

4. Now check the following:

    - [ ] Try out various menus all around Twist and see that they work. Specifically, try to trigger menus that might break due to z-index issues (e.g. the thread view header menus when the view header is already "lifted" on top of the scrolling content, things like that). In general, try to see if you can break any menu in twist-web.
    - [ ] Make sure that menus are still rendered floating nearby the button that triggered them.
    - [ ] Make sure in the HTML inspector dev tool that the menu is now rendered in a couple of portal div that are mounted right inside the `<body>` element at the bottom (see https://cln.sh/nyXpWq)
    - [ ] Try specifically the menus in the thread list (each thread's options menu, ). Make sure that clicking on the outside of the menu to dismiss it does not trigger navigation (see [Valente's description below about this issue](https://github.com/Doist/reactist/pull/619#issuecomment-1012086512), that he experienced during his initial review of this PR).
    - [ ] Check that the Firefox-specific bug described in https://github.com/Doist/Issues/issues/4239 is no longer happening when using this setup.

## Versioning

Patch release (bug fix, no new features or breaking changes).