### PR TITLE
fix: set TextLink color using CSS variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 # Upcoming
 
 -   [Feat] Add `positive` tone to `Text`
+-   [Fix] Apply TextLink color through `--reactist-text-link-color`
 -   [Feat] Add `xsmall` size to `Loading`
 
 # v11.5.1

--- a/src/new-components/text-link/text-link.module.css
+++ b/src/new-components/text-link/text-link.module.css
@@ -1,9 +1,13 @@
+:root {
+    --reactist-text-link-color: rgb(36, 111, 224);
+}
+
 .container {
     font-size: inherit;
     font-weight: inherit;
     font-family: inherit;
     text-decoration: none;
-    color: rgb(36, 111, 224);
+    color: var(--reactist-text-link-color);
     cursor: pointer;
 }
 


### PR DESCRIPTION
## Short description

Apply TextLink color through `--reactist-text-link-color`.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Does not require immediate release. Added the changes as "Upcoming" to the CHANGELOG.
