### PR TITLE
style: [internal] Update headers to align size, weight and line-height with Figma styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # Next
 
+-   [Feat] Updates the default `Heading` sizes, weights and line-heights to align with the product library
+
 # v11.3.0
 
 -   [Feat] Added `alignSelf` prop to `Box`

--- a/src/new-components/heading/heading.module.css
+++ b/src/new-components/heading/heading.module.css
@@ -21,6 +21,8 @@
 
 h1.heading {
     font-size: var(--reactist-font-size-header);
+    font-weight: var(--reactist-font-weight-strong);
+    line-height: 43px;
 }
 h1.size-largest {
     font-size: var(--reactist-font-size-header-xlarge);
@@ -33,7 +35,9 @@ h1.size-smaller {
 }
 
 h2.heading {
-    font-size: var(--reactist-font-size-subtitle);
+    font-size: calc(var(--reactist-font-size-header-large) + 2px);
+    font-weight: var(--reactist-font-weight-medium);
+    line-height: 35px;
 }
 h2.size-largest {
     font-size: var(--reactist-font-size-header-large);
@@ -46,7 +50,9 @@ h2.size-smaller {
 }
 
 h3.heading {
-    font-size: var(--reactist-font-size-body);
+    font-size: var(--reactist-font-size-header);
+    font-weight: var(--reactist-font-weight-medium);
+    line-height: 27px;
 }
 h3.size-largest {
     font-size: var(--reactist-font-size-header);


### PR DESCRIPTION
- A continuation of https://github.com/Doist/reactist/pull/640

## Short description

This PR aligns the default styles for the `Heading` (`h1`, `h2`, `h3`) with the styles from the [product library](https://www.figma.com/file/xo9yAsH8PQUpi0eTJh9pmR/Product---Global?node-id=2527%3A3732). More specifically:
- font-size
- font-weight
- line-height [^1]

Something for the reviewer to keep in mind - I'm concerned about how "aggressive" this change is and the impact it will have in our products as we are shifting heading sizes. I tried to contain this impact and keep it to a minimum. There are certain header variables that should be renamed, for example, to introduce the new `26px` font-size in between `-large` and `-xlarge`. But refrained from doing this. I'm still not sure on how we plan to align but I felt an aggressive approach was risky here so took a gradual one.

[^1]: Each of the headers in the product library has different line heights depending on the font, I wasn't sure how to go about this so I went for the `Segoe` line-height as the default one. Thoughts?

## PR Checklist

-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`

## Versioning

New default `Heading` sizes, weights and line-heights to align Reactist with the [product library](https://www.figma.com/file/xo9yAsH8PQUpi0eTJh9pmR/Product---Global?node-id=2527%3A3732). To be released as soon as it's merged.