### PR TITLE
BREAKING: Remove Button's tooltipGapSize prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 -   [Feat] Allow buttons to have fully rounded/circular corners.
 -   [Fix] Only apply full width labels when the button is full width
+-   [Breaking] Button's `tooltipGapSize` prop is no longer supported. When wanting to customize the tooltip appearance, consumers should take ownership of rendering the tooltip manually.
+-   [Breaking] Icon-only buttons can have their implicit "aria-label as tooltip" behaviour suppressed by passing `tooltip={null}`. Useful when wanting to get full control over rendering the tooltip manually.
 
 # v12.1.1
 

--- a/src/new-components/base-button/base-button.tsx
+++ b/src/new-components/base-button/base-button.tsx
@@ -60,11 +60,6 @@ type CommonProps = {
      * A tooltip linked to the button element.
      */
     tooltip?: TooltipProps['content']
-
-    /**
-     * The distance between the button element and the linked tooltip.
-     */
-    tooltipGapSize?: TooltipProps['gapSize']
 }
 
 type AlignmentProps = {
@@ -113,7 +108,6 @@ export const BaseButton = polymorphicComponent<'div', BaseButtonProps>(function 
         disabled = false,
         loading = false,
         tooltip,
-        tooltipGapSize,
         onClick,
         exceptionallySetClassName,
         children,
@@ -177,11 +171,9 @@ export const BaseButton = polymorphicComponent<'div', BaseButtonProps>(function 
     )
 
     // If it's an icon-only button, make sure it uses the aria-label as tooltip if no tooltip was provided
-    const tooltipContent = icon ? tooltip ?? props['aria-label'] : tooltip
+    const tooltipContent = icon && tooltip === undefined ? props['aria-label'] : tooltip
     return tooltipContent ? (
-        <Tooltip content={tooltipContent} gapSize={tooltipGapSize}>
-            {buttonElement}
-        </Tooltip>
+        <Tooltip content={tooltipContent}>{buttonElement}</Tooltip>
     ) : (
         buttonElement
     )

--- a/src/new-components/button/button.test.tsx
+++ b/src/new-components/button/button.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { render, screen, within } from '@testing-library/react'
+import { act, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Button } from './button'
 import { axe } from 'jest-axe'
@@ -287,6 +287,39 @@ describe('Button', () => {
             const button = screen.getByRole('button', { name: 'Smile' })
             expect(button.className).not.toMatch(/align/)
             expect(button.className).not.toMatch(/width/)
+        })
+
+        it('renders with the aria-label implicitly used as its tooltip', async () => {
+            render(<Button variant="primary" icon="😄" aria-label="Smile" />)
+            expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+            userEvent.tab()
+            expect(screen.getByRole('button', { name: 'Smile' })).toHaveFocus()
+            expect(await screen.findByRole('tooltip', { name: 'Smile' })).toBeInTheDocument()
+        })
+
+        it('renders a different tooltip if given explicitly', async () => {
+            render(<Button variant="primary" icon="😄" aria-label="Smile" tooltip="Say cheese!" />)
+            expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+            userEvent.tab()
+            expect(screen.getByRole('button', { name: 'Smile' })).toHaveFocus()
+            expect(await screen.findByRole('tooltip', { name: 'Say cheese!' })).toBeInTheDocument()
+        })
+
+        it('allows to supress the implicit "aria-label as tooltip" behaviour by passing tooltip={null}', () => {
+            jest.useFakeTimers()
+
+            render(<Button variant="primary" icon="😄" aria-label="Smile" tooltip={null} />)
+            expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+            userEvent.tab()
+            expect(screen.getByRole('button', { name: 'Smile' })).toHaveFocus()
+
+            act(() => {
+                jest.advanceTimersByTime(2000) // More than enough time for a potential tooltip appearance
+            })
+
+            expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+            jest.useRealTimers()
         })
     })
 


### PR DESCRIPTION
## Short description

The `tooltipGapSize` button prop was introduced in #636, but was challenged shortly afterwards, as not being a good course of action. See https://github.com/Doist/reactist/pull/636#issuecomment-1098598788.

However, the reason for needing it was related to the fact that icon-only buttons are too aggressive in assuming they should use the `aria-label` for the tooltip if no tooltip is given. This PR makes it so that icon-only buttons only fall back to use `aria-label` as tooltip if the tooltip is really omitted (that is, the prop is not given at all, or given with value `undefined`). If the `tooltip` prop is given, but with a falsy/empty value, the implicit tooltip is now omitted, allowing consumers of the button to fully own the rendering of the tooltip, or to really suppress it if they really want to (with great power comes great responsibility).

So, from now on, instead of this:

```jsx
// Not good
<Button
  icon={<SomeIcon />}
  aria-label="Click me"
  tooltipGapSize={8}
/>
```

We should use this:

```jsx
// Good
<Tooltip content="Click me" gapSize={8}>
  <Button
    icon={<SomeIcon />}
    aria-label="Click me"
    tooltip={null}
  />
</Tooltip>
```

However, the most common use case (not needing to customize the tooltip), remains as simple as ever:

```jsx
<Button
  icon={<SomeIcon />}
  aria-label="Click me"
/>
```

Or customizing only the tooltip content, but nothing else:


```jsx
<Button
  icon={<SomeIcon />}
  aria-label="Click me"
  tooltip="Click me NOW"
/>
```

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

This is a breaking change, which implies a new major version release.