### PR TITLE
fix: Reset input padding for bordered TextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# next
+
+-   [Fix] Reset input padding for `variant="bordered"` `TextField`.
+
 # v12.1.0
 
 -   [Feat] New `message` and `tone` props that allow to associate a visual and semantic message to various field components. Supported in `TextField`, `PasswordField`, `TextArea` and `SelectField`.

--- a/src/new-components/text-field/text-field.module.css
+++ b/src/new-components/text-field/text-field.module.css
@@ -5,6 +5,7 @@
 }
 
 .inputWrapper.bordered input {
+    padding: 0;
     height: 24px;
 }
 


### PR DESCRIPTION
## Short description

Fixes the input padding for `<TextField variant="bordered" />`.

Before:
![image](https://user-images.githubusercontent.com/40036/178701940-20986def-9532-4df6-addd-79da810209ce.png)

After:
![image](https://user-images.githubusercontent.com/40036/178702185-7ddd7139-70f4-4278-85d9-fa2c735db682.png)


## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)