### PR TITLE
refactor: Make label full width configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 # Next
 
 -   [Feat] Allow buttons to have fully rounded/circular corners.
+-   [Fix] Only apply full width labels when the button is full width
 
 # v12.1.1
 

--- a/src/new-components/base-button/base-button.module.css
+++ b/src/new-components/base-button/base-button.module.css
@@ -86,6 +86,7 @@
 .label {
     text-overflow: ellipsis;
     white-space: nowrap;
+    font-size: inherit;
 }
 
 /* nice little animation when clicked to give some visual feedback */

--- a/src/new-components/base-button/base-button.module.css
+++ b/src/new-components/base-button/base-button.module.css
@@ -86,21 +86,6 @@
 .label {
     text-overflow: ellipsis;
     white-space: nowrap;
-    overflow: hidden;
-    width: 100%;
-    text-align: center;
-}
-
-.align-start .label {
-    text-align: start;
-}
-
-.align-center .label {
-    text-align: center;
-}
-
-.align-end .label {
-    text-align: end;
 }
 
 /* nice little animation when clicked to give some visual feedback */

--- a/src/new-components/base-button/base-button.tsx
+++ b/src/new-components/base-button/base-button.tsx
@@ -121,7 +121,7 @@ export const BaseButton = polymorphicComponent<'div', BaseButtonProps>(function 
         endIcon,
         icon,
         width = 'auto',
-        align,
+        align = 'center',
         ...props
     },
     ref,
@@ -142,7 +142,6 @@ export const BaseButton = polymorphicComponent<'div', BaseButtonProps>(function 
                 styles[`tone-${tone}`],
                 styles[`size-${size}`],
                 shape === 'rounded' ? styles['shape-rounded'] : null,
-                width !== 'auto' && icon == null && align != null ? styles[`align-${align}`] : null,
                 icon ? styles.iconButton : null,
                 disabled ? styles.disabled : null,
             ]}
@@ -156,7 +155,17 @@ export const BaseButton = polymorphicComponent<'div', BaseButtonProps>(function 
                             {loading && !endIcon ? <Spinner /> : startIcon}
                         </Box>
                     ) : null}
-                    {children ? <span className={styles.label}>{children}</span> : null}
+                    {children ? (
+                        <Box
+                            as="span"
+                            className={styles.label}
+                            overflow="hidden"
+                            width={width === 'full' ? 'full' : undefined}
+                            textAlign={width === 'auto' ? 'center' : align}
+                        >
+                            {children}
+                        </Box>
+                    ) : null}
                     {endIcon || (loading && !startIcon) ? (
                         <Box display="flex" className={styles.endIcon} aria-hidden>
                             {loading ? <Spinner /> : endIcon}

--- a/src/new-components/button-link/button-link.test.tsx
+++ b/src/new-components/button-link/button-link.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ButtonLink } from './button-link'
 
@@ -96,7 +96,7 @@ describe('ButtonLink', () => {
         )
         const buttonLink = screen.getByRole('link', { name: 'Click me now' })
         expect(buttonLink.innerHTML).toMatchInlineSnapshot(
-            `"<span class=\\"label\\">Click me <strong>now</strong></span>"`,
+            `"<span class=\\"label box textAlign-center overflow-hidden\\">Click me <strong>now</strong></span>"`,
         )
     })
 
@@ -217,15 +217,16 @@ describe('ButtonLink', () => {
         expect(link).not.toHaveClass('size-small')
     })
 
-    it('applies different class names based on width and alignment', () => {
+    it('applies different class names to the label based on width and alignment', () => {
         render(
             <ButtonLink href="/" variant="primary" width="full" align="end">
                 Click me
             </ButtonLink>,
         )
         const buttonLink = screen.getByRole('link', { name: 'Click me' })
-        expect(buttonLink).toHaveClass('align-end')
-        expect(buttonLink).toHaveClass('width-full')
+        const buttonLabel = within(buttonLink).getByText('Click me')
+        expect(buttonLabel).toHaveClass('textAlign-end')
+        expect(buttonLabel).toHaveClass('width-full')
     })
 
     it('ignores align when width is not full', () => {

--- a/src/new-components/button/button.test.tsx
+++ b/src/new-components/button/button.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Button } from './button'
 import { axe } from 'jest-axe'
@@ -114,7 +114,9 @@ describe('Button', () => {
         )
         expect(
             screen.getByRole('button', { name: 'Click me now' }).innerHTML,
-        ).toMatchInlineSnapshot(`"<span class=\\"label\\">Click me <strong>now</strong></span>"`)
+        ).toMatchInlineSnapshot(
+            `"<span class=\\"label box textAlign-center overflow-hidden\\">Click me <strong>now</strong></span>"`,
+        )
     })
 
     it('renders a tooltip when the tooltip prop is given', async () => {
@@ -214,15 +216,16 @@ describe('Button', () => {
         expect(button).not.toHaveClass('size-small')
     })
 
-    it('applies different class names based on width and alignment', () => {
+    it('applies different class names to the label based on width and alignment', () => {
         render(
             <Button variant="primary" width="full" align="end">
                 Click me
             </Button>,
         )
         const button = screen.getByRole('button', { name: 'Click me' })
-        expect(button).toHaveClass('align-end')
-        expect(button).toHaveClass('width-full')
+        const buttonLabel = within(button).getByText('Click me')
+        expect(buttonLabel).toHaveClass('textAlign-end')
+        expect(buttonLabel).toHaveClass('width-full')
     })
 
     it('ignores align when width is not full', () => {


### PR DESCRIPTION
## Short description

The main motivation for this PR was to remove the forced 100% width on button labels. However, in doing so I also noticed an opportunity to remove some custom CSS in favour of using props on existing components. The 100% width on button labels introduced a regression that requires custom styling as highlighted [here](https://github.com/Doist/reactist/pull/647/files#r875136060)

## Test Plan

- Run storybook, and compare https://doist.github.io/reactist/?path=/docs/design-system-button--full-width to http://localhost:6006/?path=/docs/design-system-button--full-width
- [x] The buttons look the same between local and production

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Patch fix that is safe to go out with the next release.
