### PR TITLE
feat: Update Heading component to support a semibold weight value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # Next
 
--   n/a
+-   [Feat] Updates `Heading` to support `semibold` weight prop value.
 
 # v11.2.0
 

--- a/src/new-components/heading/heading.module.css
+++ b/src/new-components/heading/heading.module.css
@@ -7,6 +7,9 @@
 .weight-light {
     font-weight: var(--reactist-font-weight-regular);
 }
+.weight-semibold {
+    font-weight: var(--reactist-font-weight-medium);
+}
 
 /* tone */
 

--- a/src/new-components/heading/heading.stories.tsx
+++ b/src/new-components/heading/heading.stories.tsx
@@ -99,7 +99,7 @@ export function ResponsiveHeadingStory(props: React.ComponentProps<typeof Headin
 ResponsiveHeadingStory.argTypes = {
     level: select(['1', '2', '3', '4', '5', '6'], '1'),
     size: selectWithNone(['largest', 'larger', 'smaller'], 'none'),
-    weight: select(['regular', 'light'], 'regular'),
+    weight: select(['regular', 'light', 'semibold'], 'regular'),
     lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
     tone: select(['normal', 'secondary', 'danger'], 'normal'),
     align: { control: false },
@@ -120,7 +120,7 @@ export function HeadingPlaygroundStory(props: React.ComponentProps<typeof Headin
 HeadingPlaygroundStory.argTypes = {
     level: select(['1', '2', '3', '4', '5', '6'], '1'),
     size: selectWithNone(['largest', 'larger', 'smaller'], 'none'),
-    weight: select(['regular', 'light'], 'regular'),
+    weight: select(['regular', 'light', 'semibold'], 'regular'),
     lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
     tone: select(['normal', 'secondary', 'danger'], 'normal'),
     align: selectWithNone(['start', 'center', 'end', 'justify'], 'none'),

--- a/src/new-components/heading/heading.test.tsx
+++ b/src/new-components/heading/heading.test.tsx
@@ -82,13 +82,19 @@ describe('Heading', () => {
             const textElement = screen.getByTestId('heading-element')
             expect(textElement).not.toHaveClass('weight-regular')
             expect(textElement).not.toHaveClass('weight-light')
+            expect(textElement).not.toHaveClass('weight-semibold')
 
             rerender(
                 <Heading level="1" data-testid="heading-element" weight="light">
                     Heading
                 </Heading>,
             )
-            expect(textElement).toHaveClass('weight-light')
+            rerender(
+                <Heading level="1" data-testid="heading-element" weight="semibold">
+                    Heading
+                </Heading>,
+            )
+            expect(textElement).toHaveClass('weight-semibold')
         })
     })
 

--- a/src/new-components/heading/heading.tsx
+++ b/src/new-components/heading/heading.tsx
@@ -25,7 +25,7 @@ type HeadingProps = SupportedHeadingElementProps & {
      *
      * @default 'regular'
      */
-    weight?: 'regular' | 'light'
+    weight?: 'regular' | 'light' | 'semibold'
     /**
      * Shifts the default heading visual text size up or down, depending on the original size
      * imposed by the `level`. The heading continues to be semantically at the given level.


### PR DESCRIPTION
## Short description

Adds `semibold` to the list of accepted values for the `Heading` component's `weight` prop.

## PR Checklist

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`

## Versioning

New heading weight required for the new [guided onboarding screen](https://www.figma.com/file/oLzMM2zBFGmjIpo4X8vo5u/TD-Onboarding---Retention-DO?node-id=298%3A70262), to be released as soon as it's merged.