### PR TITLE
chore: Remove registry configs before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,10 @@ jobs:
             - uses: actions/setup-node@v1
               with:
                   node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
+
+            # Remove any registry configurations from .npmrc
+            - run: sed -i "/@doist/d" ./.npmrc
+
             - run: npm ci
             - run: npm run lint
             - run: npm run type-check

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
 engine-strict=true
+
+# Ensure dependencies are installed from the npm registry instead of GitHub
+# if you've defined the default registry for @doist in another .npmrc
 @doist:registry=https://registry.npmjs.org/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # Next
 
+# v12.0.1
+
+-   [Fix] Fix publishing flow
+
 # v12.0.0
 
 -   [Breaking] Dropped support for React 16

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "12.0.0",
+    "version": "12.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "12.0.0",
+            "version": "12.0.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@doist/reactist",
     "description": "Open source React components by Doist",
     "author": "Henning Muszynski <henning@doist.com> (http://doist.com)",
-    "version": "12.0.0",
+    "version": "12.0.1",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": "git+https://github.com/Doist/reactist.git",


### PR DESCRIPTION
## Short description

In #661 I added a `@doist:registry` entry in the project's .npmrc, forcing installs for Doist's dependencies to be sourced from the npm registry rather than GH, but this broke the release script. In this PR, the `@doist:registry` line is removed before initiating a release.

`💚 Show`

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Patch
