### PR TITLE
feat: Allow buttons to customize tooltip `gapSize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 -   [Fix] Hiding `ModalHeader` close button no longer renders the button wrapper column
 -   [Fix] Using `start` as a value for `Box`'s `textAlign` now adds a class to properly set the `text-align` value
 -   [Fix] `TextArea`'s `rows` prop is not added to the component's type definition
+-   [Feat] Updates `Button` to support `gapSize` from `Tooltip` (as `tooltipGapSize`)
 
 # v11.1.0
 

--- a/src/new-components/base-button/base-button.tsx
+++ b/src/new-components/base-button/base-button.tsx
@@ -47,6 +47,10 @@ type CommonProps = {
      * A tooltip linked to the button element.
      */
     tooltip?: TooltipProps['content']
+    /**
+     * The distance between the button element and the linked tooltip.
+     */
+    tooltipGapSize?: TooltipProps['gapSize']
 }
 
 type IconButtonProps = {
@@ -84,6 +88,7 @@ export const BaseButton = polymorphicComponent<'div', BaseButtonProps>(function 
         disabled = false,
         loading = false,
         tooltip,
+        tooltipGapSize,
         onClick,
         exceptionallySetClassName,
         children,
@@ -135,7 +140,9 @@ export const BaseButton = polymorphicComponent<'div', BaseButtonProps>(function 
     // If it's an icon-only button, make sure it uses the aria-label as tooltip if no tooltip was provided
     const tooltipContent = icon ? tooltip ?? props['aria-label'] : tooltip
     return tooltipContent ? (
-        <Tooltip content={tooltipContent}>{buttonElement}</Tooltip>
+        <Tooltip content={tooltipContent} gapSize={tooltipGapSize}>
+            {buttonElement}
+        </Tooltip>
     ) : (
         buttonElement
     )


### PR DESCRIPTION
## Short description

Exposes the  `gapSize` prop from `<Tooltip>` as a `tooltipGapSize` prop in `<Button>`. This is required by the new editor toolbar:

![image](https://user-images.githubusercontent.com/96476/155986423-226894ae-3ce9-4205-abb3-67babd4edbfb.png)

We need to push the tooltip further up a bit.

## PR Checklist

-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`

## Versioning

New feature required for the new editor toolbar, to be released as soon as it's merged.