### PR TITLE
feat: <Button width="full" align="start|center|end">

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # Next
 
+-   [Feat] Button can now have a width set (except icon-only buttons). When having a width, the label aligment can also be customized
 -   [Fix] Button focus styles should only be shown when interacting with the button via keyboard (using CSS's `:focus-visible`)
 
 # v11.3.0

--- a/src/new-components/base-button/base-button.module.css
+++ b/src/new-components/base-button/base-button.module.css
@@ -137,10 +137,6 @@
     --reactist-btn-font-size: var(--reactist-button-large-font-size);
 }
 
-.baseButton.width-full {
-    width: 100%;
-}
-
 /* setup the color variables for all the different states */
 /* variables are then set per variant and tone so that we do not repeat these definitions below */
 

--- a/src/new-components/base-button/base-button.module.css
+++ b/src/new-components/base-button/base-button.module.css
@@ -91,16 +91,16 @@
     text-align: center;
 }
 
-.align-left .label {
-    text-align: left;
+.align-start .label {
+    text-align: start;
 }
 
 .align-center .label {
     text-align: center;
 }
 
-.align-right .label {
-    text-align: right;
+.align-end .label {
+    text-align: end;
 }
 
 /* nice little animation when clicked to give some visual feedback */

--- a/src/new-components/base-button/base-button.module.css
+++ b/src/new-components/base-button/base-button.module.css
@@ -57,12 +57,6 @@
     --reactist-actionable-secondary-destructive-disabled-tint: #f1b7b2;
 }
 
-.label {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-}
-
 /* general styles for all buttons */
 .baseButton {
     max-width: 100%;
@@ -87,6 +81,26 @@
     transition-duration: 0.3s;
     transition-property: color, background-color;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.label {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    width: 100%;
+    text-align: center;
+}
+
+.align-left .label {
+    text-align: left;
+}
+
+.align-center .label {
+    text-align: center;
+}
+
+.align-right .label {
+    text-align: right;
 }
 
 /* nice little animation when clicked to give some visual feedback */
@@ -121,6 +135,10 @@
     --reactist-btn-height: var(--reactist-button-large-height);
     --reactist-btn-spacing: var(--reactist-button-large-spacing);
     --reactist-btn-font-size: var(--reactist-button-large-font-size);
+}
+
+.baseButton.width-full {
+    width: 100%;
 }
 
 /* setup the color variables for all the different states */

--- a/src/new-components/base-button/base-button.tsx
+++ b/src/new-components/base-button/base-button.tsx
@@ -54,7 +54,7 @@ type CommonProps = {
 }
 
 type AlignmentProps = {
-    width: 'full'
+    width: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'full'
     align?: 'left' | 'center' | 'right'
 }
 
@@ -119,6 +119,7 @@ export const BaseButton = polymorphicComponent<'div', BaseButtonProps>(function 
             ref={ref}
             aria-disabled={isDisabled}
             onClick={isDisabled ? preventDefault : onClick}
+            width={icon ? undefined : width}
             className={[
                 exceptionallySetClassName,
                 styles.baseButton,
@@ -126,7 +127,6 @@ export const BaseButton = polymorphicComponent<'div', BaseButtonProps>(function 
                 styles[`tone-${tone}`],
                 styles[`size-${size}`],
                 width !== 'auto' && icon == null && align != null ? styles[`align-${align}`] : null,
-                width !== 'auto' && icon == null ? styles[`width-${width}`] : null,
                 icon ? styles.iconButton : null,
                 disabled ? styles.disabled : null,
             ]}

--- a/src/new-components/base-button/base-button.tsx
+++ b/src/new-components/base-button/base-button.tsx
@@ -53,6 +53,16 @@ type CommonProps = {
     tooltipGapSize?: TooltipProps['gapSize']
 }
 
+type AlignmentProps = {
+    width: 'full'
+    align?: 'left' | 'center' | 'right'
+}
+
+type AutoWidthProps = {
+    width?: 'auto'
+    align?: never
+}
+
 type IconButtonProps = {
     icon: IconElement
     'aria-label': string
@@ -68,9 +78,7 @@ type LabelledButtonProps = {
     startIcon?: IconElement
     endIcon?: IconElement
     icon?: never
-    width?: 'auto' | 'full'
-    align?: 'left' | 'center' | 'right'
-}
+} & (AutoWidthProps | AlignmentProps)
 
 export type BaseButtonProps = CommonProps & (IconButtonProps | LabelledButtonProps)
 

--- a/src/new-components/base-button/base-button.tsx
+++ b/src/new-components/base-button/base-button.tsx
@@ -59,6 +59,8 @@ type IconButtonProps = {
     children?: never
     startIcon?: never
     endIcon?: never
+    width?: never
+    align?: never
 }
 
 type LabelledButtonProps = {
@@ -66,6 +68,8 @@ type LabelledButtonProps = {
     startIcon?: IconElement
     endIcon?: IconElement
     icon?: never
+    width?: 'auto' | 'full'
+    align?: 'left' | 'center' | 'right'
 }
 
 export type BaseButtonProps = CommonProps & (IconButtonProps | LabelledButtonProps)
@@ -93,6 +97,8 @@ export const BaseButton = polymorphicComponent<'div', BaseButtonProps>(function 
         startIcon,
         endIcon,
         icon,
+        width = 'auto',
+        align,
         ...props
     },
     ref,
@@ -111,6 +117,8 @@ export const BaseButton = polymorphicComponent<'div', BaseButtonProps>(function 
                 styles[`variant-${variant}`],
                 styles[`tone-${tone}`],
                 styles[`size-${size}`],
+                width !== 'auto' && icon == null && align != null ? styles[`align-${align}`] : null,
+                width !== 'auto' && icon == null ? styles[`width-${width}`] : null,
                 icon ? styles.iconButton : null,
                 disabled ? styles.disabled : null,
             ]}

--- a/src/new-components/base-button/base-button.tsx
+++ b/src/new-components/base-button/base-button.tsx
@@ -55,7 +55,7 @@ type CommonProps = {
 
 type AlignmentProps = {
     width: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'full'
-    align?: 'left' | 'center' | 'right'
+    align?: 'start' | 'center' | 'end'
 }
 
 type AutoWidthProps = {

--- a/src/new-components/button-link/button-link.stories.mdx
+++ b/src/new-components/button-link/button-link.stories.mdx
@@ -480,7 +480,7 @@ export function LoadingButtonLink(props) {
 
 ### Full-width
 
-export function FullWidthTemplate({ label, variant, tone, size }) {
+export function FullWidthTemplate({ label, variant, tone, size, width }) {
     if (label === 'Click me <em>now</em>') {
         label = (
             <>
@@ -492,7 +492,7 @@ export function FullWidthTemplate({ label, variant, tone, size }) {
         variant,
         tone,
         size,
-        width: 'full',
+        width,
         startIcon: <Icon />,
         endIcon: <Icon />,
     }
@@ -500,10 +500,10 @@ export function FullWidthTemplate({ label, variant, tone, size }) {
         <Stack space="medium">
             <Heading level="2">Full-width buttons and label alignment</Heading>
             <Text>
-                When buttons have <code>width="full"</code> they can also customize how the label is
-                aligned horizontally.
+                When buttons have `width` other than the default `auto` they can also customize how
+                the label is aligned horizontally.
             </Text>
-            <Box width="small">
+            <Box width="full" padding="medium" style={{ border: '1px solid gray' }}>
                 <Stack space="medium">
                     <LoadingButtonLink {...props} align="left">
                         {label}
@@ -551,6 +551,12 @@ export function FullWidthTemplate({ label, variant, tone, size }) {
                 control: { type: 'inline-radio' },
                 defaultValue: 'normal',
             },
+            width: {
+                options: ['none', 'xsmall', 'small', 'medium', 'large', 'xlarge', 'full'],
+                control: { type: 'select' },
+                defaultValue: 'full',
+            },
+            align: { control: false },
             disabled: { control: false },
             startIcon: { control: false },
             endIcon: { control: false },

--- a/src/new-components/button-link/button-link.stories.mdx
+++ b/src/new-components/button-link/button-link.stories.mdx
@@ -478,6 +478,92 @@ export function LoadingButtonLink(props) {
     return <ButtonLink {...props} loading={loading} onClick={(event) => setLoading(true)} />
 }
 
+### Full-width
+
+export function FullWidthTemplate({ label, variant, tone, size }) {
+    if (label === 'Click me <em>now</em>') {
+        label = (
+            <>
+                Click me <em>now</em>
+            </>
+        )
+    }
+    const props = {
+        variant,
+        tone,
+        size,
+        width: 'full',
+        startIcon: <Icon />,
+        endIcon: <Icon />,
+    }
+    return (
+        <Stack space="medium">
+            <Heading level="2">Full-width buttons and label alignment</Heading>
+            <Text>
+                When buttons have <code>width="full"</code> they can also customize how the label is
+                aligned horizontally.
+            </Text>
+            <Box width="small">
+                <Stack space="medium">
+                    <LoadingButtonLink {...props} align="left">
+                        {label}
+                    </LoadingButtonLink>
+                    <LoadingButtonLink {...props} align="center">
+                        {label}
+                    </LoadingButtonLink>
+                    <LoadingButtonLink {...props} align="right">
+                        {label}
+                    </LoadingButtonLink>
+                </Stack>
+            </Box>
+        </Stack>
+    )
+}
+
+<Canvas>
+    <Story
+        parameters={{ docs: { source: { type: 'code' } } }}
+        argTypes={{
+            label: {
+                control: { type: 'select' },
+                options: [
+                    'OK',
+                    'Submit',
+                    'Mark as done',
+                    'Yes, cancel my subscription',
+                    'Click me <em>now</em>',
+                    'If you click me now, youʼll take away the biggest part of me',
+                ],
+                defaultValue: 'Submit',
+            },
+            variant: {
+                options: ['primary', 'secondary', 'tertiary', 'quaternary'],
+                control: { type: 'select' },
+                defaultValue: 'primary',
+            },
+            tone: {
+                options: ['normal', 'destructive'],
+                control: { type: 'inline-radio' },
+                defaultValue: 'normal',
+            },
+            size: {
+                options: ['small', 'normal', 'large'],
+                control: { type: 'inline-radio' },
+                defaultValue: 'normal',
+            },
+            disabled: { control: false },
+            startIcon: { control: false },
+            endIcon: { control: false },
+            icon: { control: false },
+            tooltip: { control: false },
+            exceptionallySetClassName: { control: false },
+        }}
+        name="Full-width"
+    >
+        {FullWidthTemplate.bind({})}
+    </Story>
+</Canvas>
+
 ### Playground
 
 export function Template({ label, variant, tone, size }) {

--- a/src/new-components/button-link/button-link.stories.mdx
+++ b/src/new-components/button-link/button-link.stories.mdx
@@ -505,13 +505,13 @@ export function FullWidthTemplate({ label, variant, tone, size, width }) {
             </Text>
             <Box width="full" padding="medium" style={{ border: '1px solid gray' }}>
                 <Stack space="medium">
-                    <LoadingButtonLink {...props} align="left">
+                    <LoadingButtonLink {...props} align="start">
                         {label}
                     </LoadingButtonLink>
                     <LoadingButtonLink {...props} align="center">
                         {label}
                     </LoadingButtonLink>
-                    <LoadingButtonLink {...props} align="right">
+                    <LoadingButtonLink {...props} align="end">
                         {label}
                     </LoadingButtonLink>
                 </Stack>

--- a/src/new-components/button-link/button-link.test.tsx
+++ b/src/new-components/button-link/button-link.test.tsx
@@ -217,6 +217,27 @@ describe('ButtonLink', () => {
         expect(link).not.toHaveClass('size-small')
     })
 
+    it('applies different class names based on width and alignment', () => {
+        render(
+            <ButtonLink href="/" variant="primary" width="full" align="right">
+                Click me
+            </ButtonLink>,
+        )
+        const buttonLink = screen.getByRole('link', { name: 'Click me' })
+        expect(buttonLink).toHaveClass('align-right')
+        expect(buttonLink).toHaveClass('width-full')
+    })
+
+    it('ignores align when width is not full', () => {
+        render(
+            <ButtonLink href="/" variant="primary" align="right">
+                Click me
+            </ButtonLink>,
+        )
+        const buttonLink = screen.getByRole('link', { name: 'Click me' })
+        expect(buttonLink).not.toHaveClass('align-right')
+    })
+
     describe('with icons', () => {
         it('renders an icon before the label when startIcon is given', () => {
             render(
@@ -262,6 +283,23 @@ describe('ButtonLink', () => {
             )
             const buttonLink = screen.getByRole('link', { name: 'Smile' })
             expect(buttonLink.textContent).toMatchInlineSnapshot(`"😄"`)
+        })
+
+        it('does not support receiving any of the props "width" and "align"', () => {
+            render(
+                // @ts-expect-error invalid props on purpose
+                <ButtonLink
+                    href="/"
+                    variant="primary"
+                    icon="😄"
+                    aria-label="Smile"
+                    width="full"
+                    align="right"
+                />,
+            )
+            const buttonLink = screen.getByRole('link', { name: 'Smile' })
+            expect(buttonLink.className).not.toMatch(/align/)
+            expect(buttonLink.className).not.toMatch(/width/)
         })
     })
 

--- a/src/new-components/button-link/button-link.test.tsx
+++ b/src/new-components/button-link/button-link.test.tsx
@@ -230,6 +230,7 @@ describe('ButtonLink', () => {
 
     it('ignores align when width is not full', () => {
         render(
+            // @ts-expect-error invalid props on purpose
             <ButtonLink href="/" variant="primary" align="right">
                 Click me
             </ButtonLink>,

--- a/src/new-components/button-link/button-link.test.tsx
+++ b/src/new-components/button-link/button-link.test.tsx
@@ -219,24 +219,24 @@ describe('ButtonLink', () => {
 
     it('applies different class names based on width and alignment', () => {
         render(
-            <ButtonLink href="/" variant="primary" width="full" align="right">
+            <ButtonLink href="/" variant="primary" width="full" align="end">
                 Click me
             </ButtonLink>,
         )
         const buttonLink = screen.getByRole('link', { name: 'Click me' })
-        expect(buttonLink).toHaveClass('align-right')
+        expect(buttonLink).toHaveClass('align-end')
         expect(buttonLink).toHaveClass('width-full')
     })
 
     it('ignores align when width is not full', () => {
         render(
             // @ts-expect-error invalid props on purpose
-            <ButtonLink href="/" variant="primary" align="right">
+            <ButtonLink href="/" variant="primary" align="end">
                 Click me
             </ButtonLink>,
         )
         const buttonLink = screen.getByRole('link', { name: 'Click me' })
-        expect(buttonLink).not.toHaveClass('align-right')
+        expect(buttonLink).not.toHaveClass('align-end')
     })
 
     describe('with icons', () => {
@@ -295,7 +295,7 @@ describe('ButtonLink', () => {
                     icon="😄"
                     aria-label="Smile"
                     width="full"
-                    align="right"
+                    align="end"
                 />,
             )
             const buttonLink = screen.getByRole('link', { name: 'Smile' })

--- a/src/new-components/button/button.stories.mdx
+++ b/src/new-components/button/button.stories.mdx
@@ -467,9 +467,95 @@ export function LoadingButton(props) {
     return <Button {...props} loading={loading} onClick={() => setLoading(true)} />
 }
 
+### Full-width
+
+export function FullWidthTemplate({ label, variant, tone, size }) {
+    if (label === 'Click me <em>now</em>') {
+        label = (
+            <>
+                Click me <em>now</em>
+            </>
+        )
+    }
+    const props = {
+        variant,
+        tone,
+        size,
+        width: 'full',
+        startIcon: <Icon />,
+        endIcon: <Icon />,
+    }
+    return (
+        <Stack space="medium">
+            <Heading level="2">Full-width buttons and label alignment</Heading>
+            <Text>
+                When buttons have <code>width="full"</code> they can also customize how the label is
+                aligned horizontally.
+            </Text>
+            <Box width="small">
+                <Stack space="medium">
+                    <LoadingButton {...props} align="left">
+                        {label}
+                    </LoadingButton>
+                    <LoadingButton {...props} align="center">
+                        {label}
+                    </LoadingButton>
+                    <LoadingButton {...props} align="right">
+                        {label}
+                    </LoadingButton>
+                </Stack>
+            </Box>
+        </Stack>
+    )
+}
+
+<Canvas>
+    <Story
+        parameters={{ docs: { source: { type: 'code' } } }}
+        argTypes={{
+            label: {
+                control: { type: 'select' },
+                options: [
+                    'OK',
+                    'Submit',
+                    'Mark as done',
+                    'Yes, cancel my subscription',
+                    'Click me <em>now</em>',
+                    'If you click me now, youʼll take away the biggest part of me',
+                ],
+                defaultValue: 'Submit',
+            },
+            variant: {
+                options: ['primary', 'secondary', 'tertiary', 'quaternary'],
+                control: { type: 'select' },
+                defaultValue: 'primary',
+            },
+            tone: {
+                options: ['normal', 'destructive'],
+                control: { type: 'inline-radio' },
+                defaultValue: 'normal',
+            },
+            size: {
+                options: ['small', 'normal', 'large'],
+                control: { type: 'inline-radio' },
+                defaultValue: 'normal',
+            },
+            disabled: { control: false },
+            startIcon: { control: false },
+            endIcon: { control: false },
+            icon: { control: false },
+            tooltip: { control: false },
+            exceptionallySetClassName: { control: false },
+        }}
+        name="Full-width"
+    >
+        {FullWidthTemplate.bind({})}
+    </Story>
+</Canvas>
+
 ### Playground
 
-export function Template({ label, variant, tone, size }) {
+export function PlaygroundTemplate({ label, variant, tone, size }) {
     let textLabel = label
     if (label === 'Click me <em>now</em>') {
         label = (
@@ -604,7 +690,7 @@ export function Template({ label, variant, tone, size }) {
         }}
         name="Playground"
     >
-        {Template.bind({})}
+        {PlaygroundTemplate.bind({})}
     </Story>
 </Canvas>
 
@@ -654,7 +740,7 @@ export function DarkModeTemplate(props) {
                 '--reactist-actionable-secondary-destructive-disabled-tint': '#8a5853',
             }}
         >
-            <Template {...props} />
+            <PlaygroundTemplate {...props} />
         </Box>
     )
 }

--- a/src/new-components/button/button.stories.mdx
+++ b/src/new-components/button/button.stories.mdx
@@ -469,7 +469,7 @@ export function LoadingButton(props) {
 
 ### Full-width
 
-export function FullWidthTemplate({ label, variant, tone, size }) {
+export function FullWidthTemplate({ label, variant, tone, size, width }) {
     if (label === 'Click me <em>now</em>') {
         label = (
             <>
@@ -481,7 +481,7 @@ export function FullWidthTemplate({ label, variant, tone, size }) {
         variant,
         tone,
         size,
-        width: 'full',
+        width,
         startIcon: <Icon />,
         endIcon: <Icon />,
     }
@@ -489,10 +489,10 @@ export function FullWidthTemplate({ label, variant, tone, size }) {
         <Stack space="medium">
             <Heading level="2">Full-width buttons and label alignment</Heading>
             <Text>
-                When buttons have <code>width="full"</code> they can also customize how the label is
-                aligned horizontally.
+                When buttons have `width` other than the default `auto` they can also customize how
+                the label is aligned horizontally.
             </Text>
-            <Box width="small">
+            <Box width="full" padding="medium" style={{ border: '1px solid gray' }}>
                 <Stack space="medium">
                     <LoadingButton {...props} align="left">
                         {label}
@@ -540,6 +540,12 @@ export function FullWidthTemplate({ label, variant, tone, size }) {
                 control: { type: 'inline-radio' },
                 defaultValue: 'normal',
             },
+            width: {
+                options: ['none', 'xsmall', 'small', 'medium', 'large', 'xlarge', 'full'],
+                control: { type: 'select' },
+                defaultValue: 'full',
+            },
+            align: { control: false },
             disabled: { control: false },
             startIcon: { control: false },
             endIcon: { control: false },

--- a/src/new-components/button/button.stories.mdx
+++ b/src/new-components/button/button.stories.mdx
@@ -494,13 +494,13 @@ export function FullWidthTemplate({ label, variant, tone, size, width }) {
             </Text>
             <Box width="full" padding="medium" style={{ border: '1px solid gray' }}>
                 <Stack space="medium">
-                    <LoadingButton {...props} align="left">
+                    <LoadingButton {...props} align="start">
                         {label}
                     </LoadingButton>
                     <LoadingButton {...props} align="center">
                         {label}
                     </LoadingButton>
-                    <LoadingButton {...props} align="right">
+                    <LoadingButton {...props} align="end">
                         {label}
                     </LoadingButton>
                 </Stack>

--- a/src/new-components/button/button.test.tsx
+++ b/src/new-components/button/button.test.tsx
@@ -227,6 +227,7 @@ describe('Button', () => {
 
     it('ignores align when width is not full', () => {
         render(
+            // @ts-expect-error invalid props on purpose
             <Button variant="primary" align="right">
                 Click me
             </Button>,

--- a/src/new-components/button/button.test.tsx
+++ b/src/new-components/button/button.test.tsx
@@ -214,6 +214,27 @@ describe('Button', () => {
         expect(button).not.toHaveClass('size-small')
     })
 
+    it('applies different class names based on width and alignment', () => {
+        render(
+            <Button variant="primary" width="full" align="right">
+                Click me
+            </Button>,
+        )
+        const button = screen.getByRole('button', { name: 'Click me' })
+        expect(button).toHaveClass('align-right')
+        expect(button).toHaveClass('width-full')
+    })
+
+    it('ignores align when width is not full', () => {
+        render(
+            <Button variant="primary" align="right">
+                Click me
+            </Button>,
+        )
+        const button = screen.getByRole('button', { name: 'Click me' })
+        expect(button).not.toHaveClass('align-right')
+    })
+
     describe('with icons', () => {
         it('renders an icon before the label when startIcon is given', () => {
             render(
@@ -252,6 +273,22 @@ describe('Button', () => {
             )
             const button = screen.getByRole('button', { name: 'Smile' })
             expect(button.textContent).toMatchInlineSnapshot(`"😄"`)
+        })
+
+        it('does not support receiving any of the props "width" and "align"', () => {
+            render(
+                // @ts-expect-error invalid props on purpose
+                <Button
+                    variant="primary"
+                    icon="😄"
+                    aria-label="Smile"
+                    width="full"
+                    align="right"
+                />,
+            )
+            const button = screen.getByRole('button', { name: 'Smile' })
+            expect(button.className).not.toMatch(/align/)
+            expect(button.className).not.toMatch(/width/)
         })
     })
 

--- a/src/new-components/button/button.test.tsx
+++ b/src/new-components/button/button.test.tsx
@@ -216,24 +216,24 @@ describe('Button', () => {
 
     it('applies different class names based on width and alignment', () => {
         render(
-            <Button variant="primary" width="full" align="right">
+            <Button variant="primary" width="full" align="end">
                 Click me
             </Button>,
         )
         const button = screen.getByRole('button', { name: 'Click me' })
-        expect(button).toHaveClass('align-right')
+        expect(button).toHaveClass('align-end')
         expect(button).toHaveClass('width-full')
     })
 
     it('ignores align when width is not full', () => {
         render(
             // @ts-expect-error invalid props on purpose
-            <Button variant="primary" align="right">
+            <Button variant="primary" align="end">
                 Click me
             </Button>,
         )
         const button = screen.getByRole('button', { name: 'Click me' })
-        expect(button).not.toHaveClass('align-right')
+        expect(button).not.toHaveClass('align-end')
     })
 
     describe('with icons', () => {
@@ -279,13 +279,7 @@ describe('Button', () => {
         it('does not support receiving any of the props "width" and "align"', () => {
             render(
                 // @ts-expect-error invalid props on purpose
-                <Button
-                    variant="primary"
-                    icon="😄"
-                    aria-label="Smile"
-                    width="full"
-                    align="right"
-                />,
+                <Button variant="primary" icon="😄" aria-label="Smile" width="full" align="end" />,
             )
             const button = screen.getByRole('button', { name: 'Smile' })
             expect(button.className).not.toMatch(/align/)

--- a/src/new-components/modal/modal.tsx
+++ b/src/new-components/modal/modal.tsx
@@ -157,6 +157,8 @@ export type ModalCloseButtonProps = Omit<
     | 'disabled'
     | 'loading'
     | 'tabIndex'
+    | 'width'
+    | 'align'
 > & {
     /**
      * The descriptive label of the button.


### PR DESCRIPTION
## Short description

During my work in the new Task details view in Todoist, I've noticed the need for buttons to be optionally expanding their width instead of growing as little as needed to have their label fit. Also, when in this mode, we want to customize the label alignment as well.

<img width="521" alt="image" src="https://user-images.githubusercontent.com/15199/163079649-35d73ece-2d52-4e2d-a325-45b9fc924034.png">

I recommend looking at the diff with whitespace changes hidden.

## Test plan

Using storybook (`npm run storybook`), do the following:

- [x] The most important thing is to validate that buttons not using this new feature are 100% unaffected visually (I recommend using [the button playground story](http://localhost:6006/?path=/docs/design-system-button--playground)).
- [x] Play with the new full-width button in [the button full-width story](http://localhost:6006/?path=/docs/design-system-button--full-width). Play with different alignment values (left, center and right), and also change some other attributes (variant, size, long vs. short labels, etc.) See that it all looks good.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] ~~Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)~~
-   [ ] ~~Updated all static build artifacts (`npm run build-all`)~~

## Versioning

New minor release.