### PR TITLE
fix: Show button focus styles only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # Next
 
+-   [Fix] Button focus styles should only be shown when interacting with the button via keyboard (using CSS's `:focus-visible`)
+
 # v11.3.0
 
 -   [Feat] Added `alignSelf` prop to `Box`

--- a/src/new-components/base-button/base-button.module.css
+++ b/src/new-components/base-button/base-button.module.css
@@ -132,7 +132,7 @@
 }
 
 .baseButton[aria-expanded='true'],
-.baseButton:focus:not([aria-disabled='true']),
+.baseButton:focus-visible:not([aria-disabled='true']),
 .baseButton:hover:not([aria-disabled='true']) {
     color: var(--reactist-btn-hover-tint);
     background-color: var(--reactist-btn-hover-fill);


### PR DESCRIPTION
## Short description

In our products today, when you click a button with the mouse, it stays visually as if hovered, even when you moved the mouse out of it. This is because buttons stay focused after clicked, and we have this rule that hover and focus states show visually the same. This is, of course, disruptive to mouse-centric users, who do not expect that unhovering leaves the button as if "engaged".

Here we're switching from `:focus` to `:focus-visible`, which automatically and transparently fixes this issue. Browser support is already good enough (all latest versions of all major supported browsers already support this, and while we may still support older versions of these browsers that do not yet support this CSS pseudo-selector, this is acceptable as it is not super disruptive, and any user who complains only need to upgrade their browser of choice).

## PR Checklist

-   [ ] ~~Added tests for bugs / new features~~
-   [ ] ~~Updated docs (storybooks, readme)~~
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] ~~Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)~~
-   [ ] ~~Updated all static build artifacts (`npm run build-all`)~~

## Versioning

Patch release.