### PR TITLE
breaking: Support `themed` and `neutral` Tab variations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # Next
 
+-   [Breaking] The `color` prop has been removed from `Tabs`, and `variant` now only supports `themed` and `neutral` as options.
 -   [Fix] `Tooltip` will now correctly use an anchor component with an `as` prop
 
 # v13.0.0

--- a/src/new-components/tabs/tabs.module.css
+++ b/src/new-components/tabs/tabs.module.css
@@ -1,20 +1,15 @@
 :root {
-    /*
-    * These are not the actual colours defined in the mocks. Until we have a colour system aligned with
-    * our product libraries, these variables should be documented and customized in the consuming apps.
-    */
-    --reactist-tab-primary-background: rgb(36, 111, 224);
-    --reactist-tab-primary-foreground: var(--reactist-content-light-on-dark);
-    --reactist-tab-primary-unselected: rgb(36, 111, 224);
-    --reactist-tab-secondary-background: var(--reactist-framework-fill-selected);
-    --reactist-tab-secondary-foreground: rgb(36, 111, 224);
-    --reactist-tab-secondary-unselected: rgb(36, 111, 224);
-    --reactist-tab-tertiary-background: rgb(128, 128, 128);
-    --reactist-tab-tertiary-foreground: var(--reactist-content-light-on-dark);
-    --reactist-tab-tertiary-unselected: var(--reactist-content-tertiary);
+    --reactist-tab-themed-background: var(--reactist-bg-default);
+    --reactist-tab-themed-foreground: #006f85;
+    --reactist-tab-themed-unselected: #006f85;
+    --reactist-tab-themed-track: rgb(242, 246, 247);
+    --reactist-tab-themed-border: var(--reactist-divider-secondary);
 
-    --reactist-tab-track: var(--reactist-framework-fill-crest);
-    --reactist-tab-border: var(--reactist-divider-primary);
+    --reactist-tab-neutral-background: var(--reactist-bg-default);
+    --reactist-tab-neutral-foreground: var(--reactist-content-primary);
+    --reactist-tab-neutral-unselected: var(--reactist-content-tertiary);
+    --reactist-tab-neutral-track: var(--reactist-framework-fill-selected);
+    --reactist-tab-neutral-border: var(--reactist-divider-primary);
 
     --reactist-tab-track-border-width: 2px;
     --reactist-tab-border-radius: 20px;
@@ -23,73 +18,17 @@
 
 .tab {
     box-sizing: border-box;
+    padding: 0 var(--reactist-spacing-medium);
     border: none;
-    border-radius: var(--reactist-border-radius-small);
     background: none;
     cursor: pointer;
-    font-weight: var(--reactist-font-weight-medium);
-    text-decoration: none;
-}
-
-/*
- * Base styles
- */
-
-.tab-normal,
-.tab-tracked {
-    padding: 0 var(--reactist-spacing-medium);
     font-size: var(--reactist-font-size-body);
+    font-weight: var(--reactist-font-weight-medium);
     line-height: 32px;
-    border-radius: var(--reactist-tab-border-radius);
-}
-
-/*
- * Colour options
- */
-
-.tab-normal.tab-primary,
-.tab-tracked.tab-primary {
-    color: var(--reactist-tab-primary-unselected);
-}
-
-.tab-normal.tab-primary[aria-selected='true'],
-.tab-tracked.tab-primary[aria-selected='true'] {
-    background-color: var(--reactist-tab-primary-background);
-    color: var(--reactist-tab-primary-foreground);
-}
-
-.tab-normal.tab-secondary,
-.tab-tracked.tab-secondary {
-    color: var(--reactist-tab-secondary-unselected);
-}
-
-.tab-normal.tab-secondary[aria-selected='true'],
-.tab-tracked.tab-secondary[aria-selected='true'] {
-    background-color: var(--reactist-tab-secondary-background);
-    color: var(--reactist-tab-secondary-foreground);
-}
-
-.tab-normal.tab-tertiary,
-.tab-tracked.tab-tertiary {
-    color: var(--reactist-tab-tertiary-unselected);
-}
-
-.tab-normal.tab-tertiary[aria-selected='true'],
-.tab-tracked.tab-tertiary[aria-selected='true'] {
-    background-color: var(--reactist-tab-tertiary-background);
-    color: var(--reactist-tab-tertiary-foreground);
-}
-
-/*
- * 'Tracked' variant
- */
-.tab-tracked {
     z-index: 1;
+    text-decoration: none;
     border: var(--reactist-tab-border-width) solid transparent;
-}
-
-.tab-tracked[aria-selected='true'] {
-    border-color: var(--reactist-tab-border);
+    border-radius: var(--reactist-tab-border-radius);
 }
 
 .track {
@@ -99,32 +38,68 @@
     bottom: calc(-1 * var(--reactist-tab-track-border-width));
     left: calc(-1 * var(--reactist-tab-track-border-width));
     margin-top: var(--reactist-spacing-large);
-
     border-radius: var(--reactist-tab-border-radius);
-    background: var(--reactist-tab-track);
-    border: var(--reactist-tab-track-border-width) solid var(--reactist-tab-track);
+    border-width: var(--reactist-tab-track-border-width);
+    border-style: solid;
 }
 
-.tab-track-xsmall {
+/*
+ * Variant options
+ */
+
+.tab,
+.tab-neutral {
+    color: var(--reactist-tab-neutral-unselected);
+}
+
+.tab[aria-selected='true'],
+.tab-neutral[aria-selected='true'] {
+    background-color: var(--reactist-tab-neutral-background);
+    color: var(--reactist-tab-neutral-foreground);
+    border-color: var(--reactist-tab-neutral-border);
+}
+
+.tab-themed {
+    color: var(--reactist-tab-themed-unselected);
+}
+
+.tab-themed[aria-selected='true'] {
+    background-color: var(--reactist-tab-themed-background);
+    color: var(--reactist-tab-themed-foreground);
+    border-color: var(--reactist-tab-themed-border);
+}
+
+.track,
+.track-neutral {
+    background: var(--reactist-tab-neutral-track);
+    border-color: var(--reactist-tab-neutral-track);
+}
+
+.track-themed {
+    background: var(--reactist-tab-themed-track);
+    border-color: var(--reactist-tab-themed-track);
+}
+
+.track-xsmall {
     margin-top: var(--reactist-spacing-xsmall);
 }
 
-.tab-track-small {
+.track-small {
     margin-top: var(--reactist-spacing-small);
 }
 
-.tab-track-medium {
+.track-medium {
     margin-top: var(--reactist-spacing-medium);
 }
 
-.tab-track-large {
+.track-large {
     margin-top: var(--reactist-spacing-large);
 }
 
-.tab-track-xlarge {
+.track-xlarge {
     margin-top: var(--reactist-spacing-xlarge);
 }
 
-.tab-track-xxlarge {
+.track-xxlarge {
     margin-top: var(--reactist-spacing-xxlarge);
 }

--- a/src/new-components/tabs/tabs.module.css
+++ b/src/new-components/tabs/tabs.module.css
@@ -12,6 +12,13 @@
     --reactist-tab-tertiary-background: rgb(128, 128, 128);
     --reactist-tab-tertiary-foreground: var(--reactist-content-light-on-dark);
     --reactist-tab-tertiary-unselected: var(--reactist-content-tertiary);
+
+    --reactist-tab-track: var(--reactist-framework-fill-crest);
+    --reactist-tab-border: var(--reactist-divider-primary);
+
+    --reactist-tab-track-border-width: 2px;
+    --reactist-tab-border-radius: 20px;
+    --reactist-tab-border-width: 1px;
 }
 
 .tab {
@@ -25,41 +32,101 @@
 }
 
 /*
- * Normal variant
+ * Base styles
  */
 
-.tab-normal {
+.tab-normal,
+.tab-tracked {
     padding: 0 var(--reactist-spacing-medium);
     font-size: var(--reactist-font-size-body);
     line-height: 32px;
-    border-radius: 20px;
+    border-radius: var(--reactist-tab-border-radius);
 }
 
-.tab-normal.tab-primary {
+/*
+ * Colour options
+ */
+
+.tab-normal.tab-primary,
+.tab-tracked.tab-primary {
     color: var(--reactist-tab-primary-unselected);
 }
 
-.tab-normal.tab-primary[aria-selected='true'] {
+.tab-normal.tab-primary[aria-selected='true'],
+.tab-tracked.tab-primary[aria-selected='true'] {
     background-color: var(--reactist-tab-primary-background);
     color: var(--reactist-tab-primary-foreground);
 }
 
-.tab-normal.tab-secondary {
+.tab-normal.tab-secondary,
+.tab-tracked.tab-secondary {
     color: var(--reactist-tab-secondary-unselected);
 }
 
-.tab-normal.tab-secondary[aria-selected='true'] {
+.tab-normal.tab-secondary[aria-selected='true'],
+.tab-tracked.tab-secondary[aria-selected='true'] {
     background-color: var(--reactist-tab-secondary-background);
     color: var(--reactist-tab-secondary-foreground);
 }
 
-.tab-normal.tab-tertiary {
+.tab-normal.tab-tertiary,
+.tab-tracked.tab-tertiary {
     color: var(--reactist-tab-tertiary-unselected);
 }
 
-.tab-normal.tab-tertiary[aria-selected='true'] {
+.tab-normal.tab-tertiary[aria-selected='true'],
+.tab-tracked.tab-tertiary[aria-selected='true'] {
     background-color: var(--reactist-tab-tertiary-background);
     color: var(--reactist-tab-tertiary-foreground);
+}
+
+/*
+ * 'Tracked' variant
+ */
+.tab-tracked {
+    z-index: 1;
+    border: var(--reactist-tab-border-width) solid transparent;
+}
+
+.tab-tracked[aria-selected='true'] {
+    border-color: var(--reactist-tab-border);
+}
+
+.track {
+    position: absolute;
+    top: calc(-1 * var(--reactist-tab-track-border-width));
+    right: calc(-1 * var(--reactist-tab-track-border-width));
+    bottom: calc(-1 * var(--reactist-tab-track-border-width));
+    left: calc(-1 * var(--reactist-tab-track-border-width));
+    margin-top: var(--reactist-spacing-large);
+
+    border-radius: var(--reactist-tab-border-radius);
+    background: var(--reactist-tab-track);
+    border: var(--reactist-tab-track-border-width) solid var(--reactist-tab-track);
+}
+
+.tab-track-xsmall {
+    margin-top: var(--reactist-spacing-xsmall);
+}
+
+.tab-track-small {
+    margin-top: var(--reactist-spacing-small);
+}
+
+.tab-track-medium {
+    margin-top: var(--reactist-spacing-medium);
+}
+
+.tab-track-large {
+    margin-top: var(--reactist-spacing-large);
+}
+
+.tab-track-xlarge {
+    margin-top: var(--reactist-spacing-xlarge);
+}
+
+.tab-track-xxlarge {
+    margin-top: var(--reactist-spacing-xxlarge);
 }
 
 /*

--- a/src/new-components/tabs/tabs.module.css
+++ b/src/new-components/tabs/tabs.module.css
@@ -128,18 +128,3 @@
 .tab-track-xxlarge {
     margin-top: var(--reactist-spacing-xxlarge);
 }
-
-/*
- * Plain variant
- */
-
-.tab-plain {
-    padding: var(--reactist-spacing-xsmall);
-    color: var(--reactist-content-secondary);
-    font-size: var(--reactist-font-size-subtitle);
-    font-weight: var(--reactist-font-weight-strong);
-}
-
-.tab-plain[aria-selected='true'] {
-    color: var(--reactist-content-primary);
-}

--- a/src/new-components/tabs/tabs.stories.mdx
+++ b/src/new-components/tabs/tabs.stories.mdx
@@ -79,7 +79,7 @@ export const Template = ({
                 control: { type: 'inline-radio' },
             },
             variant: {
-                options: ['normal', 'plain'],
+                options: ['normal', 'tracked', 'plain'],
                 control: { type: 'inline-radio' },
             },
             color: {
@@ -143,9 +143,42 @@ The following CSS custom properties are available so that the tabs' colors can b
 --reactist-tab-tertiary-background
 --reactist-tab-tertiary-foreground
 --reactist-tab-tertiary-unselected
+
+--reactist-tab-track
+--reactist-tab-border
 ```
 
 ## Stories
+
+### Tracked variant
+
+<Canvas withToolbar>
+    <Story
+        parameters={{ docs: { source: { type: 'code' } } }}
+        args={{
+            'aria-label': 'Tabs with tracked variant style',
+            variant: 'tracked',
+        }}
+        name="Tracked variant"
+    >
+        {Template.bind({})}
+    </Story>
+</Canvas>
+
+### Plain variant
+
+<Canvas withToolbar>
+    <Story
+        parameters={{ docs: { source: { type: 'code' } } }}
+        args={{
+            'aria-label': 'Tabs with plain variant style',
+            variant: 'plain',
+        }}
+        name="Plain variant"
+    >
+        {Template.bind({})}
+    </Story>
+</Canvas>
 
 ### Primary color
 
@@ -186,21 +219,6 @@ The following CSS custom properties are available so that the tabs' colors can b
             color: 'tertiary',
         }}
         name="Tertiary color"
-    >
-        {Template.bind({})}
-    </Story>
-</Canvas>
-
-### Plain variant
-
-<Canvas withToolbar>
-    <Story
-        parameters={{ docs: { source: { type: 'code' } } }}
-        args={{
-            'aria-label': 'Tabs with plain variant style',
-            variant: 'plain',
-        }}
-        name="Plain variant"
     >
         {Template.bind({})}
     </Story>

--- a/src/new-components/tabs/tabs.stories.mdx
+++ b/src/new-components/tabs/tabs.stories.mdx
@@ -79,7 +79,7 @@ export const Template = ({
                 control: { type: 'inline-radio' },
             },
             variant: {
-                options: ['normal', 'tracked', 'plain'],
+                options: ['normal', 'tracked'],
                 control: { type: 'inline-radio' },
             },
             color: {
@@ -160,21 +160,6 @@ The following CSS custom properties are available so that the tabs' colors can b
             variant: 'tracked',
         }}
         name="Tracked variant"
-    >
-        {Template.bind({})}
-    </Story>
-</Canvas>
-
-### Plain variant
-
-<Canvas withToolbar>
-    <Story
-        parameters={{ docs: { source: { type: 'code' } } }}
-        args={{
-            'aria-label': 'Tabs with plain variant style',
-            variant: 'plain',
-        }}
-        name="Plain variant"
     >
         {Template.bind({})}
     </Story>

--- a/src/new-components/tabs/tabs.stories.mdx
+++ b/src/new-components/tabs/tabs.stories.mdx
@@ -247,8 +247,7 @@ As long as they exist within the same `<Tabs>` component tree, multiple `<TabLis
 By default, the `TabPanel` renders an unstyled div. When more control is needed, an element type or component
 can be specified with the `as` prop.
 
-Note that when combined with the `render="active"` prop, only the tabpanel's
-children are prevented from rendering, and not the actual polymorphic component/element itself.
+Note that when combined with the `render="active"` prop, the entire tabpanel will be affected, including the actual polymorphic component/element passed into `as`.
 
 <Canvas withToolbar>
     <Story parameters={{ docs: { source: { type: 'code' } } }} name="Polymorphism">

--- a/src/new-components/tabs/tabs.stories.mdx
+++ b/src/new-components/tabs/tabs.stories.mdx
@@ -19,7 +19,6 @@ This component is powered by [Ariakit's Tab component](https://ariakit.org/examp
 behaviour, see [ARIA: tab role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role).
 
 export const Template = ({
-    color,
     variant,
     space,
     selectedId,
@@ -30,7 +29,6 @@ export const Template = ({
     'aria-labelledby': ariaLabelledby,
 }) => (
     <Tabs
-        color={color}
         variant={variant}
         selectedId={selectedId}
         defaultSelectedId={defaultSelectedId}
@@ -79,11 +77,7 @@ export const Template = ({
                 control: { type: 'inline-radio' },
             },
             variant: {
-                options: ['normal', 'tracked'],
-                control: { type: 'inline-radio' },
-            },
-            color: {
-                options: ['primary', 'secondary', 'tertiary'],
+                options: ['themed', 'neutral'],
                 control: { type: 'inline-radio' },
             },
             space: {
@@ -132,78 +126,31 @@ export const Template = ({
 The following CSS custom properties are available so that the tabs' colors can be customized:
 
 ```
---reactist-tab-primary-background
---reactist-tab-primary-foreground
---reactist-tab-primary-unselected
+--reactist-tab-neutral-background
+--reactist-tab-neutral-foreground
+--reactist-tab-neutral-unselected
+--reactist-tab-neutral-track
+--reactist-tab-neutral-border
 
---reactist-tab-secondary-background
---reactist-tab-secondary-foreground
---reactist-tab-secondary-unselected
-
---reactist-tab-tertiary-background
---reactist-tab-tertiary-foreground
---reactist-tab-tertiary-unselected
-
---reactist-tab-track
---reactist-tab-border
+--reactist-tab-themed-background
+--reactist-tab-themed-foreground
+--reactist-tab-themed-unselected
+--reactist-tab-themed-track
+--reactist-tab-themed-border
 ```
 
 ## Stories
 
-### Tracked variant
+### Themed variant
 
 <Canvas withToolbar>
     <Story
         parameters={{ docs: { source: { type: 'code' } } }}
         args={{
-            'aria-label': 'Tabs with tracked variant style',
-            variant: 'tracked',
+            'aria-label': 'Tabs with themed variant style',
+            variant: 'themed',
         }}
-        name="Tracked variant"
-    >
-        {Template.bind({})}
-    </Story>
-</Canvas>
-
-### Primary color
-
-<Canvas withToolbar>
-    <Story
-        parameters={{ docs: { source: { type: 'code' } } }}
-        args={{
-            'aria-label': 'Tabs with primary color style',
-        }}
-        name="Primary color"
-    >
-        {Template.bind({})}
-    </Story>
-</Canvas>
-
-### Secondary color
-
-<Canvas withToolbar>
-    <Story
-        parameters={{ docs: { source: { type: 'code' } } }}
-        args={{
-            'aria-label': 'Tabs with secondary color style',
-            color: 'secondary',
-        }}
-        name="Secondary color"
-    >
-        {Template.bind({})}
-    </Story>
-</Canvas>
-
-### Tertiary color
-
-<Canvas withToolbar>
-    <Story
-        parameters={{ docs: { source: { type: 'code' } } }}
-        args={{
-            'aria-label': 'Tabs with tertiary color style',
-            color: 'tertiary',
-        }}
-        name="Tertiary color"
+        name="Themed variant"
     >
         {Template.bind({})}
     </Story>

--- a/src/new-components/tabs/tabs.tsx
+++ b/src/new-components/tabs/tabs.tsx
@@ -10,14 +10,14 @@ import {
 import { Inline } from '../inline'
 import { usePrevious } from '../../hooks/use-previous'
 import { polymorphicComponent } from '../../utils/polymorphism'
-import type { ResponsiveProp } from '../responsive-props'
 import type { Space } from '../common-types'
 
 import styles from './tabs.module.css'
+import { Box } from '../box'
 
 type TabsContextValue = {
     tabState: TabState
-} & Pick<TabsProps, 'color' | 'variant'>
+} & Required<Pick<TabsProps, 'color' | 'variant'>>
 
 const TabsContext = React.createContext<TabsContextValue | null>(null)
 
@@ -25,13 +25,13 @@ type TabsProps = {
     /** The `<Tabs>` component must be composed from a `<TabList>` and corresponding `<TabPanel>` components */
     children: React.ReactNode
     /**
-     * Determines the primary colour of the tabs
+     * Determines the primary colour of the tabs. Applicable to the 'tracked' and 'normal' variants.
      */
     color?: 'primary' | 'secondary' | 'tertiary'
     /**
      * Determines the style of the tabs
      */
-    variant?: 'normal' | 'plain'
+    variant?: 'normal' | 'tracked' | 'plain'
     /**
      * The id of the selected tab. Assigning a value makes this a
      * controlled component
@@ -121,8 +121,8 @@ export const Tab = polymorphicComponent<'button', TabProps>(function Tab(
             className={classNames(
                 exceptionallySetClassName,
                 styles.tab,
-                styles[`tab-${variant ?? ''}`],
-                styles[`tab-${color ?? ''}`],
+                styles[`tab-${variant}`],
+                styles[`tab-${color}`],
             )}
             id={id}
             state={tabState}
@@ -160,7 +160,7 @@ type TabListProps = (
     /**
      * Controls the spacing between tabs
      */
-    space?: ResponsiveProp<Space>
+    space?: Space
 }
 
 /**
@@ -168,7 +168,7 @@ type TabListProps = (
  */
 export function TabList({
     children,
-    space = 'medium',
+    space: preferredSpace,
     ...props
 }: TabListProps): React.ReactElement | null {
     const tabContextValue = React.useContext(TabsContext)
@@ -177,10 +177,15 @@ export function TabList({
         return null
     }
 
-    const { tabState } = tabContextValue
+    const { tabState, variant } = tabContextValue
+    const defaultSpace = variant === 'tracked' ? 'xsmall' : 'medium'
+    const space = preferredSpace ?? defaultSpace
 
     return (
-        <BaseTabList state={tabState} {...props}>
+        <BaseTabList state={tabState} as={Box} position="relative" width="maxContent" {...props}>
+            {variant === 'tracked' ? (
+                <Box className={classNames(styles.track, styles[`tab-track-${space}`])} />
+            ) : null}
             <Inline space={space}>{children}</Inline>
         </BaseTabList>
     )

--- a/src/new-components/tabs/tabs.tsx
+++ b/src/new-components/tabs/tabs.tsx
@@ -17,7 +17,7 @@ import { Box } from '../box'
 
 type TabsContextValue = {
     tabState: TabState
-} & Required<Pick<TabsProps, 'color' | 'variant'>>
+} & Required<Pick<TabsProps, 'variant'>>
 
 const TabsContext = React.createContext<TabsContextValue | null>(null)
 
@@ -25,13 +25,9 @@ type TabsProps = {
     /** The `<Tabs>` component must be composed from a `<TabList>` and corresponding `<TabPanel>` components */
     children: React.ReactNode
     /**
-     * Determines the primary colour of the tabs. Applicable to the 'tracked' and 'normal' variants.
+     * Determines the look and feel of the tabs.
      */
-    color?: 'primary' | 'secondary' | 'tertiary'
-    /**
-     * Determines the style of the tabs
-     */
-    variant?: 'normal' | 'tracked'
+    variant?: 'themed' | 'neutral'
     /**
      * The id of the selected tab. Assigning a value makes this a
      * controlled component
@@ -55,8 +51,7 @@ export function Tabs({
     children,
     selectedId,
     defaultSelectedId,
-    color = 'primary',
-    variant = 'normal',
+    variant = 'neutral',
     onSelectedIdChange,
 }: TabsProps): React.ReactElement {
     const tabState = useTabState({ selectedId, setSelectedId: onSelectedIdChange })
@@ -81,11 +76,10 @@ export function Tabs({
         function memoizeTabState() {
             return {
                 tabState,
-                color,
                 variant,
             }
         },
-        [color, variant, tabState],
+        [variant, tabState],
     )
 
     return <TabsContext.Provider value={memoizedTabState}>{children}</TabsContext.Provider>
@@ -112,18 +106,13 @@ export const Tab = polymorphicComponent<'button', TabProps>(function Tab(
         return null
     }
 
-    const { color, variant, tabState } = tabContextValue
+    const { variant, tabState } = tabContextValue
 
     return (
         <BaseTab
             {...props}
             as={as}
-            className={classNames(
-                exceptionallySetClassName,
-                styles.tab,
-                styles[`tab-${variant}`],
-                styles[`tab-${color}`],
-            )}
+            className={classNames(exceptionallySetClassName, styles.tab, styles[`tab-${variant}`])}
             id={id}
             state={tabState}
             ref={ref}
@@ -168,7 +157,7 @@ type TabListProps = (
  */
 export function TabList({
     children,
-    space: preferredSpace,
+    space = 'xsmall',
     ...props
 }: TabListProps): React.ReactElement | null {
     const tabContextValue = React.useContext(TabsContext)
@@ -178,14 +167,16 @@ export function TabList({
     }
 
     const { tabState, variant } = tabContextValue
-    const defaultSpace = variant === 'tracked' ? 'xsmall' : 'medium'
-    const space = preferredSpace ?? defaultSpace
 
     return (
         <BaseTabList state={tabState} as={Box} position="relative" width="maxContent" {...props}>
-            {variant === 'tracked' ? (
-                <Box className={classNames(styles.track, styles[`tab-track-${space}`])} />
-            ) : null}
+            <Box
+                className={classNames(
+                    styles.track,
+                    styles[`track-${space}`],
+                    styles[`track-${variant}`],
+                )}
+            />
             <Inline space={space}>{children}</Inline>
         </BaseTabList>
     )

--- a/src/new-components/tabs/tabs.tsx
+++ b/src/new-components/tabs/tabs.tsx
@@ -31,7 +31,7 @@ type TabsProps = {
     /**
      * Determines the style of the tabs
      */
-    variant?: 'normal' | 'tracked' | 'plain'
+    variant?: 'normal' | 'tracked'
     /**
      * The id of the selected tab. Assigning a value makes this a
      * controlled component

--- a/src/new-components/tabs/tabs.tsx
+++ b/src/new-components/tabs/tabs.tsx
@@ -169,16 +169,26 @@ export function TabList({
     const { tabState, variant } = tabContextValue
 
     return (
-        <BaseTabList state={tabState} as={Box} position="relative" width="maxContent" {...props}>
-            <Box
-                className={classNames(
-                    styles.track,
-                    styles[`track-${space}`],
-                    styles[`track-${variant}`],
-                )}
-            />
-            <Inline space={space}>{children}</Inline>
-        </BaseTabList>
+        // The extra <Box> prevents <Inline>'s negative margins from collapsing when used in a flex container
+        // which will render the track with the wrong height
+        <Box>
+            <BaseTabList
+                state={tabState}
+                as={Box}
+                position="relative"
+                width="maxContent"
+                {...props}
+            >
+                <Box
+                    className={classNames(
+                        styles.track,
+                        styles[`track-${space}`],
+                        styles[`track-${variant}`],
+                    )}
+                />
+                <Inline space={space}>{children}</Inline>
+            </BaseTabList>
+        </Box>
     )
 }
 

--- a/src/new-components/tabs/tabs.tsx
+++ b/src/new-components/tabs/tabs.tsx
@@ -233,14 +233,16 @@ export const TabPanel = polymorphicComponent<'div', TabPanelProps, 'omitClassNam
         }
 
         const { tabState } = tabContextValue
+        const shouldRender =
+            render === 'always' ||
+            (render === 'active' && tabIsActive) ||
+            (render === 'lazy' && (tabIsActive || tabRendered))
 
-        return (
+        return shouldRender ? (
             <BaseTabPanel tabId={id} {...props} state={tabState} as={as} ref={ref}>
-                {render === 'always' ? children : null}
-                {render === 'active' && tabIsActive ? children : null}
-                {render === 'lazy' && (tabIsActive || tabRendered) ? children : null}
+                {children}
             </BaseTabPanel>
-        )
+        ) : null
     },
 )
 

--- a/src/new-components/tabs/tabs.tsx
+++ b/src/new-components/tabs/tabs.tsx
@@ -194,7 +194,7 @@ export function TabList({
 
 type TabPanelProps = {
     /** The content to be rendered inside the tab */
-    children: React.ReactNode
+    children?: React.ReactNode
 
     /** The tabPanel's identifier. This must match its corresponding `<Tab>`'s id */
     id: string


### PR DESCRIPTION
## Short description

This changes the `Tab` component's API and drops a few variations that we no longer use. The `color` prop has been removed, and `variant` now accepts `themed` and `neutral` as valid options.

More details are in https://github.com/Doist/Issues/issues/6854 and https://twist.com/a/1585/inbox/t/3688056/.

![image](https://user-images.githubusercontent.com/8531248/184360532-98b8cf00-28a1-41e4-a439-25f10a4c2cf5.png)

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Major
