### PR TITLE
feat: Add `alignSelf` to `<Box>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # Next
 
--   n/a
+-   [Feat] Added `alignSelf` prop to `Box`
 
 # v11.2.0
 

--- a/src/new-components/box/box.module.css
+++ b/src/new-components/box/box.module.css
@@ -267,6 +267,57 @@ pre.box {
     }
 }
 
+/* align-self */
+.alignSelf-stretch {
+    align-self: stretch;
+}
+.alignSelf-flexStart {
+    align-self: flex-start;
+}
+.alignSelf-center {
+    align-self: center;
+}
+.alignSelf-flexEnd {
+    align-self: flex-end;
+}
+.alignSelf-baseline {
+    align-self: baseline;
+}
+@media (min-width: 768px /* --reactist-breakpoint-tablet */) {
+    .tablet-alignSelf-stretch {
+        align-self: stretch;
+    }
+    .tablet-alignSelf-flexStart {
+        align-self: flex-start;
+    }
+    .tablet-alignSelf-center {
+        align-self: center;
+    }
+    .tablet-alignSelf-flexEnd {
+        align-self: flex-end;
+    }
+    .tablet-alignSelf-baseline {
+        align-self: baseline;
+    }
+}
+@media (min-width: 992px /* --reactist-breakpoint-desktop */) {
+    .desktop-alignSelf-stretch {
+        align-self: stretch;
+    }
+    .desktop-alignSelf-flexStart {
+        align-self: flex-start;
+    }
+    .desktop-alignSelf-center {
+        align-self: center;
+    }
+    .desktop-alignSelf-flexEnd {
+        align-self: flex-end;
+    }
+    .desktop-alignSelf-baseline {
+        align-self: baseline;
+    }
+}
+
 /* overflow */
 .overflow-hidden {
     overflow: hidden;

--- a/src/new-components/box/box.tsx
+++ b/src/new-components/box/box.tsx
@@ -47,6 +47,7 @@ type BoxJustifyContent =
     | 'spaceAround'
     | 'spaceBetween'
     | 'spaceEvenly'
+type BoxAlignSelf = 'flexStart' | 'flexEnd' | 'center' | 'baseline' | 'stretch'
 type BoxOverflow = 'hidden' | 'auto' | 'visible' | 'scroll'
 
 type BoxMaxMinWidth = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
@@ -77,6 +78,7 @@ interface BoxProps extends WithEnhancedClassName, ReusableBoxProps, BoxMarginPro
     flexDirection?: ResponsiveProp<BoxFlexDirection>
     flexWrap?: BoxFlexWrap
     alignItems?: ResponsiveProp<BoxAlignItems>
+    alignSelf?: ResponsiveProp<BoxAlignSelf>
     justifyContent?: ResponsiveProp<BoxJustifyContent>
     overflow?: BoxOverflow
     height?: 'full'
@@ -94,6 +96,7 @@ const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
         flexShrink,
         alignItems,
         justifyContent,
+        alignSelf,
         overflow,
         width,
         height,
@@ -166,6 +169,7 @@ const Box = polymorphicComponent<'div', BoxProps, 'keepClassName'>(function Box(
                     omitFlex ? null : getClassNames(styles, 'flexWrap', flexWrap),
                     omitFlex ? null : getClassNames(styles, 'alignItems', alignItems),
                     omitFlex ? null : getClassNames(styles, 'justifyContent', justifyContent),
+                    alignSelf != null ? getClassNames(styles, 'alignSelf', alignSelf) : null,
                     flexShrink != null
                         ? getClassNames(styles, 'flexShrink', String(flexShrink))
                         : null,


### PR DESCRIPTION
## Short description

Split from https://github.com/Doist/twist-web/pull/4667, this adds the `alignSelf` option so that `Box`s rendered as flex children can be aligned differently from their siblings or how the parent flex container defined its `alignItems`.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Minor release
