### PR TITLE
feat: Introduce a "bordered" variant for all text-like fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 # Next
 
 -   [Feat] New `message` and `tone` props that allow to associate a visual and semantic message to various field components. Supported in `TextField`, `PasswordField`, `TextArea` and `SelectField`.
+-   [Feat] New `variant="bordered"` supported in `TextField`, `PasswordField` and `TextArea`. It renders the field and its labels enclosed in an outer border, rather than having a border around the editing area only.
 
 # v12.0.4
 

--- a/src/new-components/base-field/base-field.module.css
+++ b/src/new-components/base-field/base-field.module.css
@@ -9,6 +9,21 @@
     overflow: clip;
 }
 
+.container.bordered label {
+    /* so that clicking in blank areas to the right of the label will focus the field element */
+    flex-grow: 1;
+}
+
+.container.bordered.text label {
+    /* to convey that clicking in blank area to the right of the label places focus on the text field */
+    cursor: text;
+}
+
+.container.bordered.text label span {
+    /* overrides the cursor set above, so that hovering over the non-blank parts of the label stay unaffected */
+    cursor: default;
+}
+
 .container.bordered:focus-within {
     border-color: var(--reactist-divider-primary) !important;
 }

--- a/src/new-components/base-field/base-field.module.css
+++ b/src/new-components/base-field/base-field.module.css
@@ -13,14 +13,11 @@
 .container.bordered label {
     /* so that clicking in blank areas to the right of the label will focus the field element */
     flex-grow: 1;
-}
-
-.container.bordered.text label {
     /* to convey that clicking in blank area to the right of the label places focus on the text field */
     cursor: text;
 }
 
-.container.bordered.text label span {
+.container.bordered label span {
     /* overrides the cursor set above, so that hovering over the non-blank parts of the label stay unaffected */
     cursor: default;
 }

--- a/src/new-components/base-field/base-field.module.css
+++ b/src/new-components/base-field/base-field.module.css
@@ -2,8 +2,35 @@
     font-family: var(--reactist-font-family);
 }
 
-.primaryLabel {
+.container.bordered {
+    border-radius: var(--reactist-border-radius-large);
+    border: 1px solid var(--reactist-divider-secondary);
+    padding: var(--reactist-spacing-small);
+    overflow: clip;
+}
+
+.container.bordered:focus-within {
+    border-color: var(--reactist-divider-primary) !important;
+}
+
+.container.bordered.error {
+    border-color: var(--reactist-alert-tone-critical-border) !important;
+}
+
+.container.bordered .primaryLabel {
+    font-weight: 500;
+}
+
+.container.bordered .auxiliaryLabel {
+    font-size: var(--reactist-font-size-caption);
+}
+
+.container:not(.bordered) .primaryLabel {
     font-weight: var(--reactist-font-weight-strong);
+}
+
+.container:not(.bordered) .auxiliaryLabel {
+    font-size: var(--reactist-font-size-body);
 }
 
 .secondaryLabel {

--- a/src/new-components/base-field/base-field.module.css
+++ b/src/new-components/base-field/base-field.module.css
@@ -2,6 +2,11 @@
     font-family: var(--reactist-font-family);
 }
 
+.container label,
+.container .auxiliaryLabel {
+    padding-bottom: var(--reactist-spacing-small);
+}
+
 .container.bordered {
     border-radius: var(--reactist-border-radius-large);
     border: 1px solid var(--reactist-divider-secondary);

--- a/src/new-components/base-field/base-field.module.css
+++ b/src/new-components/base-field/base-field.module.css
@@ -6,6 +6,7 @@
     border-radius: var(--reactist-border-radius-large);
     border: 1px solid var(--reactist-divider-secondary);
     padding: var(--reactist-spacing-small);
+    padding-bottom: var(--reactist-spacing-xsmall);
     overflow: clip;
 }
 

--- a/src/new-components/base-field/base-field.tsx
+++ b/src/new-components/base-field/base-field.tsx
@@ -89,8 +89,6 @@ type BaseFieldVariantProps = {
 
 type BaseFieldProps = WithEnhancedClassName &
     Pick<HtmlInputProps<HTMLInputElement>, 'id' | 'hidden' | 'aria-describedby'> & {
-        _fieldType?: 'text'
-
         /**
          * The main label for this field element.
          *
@@ -182,12 +180,11 @@ type BaseFieldProps = WithEnhancedClassName &
 
 type FieldComponentProps<T extends HTMLElement> = Omit<
     BaseFieldProps,
-    'children' | 'className' | '_fieldType' | 'variant'
+    'children' | 'className' | 'variant'
 > &
     Omit<HtmlInputProps<T>, 'className' | 'style'>
 
 function BaseField({
-    _fieldType,
     variant = 'default',
     label,
     secondaryLabel,
@@ -223,7 +220,6 @@ function BaseField({
                     styles.container,
                     tone === 'error' ? styles.error : null,
                     variant === 'bordered' ? styles.bordered : null,
-                    _fieldType === 'text' ? styles.text : null,
                 ]}
                 maxWidth={maxWidth}
             >

--- a/src/new-components/base-field/base-field.tsx
+++ b/src/new-components/base-field/base-field.tsx
@@ -70,11 +70,26 @@ type HtmlInputProps<T extends HTMLElement> = React.DetailedHTMLProps<
     T
 >
 
+type BaseFieldVariant = 'default' | 'bordered'
+type BaseFieldVariantProps = {
+    /**
+     * Provides alternative visual layouts or modes that the field can be rendered in.
+     *
+     * Namely, there are two variants supported:
+     *
+     * - the default one
+     * - a "bordered" variant, where the border of the field surrounds also the labels, instead
+     *   of just surrounding the actual field element
+     *
+     * In both cases, the message and description texts for the field lie outside the bordered
+     * area.
+     */
+    variant?: BaseFieldVariant
+}
+
 type BaseFieldProps = WithEnhancedClassName &
     Pick<HtmlInputProps<HTMLInputElement>, 'id' | 'hidden' | 'aria-describedby'> & {
         _fieldType?: 'text'
-
-        variant?: 'normal' | 'bordered'
 
         /**
          * The main label for this field element.
@@ -167,13 +182,13 @@ type BaseFieldProps = WithEnhancedClassName &
 
 type FieldComponentProps<T extends HTMLElement> = Omit<
     BaseFieldProps,
-    'children' | 'className' | '_fieldType'
+    'children' | 'className' | '_fieldType' | 'variant'
 > &
     Omit<HtmlInputProps<T>, 'className' | 'style'>
 
 function BaseField({
     _fieldType,
-    variant = 'normal',
+    variant = 'default',
     label,
     secondaryLabel,
     auxiliaryLabel,
@@ -186,7 +201,7 @@ function BaseField({
     hidden,
     'aria-describedby': originalAriaDescribedBy,
     id: originalId,
-}: BaseFieldProps & WithEnhancedClassName) {
+}: BaseFieldProps & BaseFieldVariantProps & WithEnhancedClassName) {
     const id = useId(originalId)
     const hintId = useId()
     const messageId = useId()
@@ -248,4 +263,4 @@ function BaseField({
 }
 
 export { BaseField, FieldHint, FieldMessage }
-export type { FieldComponentProps }
+export type { BaseFieldVariant, BaseFieldVariantProps, FieldComponentProps }

--- a/src/new-components/base-field/base-field.tsx
+++ b/src/new-components/base-field/base-field.tsx
@@ -72,6 +72,8 @@ type HtmlInputProps<T extends HTMLElement> = React.DetailedHTMLProps<
 
 type BaseFieldProps = WithEnhancedClassName &
     Pick<HtmlInputProps<HTMLInputElement>, 'id' | 'hidden' | 'aria-describedby'> & {
+        variant?: 'normal' | 'bordered'
+
         /**
          * The main label for this field element.
          *
@@ -165,6 +167,7 @@ type FieldComponentProps<T extends HTMLElement> = Omit<BaseFieldProps, 'children
     Omit<HtmlInputProps<T>, 'className' | 'style'>
 
 function BaseField({
+    variant = 'normal',
     label,
     secondaryLabel,
     auxiliaryLabel,
@@ -193,7 +196,15 @@ function BaseField({
 
     return (
         <Stack space="small" hidden={hidden}>
-            <Box className={[className, styles.container]} maxWidth={maxWidth}>
+            <Box
+                className={[
+                    className,
+                    styles.container,
+                    tone === 'error' ? styles.error : null,
+                    variant === 'bordered' ? styles.bordered : null,
+                ]}
+                maxWidth={maxWidth}
+            >
                 <Box
                     as="span"
                     display="flex"
@@ -201,7 +212,11 @@ function BaseField({
                     alignItems="flexEnd"
                     paddingBottom="small"
                 >
-                    <Text size="body" as="label" htmlFor={id}>
+                    <Text
+                        size={variant === 'bordered' ? 'caption' : 'body'}
+                        as="label"
+                        htmlFor={id}
+                    >
                         {label ? <span className={styles.primaryLabel}>{label}</span> : null}
                         {secondaryLabel ? (
                             <span className={styles.secondaryLabel}>&nbsp;({secondaryLabel})</span>

--- a/src/new-components/base-field/base-field.tsx
+++ b/src/new-components/base-field/base-field.tsx
@@ -223,13 +223,7 @@ function BaseField({
                 ]}
                 maxWidth={maxWidth}
             >
-                <Box
-                    as="span"
-                    display="flex"
-                    justifyContent="spaceBetween"
-                    alignItems="flexEnd"
-                    paddingBottom="small"
-                >
+                <Box as="span" display="flex" justifyContent="spaceBetween" alignItems="flexEnd">
                     <Text
                         size={variant === 'bordered' ? 'caption' : 'body'}
                         as="label"

--- a/src/new-components/base-field/base-field.tsx
+++ b/src/new-components/base-field/base-field.tsx
@@ -72,6 +72,8 @@ type HtmlInputProps<T extends HTMLElement> = React.DetailedHTMLProps<
 
 type BaseFieldProps = WithEnhancedClassName &
     Pick<HtmlInputProps<HTMLInputElement>, 'id' | 'hidden' | 'aria-describedby'> & {
+        _fieldType?: 'text'
+
         variant?: 'normal' | 'bordered'
 
         /**
@@ -163,10 +165,14 @@ type BaseFieldProps = WithEnhancedClassName &
         children: (props: ChildrenRenderProps) => React.ReactNode
     }
 
-type FieldComponentProps<T extends HTMLElement> = Omit<BaseFieldProps, 'children' | 'className'> &
+type FieldComponentProps<T extends HTMLElement> = Omit<
+    BaseFieldProps,
+    'children' | 'className' | '_fieldType'
+> &
     Omit<HtmlInputProps<T>, 'className' | 'style'>
 
 function BaseField({
+    _fieldType,
     variant = 'normal',
     label,
     secondaryLabel,
@@ -202,6 +208,7 @@ function BaseField({
                     styles.container,
                     tone === 'error' ? styles.error : null,
                     variant === 'bordered' ? styles.bordered : null,
+                    _fieldType === 'text' ? styles.text : null,
                 ]}
                 maxWidth={maxWidth}
             >

--- a/src/new-components/password-field/password-field.module.css
+++ b/src/new-components/password-field/password-field.module.css
@@ -7,8 +7,8 @@
 .inputWrapper button {
     outline: none; /* we take care of the focus state below */
     line-height: 0;
-    align-self: stretch;
-    margin: 2px;
+    margin: 0 3px;
+    padding: 0;
     border: none;
     border-radius: 3px;
     background: none;

--- a/src/new-components/password-field/password-field.stories.tsx
+++ b/src/new-components/password-field/password-field.stories.tsx
@@ -66,9 +66,9 @@ InteractivePropsStory.argTypes = {
         defaultValue: 'neutral',
     },
     variant: {
-        options: ['normal', 'bordered'],
+        options: ['default', 'bordered'],
         control: { type: 'inline-radio' },
-        defaultValue: 'normal',
+        defaultValue: 'default',
     },
     placeholder: {
         control: { type: 'text' },

--- a/src/new-components/password-field/password-field.stories.tsx
+++ b/src/new-components/password-field/password-field.stories.tsx
@@ -65,6 +65,11 @@ InteractivePropsStory.argTypes = {
         control: { type: 'inline-radio' },
         defaultValue: 'neutral',
     },
+    variant: {
+        options: ['normal', 'bordered'],
+        control: { type: 'inline-radio' },
+        defaultValue: 'normal',
+    },
     placeholder: {
         control: { type: 'text' },
         defaultValue: 'Type your password',

--- a/src/new-components/password-field/password-field.tsx
+++ b/src/new-components/password-field/password-field.tsx
@@ -19,6 +19,7 @@ type PasswordFieldProps = Omit<TextFieldProps, 'type'> & {
 
 const PasswordField = React.forwardRef<HTMLInputElement, PasswordFieldProps>(function PasswordField(
     {
+        variant = 'normal',
         label,
         secondaryLabel,
         auxiliaryLabel,
@@ -46,6 +47,7 @@ const PasswordField = React.forwardRef<HTMLInputElement, PasswordFieldProps>(fun
 
     return (
         <BaseField
+            variant={variant}
             id={id}
             label={label}
             secondaryLabel={secondaryLabel}
@@ -65,6 +67,7 @@ const PasswordField = React.forwardRef<HTMLInputElement, PasswordFieldProps>(fun
                         styles.inputWrapper,
                         textFieldStyles.inputWrapper,
                         tone === 'error' ? textFieldStyles.error : null,
+                        variant === 'bordered' ? textFieldStyles.bordered : null,
                     ]}
                 >
                     <input

--- a/src/new-components/password-field/password-field.tsx
+++ b/src/new-components/password-field/password-field.tsx
@@ -47,6 +47,7 @@ const PasswordField = React.forwardRef<HTMLInputElement, PasswordFieldProps>(fun
 
     return (
         <BaseField
+            _fieldType="text"
             variant={variant}
             id={id}
             label={label}

--- a/src/new-components/password-field/password-field.tsx
+++ b/src/new-components/password-field/password-field.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useForkRef } from 'ariakit-utils'
 import { Tooltip } from '../../components/tooltip'
-import { BaseField } from '../base-field'
+import { BaseField, BaseFieldVariantProps } from '../base-field'
 import { Box } from '../box'
 import { useId } from '../common-helpers'
 
@@ -13,13 +13,14 @@ import textFieldStyles from '../text-field/text-field.module.css'
 
 import type { TextFieldProps } from '../text-field'
 
-type PasswordFieldProps = Omit<TextFieldProps, 'type'> & {
-    togglePasswordLabel?: string
-}
+type PasswordFieldProps = Omit<TextFieldProps, 'type'> &
+    BaseFieldVariantProps & {
+        togglePasswordLabel?: string
+    }
 
 const PasswordField = React.forwardRef<HTMLInputElement, PasswordFieldProps>(function PasswordField(
     {
-        variant = 'normal',
+        variant = 'default',
         label,
         secondaryLabel,
         auxiliaryLabel,

--- a/src/new-components/password-field/password-field.tsx
+++ b/src/new-components/password-field/password-field.tsx
@@ -48,7 +48,6 @@ const PasswordField = React.forwardRef<HTMLInputElement, PasswordFieldProps>(fun
 
     return (
         <BaseField
-            _fieldType="text"
             variant={variant}
             id={id}
             label={label}

--- a/src/new-components/text-area/text-area.module.css
+++ b/src/new-components/text-area/text-area.module.css
@@ -1,11 +1,13 @@
+.container {
+    width: min-content;
+}
+
 .container textarea {
     outline: none; /* we're taking care of the outline styles ourselves */
     border: none;
     padding: 0;
-    width: 100%;
     box-sizing: border-box;
     font-family: var(--reactist-font-family);
-    resize: vertical;
 }
 
 .container:not(.bordered) textarea {

--- a/src/new-components/text-area/text-area.module.css
+++ b/src/new-components/text-area/text-area.module.css
@@ -1,16 +1,31 @@
 .container textarea {
-    padding: var(--reactist-spacing-small);
+    border: none;
+    padding: 0;
     width: 100%;
     box-sizing: border-box;
-    border-radius: var(--reactist-border-radius-small);
-    border: 1px solid var(--reactist-divider-secondary);
     font-family: var(--reactist-font-family);
 }
 
-.container.error textarea {
-    border-color: var(--reactist-alert-tone-critical-border) !important;
+.container:not(.bordered) textarea {
+    border-radius: var(--reactist-border-radius-small);
+    padding: var(--reactist-spacing-small);
 }
 
-.container textarea:focus-visible {
+.container.bordered {
+    border-radius: var(--reactist-border-radius-large);
+}
+
+.container:not(.bordered) textarea,
+.container.bordered {
+    border: 1px solid var(--reactist-divider-secondary);
+}
+
+.container:not(.bordered) textarea:focus-visible,
+.container.bordered:focus-within:focus-visible {
     border-color: var(--reactist-divider-primary);
+}
+
+.container.error:not(.bordered) textarea,
+.container.bordered.error {
+    border-color: var(--reactist-alert-tone-critical-border) !important;
 }

--- a/src/new-components/text-area/text-area.module.css
+++ b/src/new-components/text-area/text-area.module.css
@@ -1,9 +1,11 @@
 .container textarea {
+    outline: none; /* we're taking care of the outline styles ourselves */
     border: none;
     padding: 0;
     width: 100%;
     box-sizing: border-box;
     font-family: var(--reactist-font-family);
+    resize: vertical;
 }
 
 .container:not(.bordered) textarea {
@@ -20,8 +22,8 @@
     border: 1px solid var(--reactist-divider-secondary);
 }
 
-.container:not(.bordered) textarea:focus-visible,
-.container.bordered:focus-within:focus-visible {
+.container:not(.bordered) textarea:focus,
+.container.bordered:focus-within {
     border-color: var(--reactist-divider-primary);
 }
 

--- a/src/new-components/text-area/text-area.stories.tsx
+++ b/src/new-components/text-area/text-area.stories.tsx
@@ -66,9 +66,9 @@ InteractivePropsStory.argTypes = {
         defaultValue: 'neutral',
     },
     variant: {
-        options: ['normal', 'bordered'],
+        options: ['default', 'bordered'],
         control: { type: 'inline-radio' },
-        defaultValue: 'normal',
+        defaultValue: 'default',
     },
     placeholder: {
         control: { type: 'text' },

--- a/src/new-components/text-area/text-area.stories.tsx
+++ b/src/new-components/text-area/text-area.stories.tsx
@@ -65,6 +65,11 @@ InteractivePropsStory.argTypes = {
         control: { type: 'inline-radio' },
         defaultValue: 'neutral',
     },
+    variant: {
+        options: ['normal', 'bordered'],
+        control: { type: 'inline-radio' },
+        defaultValue: 'normal',
+    },
     placeholder: {
         control: { type: 'text' },
         defaultValue: 'Tell us something about yourself. Don’t be shy.',

--- a/src/new-components/text-area/text-area.tsx
+++ b/src/new-components/text-area/text-area.tsx
@@ -21,6 +21,7 @@ function TextArea({
 }: TextAreaProps) {
     return (
         <BaseField
+            _fieldType="text"
             variant={variant}
             id={id}
             label={label}

--- a/src/new-components/text-area/text-area.tsx
+++ b/src/new-components/text-area/text-area.tsx
@@ -39,7 +39,7 @@ function TextArea({
             maxWidth={maxWidth}
         >
             {(extraProps) => (
-                <Box width="full">
+                <Box width="full" display="flex">
                     <textarea {...props} {...extraProps} />
                 </Box>
             )}

--- a/src/new-components/text-area/text-area.tsx
+++ b/src/new-components/text-area/text-area.tsx
@@ -8,6 +8,7 @@ type TextAreaProps = FieldComponentProps<HTMLTextAreaElement> & {
 }
 
 function TextArea({
+    variant = 'normal',
     id,
     label,
     secondaryLabel,
@@ -20,6 +21,7 @@ function TextArea({
 }: TextAreaProps) {
     return (
         <BaseField
+            variant={variant}
             id={id}
             label={label}
             secondaryLabel={secondaryLabel}
@@ -27,7 +29,11 @@ function TextArea({
             hint={hint}
             message={message}
             tone={tone}
-            className={[styles.container, tone === 'error' ? styles.error : null]}
+            className={[
+                styles.container,
+                tone === 'error' ? styles.error : null,
+                variant === 'bordered' ? styles.bordered : null,
+            ]}
             maxWidth={maxWidth}
         >
             {(extraProps) => (

--- a/src/new-components/text-area/text-area.tsx
+++ b/src/new-components/text-area/text-area.tsx
@@ -22,7 +22,6 @@ function TextArea({
 }: TextAreaProps) {
     return (
         <BaseField
-            _fieldType="text"
             variant={variant}
             id={id}
             label={label}

--- a/src/new-components/text-area/text-area.tsx
+++ b/src/new-components/text-area/text-area.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react'
-import { BaseField, FieldComponentProps } from '../base-field'
+import { BaseField, BaseFieldVariantProps, FieldComponentProps } from '../base-field'
 import { Box } from '../box'
 import styles from './text-area.module.css'
 
-type TextAreaProps = FieldComponentProps<HTMLTextAreaElement> & {
-    rows?: number
-}
+type TextAreaProps = FieldComponentProps<HTMLTextAreaElement> &
+    BaseFieldVariantProps & {
+        rows?: number
+    }
 
 function TextArea({
-    variant = 'normal',
+    variant = 'default',
     id,
     label,
     secondaryLabel,

--- a/src/new-components/text-field/text-field.module.css
+++ b/src/new-components/text-field/text-field.module.css
@@ -1,14 +1,14 @@
-.inputWrapper {
+.inputWrapper:not(.bordered) {
     border-radius: var(--reactist-border-radius-small);
     border: 1px solid var(--reactist-divider-secondary);
     overflow: clip;
 }
 
-.inputWrapper:focus-within {
+.inputWrapper:not(.bordered):focus-within {
     border-color: var(--reactist-divider-primary);
 }
 
-.inputWrapper.error {
+.inputWrapper:not(.bordered).error {
     border-color: var(--reactist-alert-tone-critical-border) !important;
 }
 
@@ -42,6 +42,9 @@
 
     font-size: var(--reactist-font-size-body);
     line-height: calc(var(--reactist-font-size-body) + 4px);
-    padding: var(--tmp-vertical-padding) 10px;
     margin: 0;
+}
+
+.inputWrapper:not(.bordered) input {
+    padding: var(--tmp-vertical-padding) 10px;
 }

--- a/src/new-components/text-field/text-field.module.css
+++ b/src/new-components/text-field/text-field.module.css
@@ -4,6 +4,10 @@
     overflow: clip;
 }
 
+.inputWrapper.bordered input {
+    height: 24px;
+}
+
 .inputWrapper:not(.bordered):focus-within {
     border-color: var(--reactist-divider-primary);
 }

--- a/src/new-components/text-field/text-field.stories.tsx
+++ b/src/new-components/text-field/text-field.stories.tsx
@@ -66,9 +66,9 @@ InteractivePropsStory.argTypes = {
         defaultValue: 'neutral',
     },
     variant: {
-        options: ['normal', 'bordered'],
+        options: ['default', 'bordered'],
         control: { type: 'inline-radio' },
-        defaultValue: 'normal',
+        defaultValue: 'default',
     },
     placeholder: {
         control: { type: 'text' },

--- a/src/new-components/text-field/text-field.stories.tsx
+++ b/src/new-components/text-field/text-field.stories.tsx
@@ -65,6 +65,11 @@ InteractivePropsStory.argTypes = {
         control: { type: 'inline-radio' },
         defaultValue: 'neutral',
     },
+    variant: {
+        options: ['normal', 'bordered'],
+        control: { type: 'inline-radio' },
+        defaultValue: 'normal',
+    },
     placeholder: {
         control: { type: 'text' },
         defaultValue: 'Enter your name as it appears in your ID',

--- a/src/new-components/text-field/text-field.tsx
+++ b/src/new-components/text-field/text-field.tsx
@@ -30,6 +30,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
 ) {
     return (
         <BaseField
+            _fieldType="text"
             variant={variant}
             id={id}
             label={label}

--- a/src/new-components/text-field/text-field.tsx
+++ b/src/new-components/text-field/text-field.tsx
@@ -31,7 +31,6 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
 ) {
     return (
         <BaseField
-            _fieldType="text"
             variant={variant}
             id={id}
             label={label}

--- a/src/new-components/text-field/text-field.tsx
+++ b/src/new-components/text-field/text-field.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react'
-import { BaseField } from '../base-field'
+import { BaseField, BaseFieldVariantProps } from '../base-field'
 import { Box } from '../box'
 import styles from './text-field.module.css'
 import type { FieldComponentProps } from '../base-field'
 
 type TextFieldType = 'email' | 'search' | 'tel' | 'text' | 'url'
 
-type TextFieldProps = Omit<FieldComponentProps<HTMLInputElement>, 'type'> & {
-    type?: TextFieldType
-}
+type TextFieldProps = Omit<FieldComponentProps<HTMLInputElement>, 'type'> &
+    BaseFieldVariantProps & {
+        type?: TextFieldType
+    }
 
 const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function TextField(
     {
-        variant = 'normal',
+        variant = 'default',
         id,
         label,
         secondaryLabel,

--- a/src/new-components/text-field/text-field.tsx
+++ b/src/new-components/text-field/text-field.tsx
@@ -12,6 +12,7 @@ type TextFieldProps = Omit<FieldComponentProps<HTMLInputElement>, 'type'> & {
 
 const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function TextField(
     {
+        variant = 'normal',
         id,
         label,
         secondaryLabel,
@@ -29,6 +30,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
 ) {
     return (
         <BaseField
+            variant={variant}
             id={id}
             label={label}
             secondaryLabel={secondaryLabel}
@@ -41,7 +43,13 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
             aria-describedby={ariaDescribedBy}
         >
             {(extraProps) => (
-                <Box className={[styles.inputWrapper, tone === 'error' ? styles.error : null]}>
+                <Box
+                    className={[
+                        styles.inputWrapper,
+                        tone === 'error' ? styles.error : null,
+                        variant === 'bordered' ? styles.bordered : null,
+                    ]}
+                >
                     <input {...props} {...extraProps} type={type} ref={ref} />
                 </Box>
             )}


### PR DESCRIPTION
## Short description

This would allow use the Reactist component for the views that use this different style of text fields (e.g. Todoist and Twist login/onboarding pages).

- [Related discussion in Twist](https://twist.com/a/1585/ch/190200/t/3456577/c/76152665)

### A note on testing

This functionality is almost purely style-related[^1], it is a bit pointless to test in jest. I could test that the correct classes are being added here and there, but that provides very little confidence, since so much could be broken by changes in the style rules applied to those classes.

Given my upcoming plans to work in visual regression testing, I'm putting my bets on that for really testing this in a much better and confident way. But if you think there's something we could do that would add value, let me know.

[^1]: Even some interaction elements that we'd like to make sure we test somehow (e.g. clicking inside blank parts inside bordered area focuses on the field) is achieved via making sure with CSS that the label expands to those blank areas, and "clicking in the label to focus" is a functionality that browsers give us for free, so there's no JS involved in making that work.

### A note on some implementation details

The way `BaseField` works is proving more and more challenging to make it work with all the smaller details and nuances of each of the components that relies on it. This may need to be revisited to see how we can better provide a framework for field-like components, while being more flexible in reusing styles and allowing each component to customize things to its needs even more.

Given how prone this is to breaking if we do it now or soon, I am also putting my bets on visual regression testing. If we manage to have it place, it would allow us to make bigger internal refactors with more confidence that we will not break things visually.

## Test plan for reviewers

Some things to pay attention to while reviewing this:

1. In all 3 types of fields (`TextField`, `TextArea`, `PasswordField`)
    - [x] Make sure the border is red when marked with an error message (regardless of the border being outside with the new variant, or the border being only around the typing area, as it has always been before this PR)
    - [x] Similar to the point above, but taking a look at how the border color changes slightly when focused vs. not focused. Regardless of where the border is (containing the labels vs. not containing the labels, the border should react to focus/blur just the same)
    - [x] When using the new bordered mode, see that clicking on the blank area to the right of the label focuses the field.
2. For `PasswordField`
    - [x] Pay some attention to how the "toggle password visibility" button looks like in bordered vs regular style modes. Does it all look good?
3. For `TextArea`
    - [ ] Pay some attention to how the text area allows to be resized, but only vertically. I want your opinion on this. It was not good to allow to resize it horizontally while in bordered mode (because the wrapper around it would not adjust accordingly). Should we allow resizing fully when in the default (non-bordered) mode?

## PR Checklist

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

New minor release

## Demo

<ul>

<li>
<details>
<summary><code>TextField</code> 🔻</summary>

<table><tr><td>

![CleanShot 2022-06-02 at 16 29 28](https://user-images.githubusercontent.com/15199/171732501-a7200dbf-336c-4e66-a6ae-80a51369bc18.gif)

</td><td>

<img width="552" alt="CleanShot 2022-06-02 at 16 26 32@2x" src="https://user-images.githubusercontent.com/15199/171732330-cfeff2c3-ccaa-4dd3-b384-d9d96d2ff601.png">

</td></tr></table>

</details>
</li>

<li>
<details>
<summary><code>PasswordField</code> 🔻</summary>

<table><tr><td>

![CleanShot 2022-06-02 at 16 43 33](https://user-images.githubusercontent.com/15199/171734863-18acfb46-0461-449a-932a-7cb94092e3ce.gif)


</td><td>

<img width="555" alt="CleanShot 2022-06-02 at 16 44 11@2x" src="https://user-images.githubusercontent.com/15199/171734842-59de25e6-c9d1-4cf0-9ce4-98cd4f1f0f2e.png">

</td></tr></table>

</details>
</li>

<li>
<details>
<summary><code>TextArea</code> 🔻</summary>

<table><tr><td>

![CleanShot 2022-06-02 at 16 47 37](https://user-images.githubusercontent.com/15199/171735435-742a9ad4-dff7-4553-9857-7912b2b1d18d.gif)

</td><td>

<img width="552" alt="CleanShot 2022-06-02 at 16 48 43@2x" src="https://user-images.githubusercontent.com/15199/171735492-82bc559f-b1ef-48ce-8651-249f2023fe76.png">

</td></tr></table>

</details>
</li>

</ul>