### PR TITLE
feat: Add xsmall size to Loading component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# Upcoming
+
+-   [Feat] Add `xsmall` size to `Loading`
+
 # v11.5.1
 
 -   [Fix] Modal header's min-height is now applied when header has no button

--- a/src/new-components/loading/loading.stories.mdx
+++ b/src/new-components/loading/loading.stories.mdx
@@ -28,6 +28,9 @@ export function Example({ children, size }) {
 <Canvas>
     <Story parameters={{ docs: { source: { type: 'dynamic' } } }} name="All Sizes">
         <Box display="flex" flexDirection="row" justifyContent="spaceEvenly" alignItems="flexEnd">
+            <Example size="xsmall">
+                <Loading aria-label="Loading Demo" size="xsmall" />
+            </Example>
             <Example size="small">
                 <Loading aria-label="Loading Demo" size="small" />
             </Example>
@@ -62,6 +65,9 @@ CSS variable.
             alignItems="flexEnd"
             style={{ '--reactist-spinner-tint': 'red' }}
         >
+            <Example size="xsmall">
+                <Loading aria-label="Loading Demo" size="xsmall" />
+            </Example>
             <Example size="small">
                 <Loading aria-label="Loading Demo" size="small" />
             </Example>

--- a/src/new-components/loading/loading.test.tsx
+++ b/src/new-components/loading/loading.test.tsx
@@ -43,12 +43,16 @@ describe('Loading', () => {
         const { rerender } = render(<Loading aria-label="Loading…" size="small" />)
         const smallSize = getSize()
 
+        rerender(<Loading aria-label="Loading…" size="xsmall" />)
+        const xsmallSize = getSize()
+
         rerender(<Loading aria-label="Loading…" size="medium" />)
         const mediumSize = getSize()
 
         rerender(<Loading aria-label="Loading…" size="large" />)
         const largeSize = getSize()
 
+        expect(xsmallSize).toBeLessThan(smallSize)
         expect(smallSize).toBeLessThan(mediumSize)
         expect(mediumSize).toBeLessThan(largeSize)
     })

--- a/src/new-components/loading/loading.tsx
+++ b/src/new-components/loading/loading.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Box } from '../box'
 import { Spinner } from '../spinner'
 
-type Size = 'small' | 'medium' | 'large'
+type Size = 'xsmall' | 'small' | 'medium' | 'large'
 
 type NativeProps = Omit<
     JSX.IntrinsicElements['div'],
@@ -35,6 +35,7 @@ type LoadingProps = NativeProps & {
     )
 
 const sizeMapping: Record<Size, number> = {
+    xsmall: 16,
     small: 24,
     medium: 36,
     large: 48,


### PR DESCRIPTION
## Short description

Adds a `xsmall` size, 16px, option to the `<Loading />` component.

![image](https://user-images.githubusercontent.com/40036/168816889-dc64f5ac-8000-4977-992d-83dd4a100a19.png)

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Does not require immediate release. Added the changes as "Upcoming" to the CHANGELOG.
