### PR TITLE
feat: Add a semantic message and tone to most field components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # Next
 
+-   [Feat] New `message` and `tone` props that allow to associate a visual and semantic message to various field components. Supported in `TextField`, `PasswordField`, `TextArea` and `SelectField`.
+
 # v12.0.4
 
 -   [Fix] Better default alignment between the `MenuList` and the `MenuButton`

--- a/src/new-components/base-field/base-field.module.css
+++ b/src/new-components/base-field/base-field.module.css
@@ -13,3 +13,7 @@
 .auxiliaryLabel {
     text-align: right;
 }
+
+.messageIcon {
+    vertical-align: bottom;
+}

--- a/src/new-components/base-field/base-field.tsx
+++ b/src/new-components/base-field/base-field.tsx
@@ -6,6 +6,7 @@ import styles from './base-field.module.css'
 import { Stack } from '../stack'
 
 import type { WithEnhancedClassName } from '../common-types'
+import { Spinner } from '../spinner'
 
 type FieldHintProps = {
     id: string
@@ -16,6 +17,75 @@ function FieldHint(props: FieldHintProps) {
     return <Text as="p" tone="secondary" size="copy" {...props} />
 }
 
+function ErrorMessageIcon(props: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
+            <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M8 2.5C4.96243 2.5 2.5 4.96243 2.5 8C2.5 11.0376 4.96243 13.5 8 13.5C11.0376 13.5 13.5 11.0376 13.5 8C13.5 4.96243 11.0376 2.5 8 2.5ZM1.5 8C1.5 4.41015 4.41015 1.5 8 1.5C11.5899 1.5 14.5 4.41015 14.5 8C14.5 11.5899 11.5899 14.5 8 14.5C4.41015 14.5 1.5 11.5899 1.5 8ZM8.66667 10.3333C8.66667 10.7015 8.36819 11 8 11C7.63181 11 7.33333 10.7015 7.33333 10.3333C7.33333 9.96514 7.63181 9.66667 8 9.66667C8.36819 9.66667 8.66667 9.96514 8.66667 10.3333ZM8.65766 5.65766C8.65766 5.29445 8.36322 5 8 5C7.99087 5.00008 7.98631 5.00013 7.98175 5.00025C7.97719 5.00038 7.97263 5.00059 7.96352 5.00101C7.60086 5.02116 7.3232 5.33149 7.34335 5.69415L7.50077 8.52774C7.53575 9.15742 8.46425 9.15742 8.49923 8.52774L8.65665 5.69415C8.65707 5.68503 8.65728 5.68047 8.65741 5.67591C8.65754 5.67135 8.65758 5.66679 8.65766 5.65766Z"
+                fill="currentColor"
+            />
+        </svg>
+    )
+}
+
+function SuccessMessageIcon(props: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
+            <path
+                d="M5.63807 7.86191C5.37772 7.60156 4.95561 7.60156 4.69526 7.86191C4.43491 8.12226 4.43491 8.54437 4.69526 8.80472L6.36193 10.4714C6.62228 10.7317 7.04439 10.7317 7.30474 10.4714L11.3047 6.47138C11.5651 6.21103 11.5651 5.78892 11.3047 5.52858C11.0444 5.26823 10.6223 5.26823 10.3619 5.52858L6.83333 9.05717L5.63807 7.86191Z"
+                fill="currentColor"
+            />
+        </svg>
+    )
+}
+
+type FieldTone = 'neutral' | 'success' | 'error' | 'loading'
+
+type FieldMessageProps = FieldHintProps & {
+    tone: FieldTone
+}
+
+function FieldMessage({ id, children, tone }: FieldMessageProps) {
+    const textTone = tone === 'error' ? 'danger' : tone === 'success' ? 'positive' : 'normal'
+    return (
+        <Text as="p" tone={textTone} size="copy" id={id}>
+            {tone && tone !== 'neutral' ? (
+                <Box
+                    as="span"
+                    marginRight="xsmall"
+                    display="inlineFlex"
+                    className={styles.messageIcon}
+                >
+                    {tone === 'error' ? (
+                        <ErrorMessageIcon aria-hidden />
+                    ) : tone === 'success' ? (
+                        <SuccessMessageIcon aria-hidden />
+                    ) : tone === 'loading' ? (
+                        <Spinner size={16} />
+                    ) : null}
+                </Box>
+            ) : null}
+            {children}
+        </Text>
+    )
+}
+
 //
 // BaseField
 //
@@ -23,6 +93,8 @@ function FieldHint(props: FieldHintProps) {
 type ChildrenRenderProps = {
     id: string
     'aria-describedby'?: string
+    'aria-errormessage'?: string
+    'aria-invalid'?: true
 }
 
 type HtmlInputProps<T extends HTMLElement> = React.DetailedHTMLProps<
@@ -31,7 +103,10 @@ type HtmlInputProps<T extends HTMLElement> = React.DetailedHTMLProps<
 >
 
 type BaseFieldProps = WithEnhancedClassName &
-    Pick<HtmlInputProps<HTMLInputElement>, 'id' | 'hidden' | 'aria-describedby'> & {
+    Pick<
+        HtmlInputProps<HTMLInputElement>,
+        'id' | 'hidden' | 'aria-describedby' | 'aria-errormessage'
+    > & {
         /**
          * The main label for this field element.
          *
@@ -41,6 +116,7 @@ type BaseFieldProps = WithEnhancedClassName &
          * @see auxiliaryLabel
          */
         label: React.ReactNode
+
         /**
          * An optional secondary label for this field element. It is combined with the `label` to
          * form the field's entire accessible name (unless the field label is overriden by using
@@ -52,6 +128,7 @@ type BaseFieldProps = WithEnhancedClassName &
          * @see auxiliaryLabel
          */
         secondaryLabel?: React.ReactNode
+
         /**
          * An optional extra element to be placed to the right of the main and secondary labels.
          *
@@ -62,16 +139,57 @@ type BaseFieldProps = WithEnhancedClassName &
          * @see secondaryLabel
          */
         auxiliaryLabel?: React.ReactNode
+
+        /**
+         * A message associated with the field. It is rendered below the field, and with an
+         * appearance that conveys the tone of the field (e.g. coloured red for errors, green for
+         * success, etc).
+         *
+         * When the tone is `"error"`, the message element is associated to the field via the
+         * `aria-errormessage` attribute. Otherwise it is associated as an extra description,
+         * alongside the `hint` element, if any.
+         *
+         * @see tone
+         * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage
+         * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid
+         */
+        message?: React.ReactNode
+
+        /**
+         * The tone with which the message, if any, is presented.
+         *
+         * If the tone is `"error"`, the field border turns red, and the message, if any, is also
+         * red. The message will also be associated to the field via the `aria-errormessage`
+         * attribute.
+         *
+         * If the tone is not `"error"`, the message, if present, acts as an extra description,
+         * alongside the `hint` element, if any.
+         *
+         * When the tone is `"loading"`, it is recommended that you also disable the field. However,
+         * this is not enforced by the component. It is only a recommendation.
+         *
+         * @see message
+         * @see hint
+         */
+        tone?: FieldTone
+
         /**
          * A hint or help-like content associated as the accessible description of the field. It is
          * generally rendered below it, and with a visual style that reduces its prominence (i.e.
          * as secondary text).
+         *
+         * It sets the `aria-describedby` attribute pointing to the element that holds the error
+         * message.
+         *
+         * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby
          */
         hint?: React.ReactNode
+
         /**
          * The maximum width that the input field can expand to.
          */
         maxWidth?: BoxProps['maxWidth']
+
         /**
          * Used internally by components composed using `BaseField`. It is not exposed as part of
          * the public props of such components.
@@ -87,17 +205,32 @@ function BaseField({
     secondaryLabel,
     auxiliaryLabel,
     hint,
+    message,
+    tone = 'neutral',
     className,
     children,
     maxWidth,
     hidden,
     'aria-describedby': originalAriaDescribedBy,
+    'aria-errormessage': originalAriaErrorMessage,
     id: originalId,
 }: BaseFieldProps & WithEnhancedClassName) {
     const id = useId(originalId)
     const hintId = useId()
+    const messageId = useId()
 
-    const ariaDescribedBy = originalAriaDescribedBy ?? (hint ? hintId : undefined)
+    const ariaDescribedBy =
+        originalAriaDescribedBy ??
+        [message && tone !== 'error' ? messageId : null, hintId].filter(Boolean).join(' ')
+    const ariaErrorMessage =
+        originalAriaErrorMessage ?? (tone === 'error' && message ? messageId : undefined)
+
+    const childrenProps: ChildrenRenderProps = {
+        id,
+        'aria-describedby': ariaDescribedBy,
+        'aria-errormessage': ariaErrorMessage,
+        'aria-invalid': tone === 'error' ? true : undefined,
+    }
 
     return (
         <Stack space="small" hidden={hidden}>
@@ -121,12 +254,17 @@ function BaseField({
                         </Box>
                     ) : null}
                 </Box>
-                {children(ariaDescribedBy ? { id, 'aria-describedby': ariaDescribedBy } : { id })}
+                {children(childrenProps)}
             </Box>
+            {message ? (
+                <FieldMessage id={messageId} tone={tone}>
+                    {message}
+                </FieldMessage>
+            ) : null}
             {hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}
         </Stack>
     )
 }
 
-export { BaseField, FieldHint }
+export { BaseField, FieldHint, FieldMessage }
 export type { FieldComponentProps }

--- a/src/new-components/base-field/base-field.tsx
+++ b/src/new-components/base-field/base-field.tsx
@@ -21,6 +21,11 @@ function FieldHint(props: FieldHintProps) {
 // BaseField
 //
 
+type ChildrenRenderProps = {
+    id: string
+    'aria-describedby'?: string
+}
+
 type HtmlInputProps<T extends HTMLElement> = React.DetailedHTMLProps<
     React.InputHTMLAttributes<T>,
     T
@@ -72,7 +77,7 @@ type BaseFieldProps = WithEnhancedClassName &
          * Used internally by components composed using `BaseField`. It is not exposed as part of
          * the public props of such components.
          */
-        children: (props: { id: string; 'aria-describedby'?: string }) => React.ReactNode
+        children: (props: ChildrenRenderProps) => React.ReactNode
     }
 
 type FieldComponentProps<T extends HTMLElement> = Omit<BaseFieldProps, 'children' | 'className'> &

--- a/src/new-components/base-field/base-field.tsx
+++ b/src/new-components/base-field/base-field.tsx
@@ -10,7 +10,6 @@ import type { WithEnhancedClassName } from '../common-types'
 type FieldHintProps = {
     id: string
     children: React.ReactNode
-    hidden?: boolean
 }
 
 function FieldHint(props: FieldHintProps) {
@@ -101,8 +100,8 @@ function BaseField({
     const ariaDescribedBy = originalAriaDescribedBy ?? (hint ? hintId : undefined)
 
     return (
-        <Stack space="small">
-            <Box className={[className, styles.container]} maxWidth={maxWidth} hidden={hidden}>
+        <Stack space="small" hidden={hidden}>
+            <Box className={[className, styles.container]} maxWidth={maxWidth}>
                 <Box
                     as="span"
                     display="flex"
@@ -124,11 +123,7 @@ function BaseField({
                 </Box>
                 {children(ariaDescribedBy ? { id, 'aria-describedby': ariaDescribedBy } : { id })}
             </Box>
-            {hint ? (
-                <FieldHint hidden={hidden} id={hintId}>
-                    {hint}
-                </FieldHint>
-            ) : null}
+            {hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}
         </Stack>
     )
 }

--- a/src/new-components/default-styles.less
+++ b/src/new-components/default-styles.less
@@ -75,6 +75,7 @@
     --reactist-content-tertiary: rgba(0, 0, 0, 0.4);
     --reactist-content-light-on-dark: rgb(255, 255, 255);
     --reactist-content-positive: rgb(5, 133, 39);
+    --reactist-content-danger: rgb(209, 69, 59);
 
     /* component-specific */
     --reactist-switch-checked: rgb(5, 133, 39);

--- a/src/new-components/password-field/password-field.stories.tsx
+++ b/src/new-components/password-field/password-field.stories.tsx
@@ -3,6 +3,7 @@ import { selectWithNone, PartialProps } from '../storybook-helper'
 import { PasswordField } from './'
 
 import type { BoxMaxWidth } from '../box'
+import { Stack } from '../stack'
 
 export default {
     title: 'Design system/PasswordField',
@@ -55,6 +56,15 @@ InteractivePropsStory.argTypes = {
         defaultValue:
             'Must be at least 100 characters long, and it should include each letter of the alphabet',
     },
+    message: {
+        control: { type: 'text' },
+        defaultValue: '',
+    },
+    tone: {
+        options: ['neutral', 'success', 'error', 'loading'],
+        control: { type: 'inline-radio' },
+        defaultValue: 'neutral',
+    },
     placeholder: {
         control: { type: 'text' },
         defaultValue: 'Type your password',
@@ -63,4 +73,37 @@ InteractivePropsStory.argTypes = {
         ['xsmall', 'small', 'medium', 'large', 'xlarge'],
         'small',
     ),
+}
+
+export function MessageToneStory() {
+    return (
+        <Stack space="xxlarge" dividers="secondary">
+            <PasswordField
+                label="Password confirmation"
+                message="Comparing to original password…"
+                tone="loading"
+                disabled
+                maxWidth="small"
+            />
+            <PasswordField
+                label="Password confirmation"
+                message="It does not match the original password"
+                tone="error"
+                maxWidth="small"
+            />
+            <PasswordField
+                label="Password confirmation"
+                message="Matches original password!"
+                tone="success"
+                maxWidth="small"
+            />
+            <PasswordField
+                label="Password confirmation"
+                message="Message with neutral tone (used as description, but still prefer the hint prop for that)"
+                hint="This is the primary description of the field, provided by the hint prop"
+                tone="neutral"
+                maxWidth="small"
+            />
+        </Stack>
+    )
 }

--- a/src/new-components/password-field/password-field.test.tsx
+++ b/src/new-components/password-field/password-field.test.tsx
@@ -71,31 +71,27 @@ describe('PasswordField', () => {
         )
     })
 
-    it('is marked as invalid and with an error message if an error message is given', () => {
-        render(
-            <PasswordField
-                data-testid="password-field"
-                label="Password confirmation"
-                message="Does not match the password"
-                tone="error"
-            />,
-        )
-        expect(screen.getByTestId('password-field')).toHaveErrorMessage(
-            'Does not match the password',
-        )
+    it('is marked as invalid and when tone="error"', () => {
+        render(<PasswordField data-testid="password-field" label="Password" tone="error" />)
+        expect(screen.getByTestId('password-field')).toBeInvalid()
     })
 
-    it('uses the message as the description, whenever the tone is not error', () => {
-        render(
-            <PasswordField
-                data-testid="password-field"
-                label="Password confirmation"
-                message="Matches password"
-                tone="success"
-            />,
-        )
-        expect(screen.getByTestId('password-field')).toHaveAccessibleDescription('Matches password')
-    })
+    it.each([['success' as const], ['loading' as const], ['neutral' as const], ['error' as const]])(
+        'uses the message as the description, when tone="%s"',
+        (tone) => {
+            render(
+                <PasswordField
+                    data-testid="password-field"
+                    label="Password confirmation"
+                    message={`Message with ${tone} tone`}
+                    tone={tone}
+                />,
+            )
+            expect(screen.getByTestId('password-field')).toHaveAccessibleDescription(
+                `Message with ${tone} tone`,
+            )
+        },
+    )
 
     it('adds the message as part of the description, whenever the tone is not error', () => {
         render(

--- a/src/new-components/password-field/password-field.test.tsx
+++ b/src/new-components/password-field/password-field.test.tsx
@@ -71,6 +71,47 @@ describe('PasswordField', () => {
         )
     })
 
+    it('is marked as invalid and with an error message if an error message is given', () => {
+        render(
+            <PasswordField
+                data-testid="password-field"
+                label="Password confirmation"
+                message="Does not match the password"
+                tone="error"
+            />,
+        )
+        expect(screen.getByTestId('password-field')).toHaveErrorMessage(
+            'Does not match the password',
+        )
+    })
+
+    it('uses the message as the description, whenever the tone is not error', () => {
+        render(
+            <PasswordField
+                data-testid="password-field"
+                label="Password confirmation"
+                message="Matches password"
+                tone="success"
+            />,
+        )
+        expect(screen.getByTestId('password-field')).toHaveAccessibleDescription('Matches password')
+    })
+
+    it('adds the message as part of the description, whenever the tone is not error', () => {
+        render(
+            <PasswordField
+                data-testid="password-field"
+                label="Password confirmation"
+                hint="Type your password one more time"
+                message="Matches password"
+                tone="success"
+            />,
+        )
+        expect(screen.getByTestId('password-field')).toHaveAccessibleDescription(
+            'Matches password Type your password one more time',
+        )
+    })
+
     it('renders its auxiliary label', () => {
         render(
             <PasswordField

--- a/src/new-components/password-field/password-field.tsx
+++ b/src/new-components/password-field/password-field.tsx
@@ -23,6 +23,8 @@ const PasswordField = React.forwardRef<HTMLInputElement, PasswordFieldProps>(fun
         secondaryLabel,
         auxiliaryLabel,
         hint,
+        message,
+        tone,
         maxWidth,
         togglePasswordLabel = 'Toggle password visibility',
         hidden,
@@ -49,6 +51,8 @@ const PasswordField = React.forwardRef<HTMLInputElement, PasswordFieldProps>(fun
             secondaryLabel={secondaryLabel}
             auxiliaryLabel={auxiliaryLabel}
             hint={hint}
+            message={message}
+            tone={tone}
             maxWidth={maxWidth}
             hidden={hidden}
             aria-describedby={ariaDescribedBy}
@@ -57,7 +61,11 @@ const PasswordField = React.forwardRef<HTMLInputElement, PasswordFieldProps>(fun
                 <Box
                     display="flex"
                     alignItems="center"
-                    className={[styles.inputWrapper, textFieldStyles.inputWrapper]}
+                    className={[
+                        styles.inputWrapper,
+                        textFieldStyles.inputWrapper,
+                        tone === 'error' ? textFieldStyles.error : null,
+                    ]}
                 >
                     <input
                         {...props}

--- a/src/new-components/select-field/select-field.module.css
+++ b/src/new-components/select-field/select-field.module.css
@@ -42,6 +42,10 @@
     margin: 0;
 }
 
+.selectWrapper.error select {
+    border-color: var(--reactist-alert-tone-critical-border) !important;
+}
+
 .selectWrapper option {
     background-color: var(--reactist-bg-aside);
 }

--- a/src/new-components/select-field/select-field.test.tsx
+++ b/src/new-components/select-field/select-field.test.tsx
@@ -63,16 +63,9 @@ describe('SelectField', () => {
         )
     })
 
-    it('is marked as invalid and with an error message if an error message is given', () => {
-        render(
-            <SelectField
-                data-testid="select-field"
-                label="Theme"
-                message="You must select one"
-                tone="error"
-            />,
-        )
-        expect(screen.getByTestId('select-field')).toHaveErrorMessage('You must select one')
+    it('is marked as invalid and when tone="error"', () => {
+        render(<SelectField data-testid="select-field" label="Theme" tone="error" />)
+        expect(screen.getByTestId('select-field')).toBeInvalid()
     })
 
     it('uses the message as the description, whenever the tone is not error', () => {
@@ -88,6 +81,23 @@ describe('SelectField', () => {
             'Your theme preference has been saved',
         )
     })
+
+    it.each([['success' as const], ['loading' as const], ['neutral' as const], ['error' as const]])(
+        'uses the message as the description, when tone="%s"',
+        (tone) => {
+            render(
+                <SelectField
+                    data-testid="select-field"
+                    label="Theme"
+                    message={`Message with ${tone} tone`}
+                    tone={tone}
+                />,
+            )
+            expect(screen.getByTestId('select-field')).toHaveAccessibleDescription(
+                `Message with ${tone} tone`,
+            )
+        },
+    )
 
     it('adds the message as part of the description, whenever the tone is not error', () => {
         render(

--- a/src/new-components/select-field/select-field.test.tsx
+++ b/src/new-components/select-field/select-field.test.tsx
@@ -63,6 +63,47 @@ describe('SelectField', () => {
         )
     })
 
+    it('is marked as invalid and with an error message if an error message is given', () => {
+        render(
+            <SelectField
+                data-testid="select-field"
+                label="Theme"
+                message="You must select one"
+                tone="error"
+            />,
+        )
+        expect(screen.getByTestId('select-field')).toHaveErrorMessage('You must select one')
+    })
+
+    it('uses the message as the description, whenever the tone is not error', () => {
+        render(
+            <SelectField
+                data-testid="select-field"
+                label="Theme"
+                message="Your theme preference has been saved"
+                tone="success"
+            />,
+        )
+        expect(screen.getByTestId('select-field')).toHaveAccessibleDescription(
+            'Your theme preference has been saved',
+        )
+    })
+
+    it('adds the message as part of the description, whenever the tone is not error', () => {
+        render(
+            <SelectField
+                data-testid="select-field"
+                label="Theme"
+                hint="Select the theme that you like"
+                message="Your theme preference has been saved"
+                tone="success"
+            />,
+        )
+        expect(screen.getByTestId('select-field')).toHaveAccessibleDescription(
+            'Your theme preference has been saved Select the theme that you like',
+        )
+    })
+
     it('renders its auxiliary label', () => {
         render(<SelectField label="Theme" auxiliaryLabel={<a href="/help">About themes</a>} />)
         expect(screen.getByRole('link', { name: 'About themes' })).toBeInTheDocument()

--- a/src/new-components/select-field/select-field.tsx
+++ b/src/new-components/select-field/select-field.tsx
@@ -12,6 +12,8 @@ const SelectField = React.forwardRef<HTMLSelectElement, SelectFieldProps>(functi
         secondaryLabel,
         auxiliaryLabel,
         hint,
+        message,
+        tone,
         maxWidth,
         children,
         hidden,
@@ -27,12 +29,14 @@ const SelectField = React.forwardRef<HTMLSelectElement, SelectFieldProps>(functi
             secondaryLabel={secondaryLabel}
             auxiliaryLabel={auxiliaryLabel}
             hint={hint}
+            message={message}
+            tone={tone}
             maxWidth={maxWidth}
             hidden={hidden}
             aria-describedby={ariaDescribedBy}
         >
             {(extraProps) => (
-                <Box className={styles.selectWrapper}>
+                <Box className={[styles.selectWrapper, tone === 'error' ? styles.error : null]}>
                     <select {...props} {...extraProps} ref={ref}>
                         {children}
                     </select>

--- a/src/new-components/text-area/text-area.module.css
+++ b/src/new-components/text-area/text-area.module.css
@@ -4,8 +4,13 @@
     box-sizing: border-box;
     border-radius: var(--reactist-border-radius-small);
     border: 1px solid var(--reactist-divider-secondary);
+    font-family: var(--reactist-font-family);
 }
 
-.container textarea:focus {
+.container.error textarea {
+    border-color: var(--reactist-alert-tone-critical-border) !important;
+}
+
+.container textarea:focus-visible {
     border-color: var(--reactist-divider-primary);
 }

--- a/src/new-components/text-area/text-area.stories.tsx
+++ b/src/new-components/text-area/text-area.stories.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import { selectWithNone, PartialProps } from '../storybook-helper'
-import { SelectField } from './'
+import { TextArea } from './'
 
 import type { BoxMaxWidth } from '../box'
 import { Stack } from '../stack'
 
 export default {
-    title: 'Design system/SelectField',
-    component: SelectField,
+    title: 'Design system/TextArea',
+    component: TextArea,
     parameters: {
         badges: ['accessible'],
     },
@@ -21,9 +21,9 @@ export function InteractivePropsStory({
     label,
     auxiliaryLabel,
     ...props
-}: PartialProps<typeof SelectField>) {
+}: PartialProps<typeof TextArea>) {
     return (
-        <SelectField
+        <TextArea
             {...props}
             label={label}
             auxiliaryLabel={
@@ -34,27 +34,14 @@ export function InteractivePropsStory({
                     </a>
                 ) : undefined
             }
-            defaultValue="-"
-        >
-            <option value="-" disabled>
-                Select theme
-            </option>
-            <optgroup label="Light themes">
-                <option value="default">Default theme</option>
-                <option value="bright">Extra bright</option>
-            </optgroup>
-            <optgroup label="Dark themes">
-                <option value="contrast">High contrast</option>
-                <option value="dark">Dark mode</option>
-            </optgroup>
-        </SelectField>
+        />
     )
 }
 
 InteractivePropsStory.argTypes = {
     label: {
         control: { type: 'text' },
-        defaultValue: 'Theme',
+        defaultValue: 'User bio',
     },
     secondaryLabel: {
         control: { type: 'text' },
@@ -67,7 +54,7 @@ InteractivePropsStory.argTypes = {
     hint: {
         control: { type: 'text' },
         defaultValue:
-            'The theme you select will be applied immediately. If you upgrade to premium you will have more themes to choose from.',
+            'You’ll have a better experience in our community if others get to know a little bit about you.',
     },
     message: {
         control: { type: 'text' },
@@ -78,6 +65,10 @@ InteractivePropsStory.argTypes = {
         control: { type: 'inline-radio' },
         defaultValue: 'neutral',
     },
+    placeholder: {
+        control: { type: 'text' },
+        defaultValue: 'Tell us something about yourself. Don’t be shy.',
+    },
     maxWidth: selectWithNone<BoxMaxWidth>(
         ['xsmall', 'small', 'medium', 'large', 'xlarge'],
         'small',
@@ -87,51 +78,32 @@ InteractivePropsStory.argTypes = {
 export function MessageToneStory() {
     return (
         <Stack space="xxlarge" dividers="secondary">
-            <SelectField
-                label="Country of residence"
-                message="Saving…"
+            <TextArea
+                label="Profile bio"
+                message="Saving changes…"
                 tone="loading"
                 disabled
                 maxWidth="small"
-            >
-                <option value="none" disabled>
-                    –
-                </option>
-            </SelectField>
-
-            <SelectField
-                label="Country of residence"
-                message="Something went wrong. Please, try again."
+            />
+            <TextArea
+                label="Profile bio"
+                message="Too short. Don't be shy, tell us a bit more."
                 tone="error"
                 maxWidth="small"
-            >
-                <option value="none" disabled>
-                    –
-                </option>
-            </SelectField>
-
-            <SelectField
-                label="Country of residence"
-                message="Saved successfully!"
+            />
+            <TextArea
+                label="Profile bio"
+                message="Changes saved successfully!"
                 tone="success"
                 maxWidth="small"
-            >
-                <option value="none" disabled>
-                    –
-                </option>
-            </SelectField>
-
-            <SelectField
-                label="Country of residence"
+            />
+            <TextArea
+                label="Profile bio"
                 message="Message with neutral tone (used as description, but still prefer the hint prop for that)"
                 hint="This is the primary description of the field, provided by the hint prop"
                 tone="neutral"
                 maxWidth="small"
-            >
-                <option value="none" disabled>
-                    –
-                </option>
-            </SelectField>
+            />
         </Stack>
     )
 }

--- a/src/new-components/text-area/text-area.tsx
+++ b/src/new-components/text-area/text-area.tsx
@@ -13,6 +13,8 @@ function TextArea({
     secondaryLabel,
     auxiliaryLabel,
     hint,
+    message,
+    tone,
     maxWidth,
     ...props
 }: TextAreaProps) {
@@ -23,7 +25,9 @@ function TextArea({
             secondaryLabel={secondaryLabel}
             auxiliaryLabel={auxiliaryLabel}
             hint={hint}
-            className={styles.container}
+            message={message}
+            tone={tone}
+            className={[styles.container, tone === 'error' ? styles.error : null]}
             maxWidth={maxWidth}
         >
             {(extraProps) => (

--- a/src/new-components/text-field/text-field.module.css
+++ b/src/new-components/text-field/text-field.module.css
@@ -8,6 +8,10 @@
     border-color: var(--reactist-divider-primary);
 }
 
+.inputWrapper.error {
+    border-color: var(--reactist-alert-tone-critical-border) !important;
+}
+
 .inputWrapper input {
     color: var(--reactist-content-primary);
     flex: 1;

--- a/src/new-components/text-field/text-field.stories.tsx
+++ b/src/new-components/text-field/text-field.stories.tsx
@@ -3,6 +3,7 @@ import { selectWithNone, PartialProps } from '../storybook-helper'
 import { TextField } from './'
 
 import type { BoxMaxWidth } from '../box'
+import { Stack } from '../stack'
 
 export default {
     title: 'Design system/TextField',
@@ -55,6 +56,15 @@ InteractivePropsStory.argTypes = {
         defaultValue:
             'We need your name for billing and shipping purposes. Make sure to enter it correctly.',
     },
+    message: {
+        control: { type: 'text' },
+        defaultValue: '',
+    },
+    tone: {
+        options: ['neutral', 'success', 'error', 'loading'],
+        control: { type: 'inline-radio' },
+        defaultValue: 'neutral',
+    },
     placeholder: {
         control: { type: 'text' },
         defaultValue: 'Enter your name as it appears in your ID',
@@ -63,4 +73,37 @@ InteractivePropsStory.argTypes = {
         ['xsmall', 'small', 'medium', 'large', 'xlarge'],
         'small',
     ),
+}
+
+export function MessageToneStory() {
+    return (
+        <Stack space="xxlarge" dividers="secondary">
+            <TextField
+                label="Verification code"
+                message="Verifying code…"
+                tone="loading"
+                disabled
+                maxWidth="small"
+            />
+            <TextField
+                label="Verification code"
+                message="Invalid code. Please, try again."
+                tone="error"
+                maxWidth="small"
+            />
+            <TextField
+                label="Verification code"
+                message="Code verification successful!"
+                tone="success"
+                maxWidth="small"
+            />
+            <TextField
+                label="Verification code"
+                message="Message with neutral tone (used as description, but still prefer the hint prop for that)"
+                hint="This is the primary description of the field, provided by the hint prop"
+                tone="neutral"
+                maxWidth="small"
+            />
+        </Stack>
+    )
 }

--- a/src/new-components/text-field/text-field.test.tsx
+++ b/src/new-components/text-field/text-field.test.tsx
@@ -57,19 +57,12 @@ describe('TextField', () => {
         )
     })
 
-    it('is marked as invalid and with an error message if a message with tone="error" is given', () => {
-        render(
-            <TextField
-                data-testid="text-field"
-                label="Phone"
-                message="Invalid phone number"
-                tone="error"
-            />,
-        )
-        expect(screen.getByTestId('text-field')).toHaveErrorMessage('Invalid phone number')
+    it('is marked as invalid and when tone="error"', () => {
+        render(<TextField data-testid="text-field" label="Verification code" tone="error" />)
+        expect(screen.getByTestId('text-field')).toBeInvalid()
     })
 
-    it.each([['success' as const], ['loading' as const], ['neutral' as const]])(
+    it.each([['success' as const], ['loading' as const], ['neutral' as const], ['error' as const]])(
         'uses the message as the description, when tone="%s"',
         (tone) => {
             render(

--- a/src/new-components/text-field/text-field.test.tsx
+++ b/src/new-components/text-field/text-field.test.tsx
@@ -57,6 +57,47 @@ describe('TextField', () => {
         )
     })
 
+    it('is marked as invalid and with an error message if an error message is given', () => {
+        render(
+            <TextField
+                data-testid="text-field"
+                label="Phone"
+                message="Invalid phone number"
+                tone="error"
+            />,
+        )
+        expect(screen.getByTestId('text-field')).toHaveErrorMessage('Invalid phone number')
+    })
+
+    it('uses the message as the description, whenever the tone is not error', () => {
+        render(
+            <TextField
+                data-testid="text-field"
+                label="Verification code"
+                message="Verification successful"
+                tone="success"
+            />,
+        )
+        expect(screen.getByTestId('text-field')).toHaveAccessibleDescription(
+            'Verification successful',
+        )
+    })
+
+    it('adds the message as part of the description, whenever the tone is not error', () => {
+        render(
+            <TextField
+                data-testid="text-field"
+                label="Verification code"
+                hint="Paste in the verification code"
+                message="Verification successful"
+                tone="success"
+            />,
+        )
+        expect(screen.getByTestId('text-field')).toHaveAccessibleDescription(
+            'Verification successful Paste in the verification code',
+        )
+    })
+
     it('renders its auxiliary label', () => {
         render(<TextField label="VAT ID" auxiliaryLabel={<a href="/help">Whatʼs this?</a>} />)
         expect(screen.getByRole('link', { name: 'Whatʼs this?' })).toBeInTheDocument()

--- a/src/new-components/text-field/text-field.test.tsx
+++ b/src/new-components/text-field/text-field.test.tsx
@@ -57,7 +57,7 @@ describe('TextField', () => {
         )
     })
 
-    it('is marked as invalid and with an error message if an error message is given', () => {
+    it('is marked as invalid and with an error message if a message with tone="error" is given', () => {
         render(
             <TextField
                 data-testid="text-field"
@@ -69,19 +69,22 @@ describe('TextField', () => {
         expect(screen.getByTestId('text-field')).toHaveErrorMessage('Invalid phone number')
     })
 
-    it('uses the message as the description, whenever the tone is not error', () => {
-        render(
-            <TextField
-                data-testid="text-field"
-                label="Verification code"
-                message="Verification successful"
-                tone="success"
-            />,
-        )
-        expect(screen.getByTestId('text-field')).toHaveAccessibleDescription(
-            'Verification successful',
-        )
-    })
+    it.each([['success' as const], ['loading' as const], ['neutral' as const]])(
+        'uses the message as the description, when tone="%s"',
+        (tone) => {
+            render(
+                <TextField
+                    data-testid="text-field"
+                    label="Verification code"
+                    message={`Message with ${tone} tone`}
+                    tone={tone}
+                />,
+            )
+            expect(screen.getByTestId('text-field')).toHaveAccessibleDescription(
+                `Message with ${tone} tone`,
+            )
+        },
+    )
 
     it('adds the message as part of the description, whenever the tone is not error', () => {
         render(

--- a/src/new-components/text-field/text-field.tsx
+++ b/src/new-components/text-field/text-field.tsx
@@ -17,6 +17,8 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
         secondaryLabel,
         auxiliaryLabel,
         hint,
+        message,
+        tone,
         type = 'text',
         maxWidth,
         hidden,
@@ -32,12 +34,14 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
             secondaryLabel={secondaryLabel}
             auxiliaryLabel={auxiliaryLabel}
             hint={hint}
+            message={message}
+            tone={tone}
             maxWidth={maxWidth}
             hidden={hidden}
             aria-describedby={ariaDescribedBy}
         >
             {(extraProps) => (
-                <Box className={styles.inputWrapper}>
+                <Box className={[styles.inputWrapper, tone === 'error' ? styles.error : null]}>
                     <input {...props} {...extraProps} type={type} ref={ref} />
                 </Box>
             )}

--- a/src/new-components/text/text.module.css
+++ b/src/new-components/text/text.module.css
@@ -26,7 +26,7 @@
     color: var(--reactist-content-secondary);
 }
 .tone-danger {
-    color: rgb(209, 69, 59);
+    color: var(--reactist-content-danger);
 }
 .tone-positive {
     color: var(--reactist-content-positive);


### PR DESCRIPTION
## Short description

- [Discussion in Twist](https://twist.com/a/1585/ch/81455/t/3484406/)
- Supersedes #659 (which only added error messages)

## Test plan

Review manually the live components in the various new stories titled "Message Tone Story" in storybook

- [x] Reviewed for `TextField`
- [x] Reviewed for `SelectField`
- [x] Reviewed for `PasswordField`
- [x] Reviewed for `TextArea`

<details>
<summary><strong>Demo</strong></summary>

<table><tr><td>

<img width="560" alt="CleanShot 2022-06-01 at 16 37 07@2x" src="https://user-images.githubusercontent.com/15199/171498278-9f32de4c-bdaa-433a-b6e3-37b7511f805f.png">

</td></tr></table>
</details>

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

New minor release
