### PR TITLE
fix: Add missing menu styling for Safari

### DIFF
--- a/src/components/menu/menu.less
+++ b/src/components/menu/menu.less
@@ -1,6 +1,9 @@
 @import '../styles/constants.less';
 
-.reactist_menulist[role='menu'] {
+// Ariakit renders the menu as menubar on Safari
+// Ref: https://github.com/ariakit/ariakit/blob/454aef1237ada31e8292ee4966adca3ed0f6e299/packages/ariakit/src/menu/menu-list.ts#L150
+.reactist_menulist[role='menu'],
+.reactist_menulist[role='menubar'] {
     display: block;
     white-space: nowrap;
     background: hsla(0, 100%, 100%, 0.99);
@@ -70,7 +73,8 @@
     }
 
     // sub-menus need to be shifted a bit towards the top to be aligned with its menu item
-    [role='menu'] {
+    [role='menu'],
+    [role='menubar'] {
         margin-top: -5px;
     }
 

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -57,7 +57,8 @@ type MenuProps = Omit<Ariakit.MenuStateProps, 'visible'> & {
 
 /**
  * Wrapper component to control a menu. It does not render anything, only providing the state
- * management for the menu components inside it.
+ * management for the menu components inside it. Note that if you are relying on the `[role='menu']`
+ * attribute to style the menu list, it is applied a `menubar` role instead in Safari.
  */
 function Menu({ children, onItemSelect, ...props }: MenuProps) {
     const state = Ariakit.useMenuState({ focusLoop: true, gutter: 8, shift: 8, ...props })


### PR DESCRIPTION
## Short description

Ariakit's menu renders the menu list with a `menubar` role instead of `menu` in Safari due to a VoiceOver issue. As we leverage the role attribute for styling, this resulted in them not being applied.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/8531248/171023167-33daab9a-00c0-47a6-ac9a-addf171a624a.png)|![image](https://user-images.githubusercontent.com/8531248/171023070-a60fddf0-7cee-428c-b633-feca7536ed57.png)|

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Patch
