### PR TITLE
feat: Field and textarea components improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 # Next-Next
 
 -   [Feat] Fields without label show no spacing above the field
+-   [Fix] `TextArea` can now be hidden
+-   [Fix] `TextArea` now properly support receiving an explicit alternative aria-describedby attribute
 
 # Next
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# Next-Next
+
+-   [Feat] Fields without label show no spacing above the field
+
 # Next
 
 # v15.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
-# Next-Next
+# Next
 
 -   [Feat] Fields without label show no spacing above the field
 -   [Fix] `TextArea` can now be hidden
 -   [Fix] `TextArea` now properly support receiving an explicit alternative aria-describedby attribute
-
-# Next
 
 # v15.0.0
 

--- a/src/new-components/base-field/base-field.tsx
+++ b/src/new-components/base-field/base-field.tsx
@@ -92,6 +92,11 @@ type BaseFieldProps = WithEnhancedClassName &
         /**
          * The main label for this field element.
          *
+         * This prop is not optional. Consumers of field components must be explicit about not
+         * wanting a label by passing `label=""` or `label={null}`. In those situations, consumers
+         * should make sure that fields are properly labelled semantically by other means (e.g using
+         * `aria-labelledby`, or rendering a `<label />` element referencing the field by id).
+         *
          * Avoid providing interactive elements in the label. Prefer `auxiliaryLabel` for that.
          *
          * @see BaseFieldProps['secondaryLabel']

--- a/src/new-components/base-field/base-field.tsx
+++ b/src/new-components/base-field/base-field.tsx
@@ -94,8 +94,8 @@ type BaseFieldProps = WithEnhancedClassName &
          *
          * Avoid providing interactive elements in the label. Prefer `auxiliaryLabel` for that.
          *
-         * @see secondaryLabel
-         * @see auxiliaryLabel
+         * @see BaseFieldProps['secondaryLabel']
+         * @see BaseFieldProps['auxiliaryLabel']
          */
         label: React.ReactNode
 
@@ -106,8 +106,8 @@ type BaseFieldProps = WithEnhancedClassName &
          *
          * Avoid providing interactive elements in the label. Prefer `auxiliaryLabel` for that.
          *
-         * @see label
-         * @see auxiliaryLabel
+         * @see BaseFieldProps['label']
+         * @see BaseFieldProps['auxiliaryLabel']
          */
         secondaryLabel?: React.ReactNode
 
@@ -117,8 +117,8 @@ type BaseFieldProps = WithEnhancedClassName &
          * This extra element is not included in the accessible name of the field element. Its only
          * purpose is either visual, or functional (if you include interactive elements in it).
          *
-         * @see label
-         * @see secondaryLabel
+         * @see BaseFieldProps['label']
+         * @see BaseFieldProps['secondaryLabel']
          */
         auxiliaryLabel?: React.ReactNode
 
@@ -134,7 +134,7 @@ type BaseFieldProps = WithEnhancedClassName &
          * In the future, when `aria-errormessage` gets better user agent support, we should use it
          * to associate the filed with a message when tone is `"error"`.
          *
-         * @see tone
+         * @see BaseFieldProps['tone']
          * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage
          * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid
          */
@@ -149,8 +149,8 @@ type BaseFieldProps = WithEnhancedClassName &
          * When the tone is `"loading"`, it is recommended that you also disable the field. However,
          * this is not enforced by the component. It is only a recommendation.
          *
-         * @see message
-         * @see hint
+         * @see BaseFieldProps['message']
+         * @see BaseFieldProps['hint']
          */
         tone?: FieldTone
 
@@ -223,23 +223,32 @@ function BaseField({
                 ]}
                 maxWidth={maxWidth}
             >
-                <Box as="span" display="flex" justifyContent="spaceBetween" alignItems="flexEnd">
-                    <Text
-                        size={variant === 'bordered' ? 'caption' : 'body'}
-                        as="label"
-                        htmlFor={id}
+                {label || secondaryLabel || auxiliaryLabel ? (
+                    <Box
+                        as="span"
+                        display="flex"
+                        justifyContent="spaceBetween"
+                        alignItems="flexEnd"
                     >
-                        {label ? <span className={styles.primaryLabel}>{label}</span> : null}
-                        {secondaryLabel ? (
-                            <span className={styles.secondaryLabel}>&nbsp;({secondaryLabel})</span>
+                        <Text
+                            size={variant === 'bordered' ? 'caption' : 'body'}
+                            as="label"
+                            htmlFor={id}
+                        >
+                            {label ? <span className={styles.primaryLabel}>{label}</span> : null}
+                            {secondaryLabel ? (
+                                <span className={styles.secondaryLabel}>
+                                    &nbsp;({secondaryLabel})
+                                </span>
+                            ) : null}
+                        </Text>
+                        {auxiliaryLabel ? (
+                            <Box className={styles.auxiliaryLabel} paddingLeft="small">
+                                {auxiliaryLabel}
+                            </Box>
                         ) : null}
-                    </Text>
-                    {auxiliaryLabel ? (
-                        <Box className={styles.auxiliaryLabel} paddingLeft="small">
-                            {auxiliaryLabel}
-                        </Box>
-                    ) : null}
-                </Box>
+                    </Box>
+                ) : null}
                 {children(childrenProps)}
             </Box>
             {message ? (

--- a/src/new-components/password-field/password-field.stories.tsx
+++ b/src/new-components/password-field/password-field.stories.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react'
 import { selectWithNone, PartialProps } from '../storybook-helper'
+
+import { Stack } from '../stack'
+import { Text } from '../text'
 import { PasswordField } from './'
 
 import type { BoxMaxWidth } from '../box'
-import { Stack } from '../stack'
 
 export default {
     title: 'Design system/PasswordField',
@@ -109,6 +111,31 @@ export function MessageToneStory() {
                 tone="neutral"
                 maxWidth="small"
             />
+        </Stack>
+    )
+}
+
+export function WithoutLabelStory() {
+    return (
+        <Stack space="xlarge" dividers="secondary" maxWidth="small">
+            <Stack as="label" htmlFor="custom-textarea" space="small">
+                <Text size="subtitle">Custom label is up here</Text>
+                <Text size="caption" tone="secondary" aria-hidden>
+                    <em>(click me to focus the textarea)</em>
+                </Text>
+            </Stack>
+            <PasswordField
+                label={null}
+                id="custom-textarea"
+                aria-describedby="custom-description"
+                placeholder="Password field without a built-in label"
+            />
+            <Stack space="small" id="custom-description">
+                <Text size="body">Custom description is down here</Text>
+                <Text size="caption" tone="secondary" aria-hidden>
+                    <em>(inspect the input element accessibility properties if you are curious)</em>
+                </Text>
+            </Stack>
         </Stack>
     )
 }

--- a/src/new-components/select-field/select-field.stories.tsx
+++ b/src/new-components/select-field/select-field.stories.tsx
@@ -2,8 +2,10 @@ import * as React from 'react'
 import { selectWithNone, PartialProps } from '../storybook-helper'
 import { SelectField } from './'
 
-import type { BoxMaxWidth } from '../box'
 import { Stack } from '../stack'
+import { Text } from '../text'
+
+import type { BoxMaxWidth } from '../box'
 
 export default {
     title: 'Design system/SelectField',
@@ -132,6 +134,32 @@ export function MessageToneStory() {
                     –
                 </option>
             </SelectField>
+        </Stack>
+    )
+}
+
+export function WithoutLabelStory() {
+    return (
+        <Stack space="xlarge" dividers="secondary" maxWidth="small">
+            <Stack as="label" htmlFor="custom-textarea" space="small">
+                <Text size="subtitle">Custom label is up here</Text>
+                <Text size="caption" tone="secondary" aria-hidden>
+                    <em>(click me to focus the select element)</em>
+                </Text>
+            </Stack>
+            <SelectField label={null} id="custom-textarea" aria-describedby="custom-description">
+                <option value="none" disabled>
+                    –
+                </option>
+            </SelectField>
+            <Stack space="small" id="custom-description">
+                <Text size="body">Custom description is down here</Text>
+                <Text size="caption" tone="secondary" aria-hidden>
+                    <em>
+                        (inspect the select element accessibility properties if you are curious)
+                    </em>
+                </Text>
+            </Stack>
         </Stack>
     )
 }

--- a/src/new-components/text-area/text-area.stories.tsx
+++ b/src/new-components/text-area/text-area.stories.tsx
@@ -115,7 +115,7 @@ export function MessageToneStory() {
     )
 }
 
-export function TextAreaWithoutLabelStory() {
+export function WithoutLabelStory() {
     return (
         <Stack space="xlarge" dividers="secondary">
             <Stack as="label" htmlFor="custom-textarea" space="small">

--- a/src/new-components/text-area/text-area.stories.tsx
+++ b/src/new-components/text-area/text-area.stories.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react'
 import { selectWithNone, PartialProps } from '../storybook-helper'
+
+import { Stack } from '../stack'
+import { Text } from '../text'
 import { TextArea } from './'
 
 import type { BoxMaxWidth } from '../box'
-import { Stack } from '../stack'
 
 export default {
     title: 'Design system/TextArea',
@@ -109,6 +111,31 @@ export function MessageToneStory() {
                 tone="neutral"
                 maxWidth="small"
             />
+        </Stack>
+    )
+}
+
+export function TextAreaWithoutLabelStory() {
+    return (
+        <Stack space="xlarge" dividers="secondary">
+            <Stack as="label" htmlFor="custom-textarea" space="small">
+                <Text size="subtitle">Custom label is up here</Text>
+                <Text size="caption" tone="secondary" aria-hidden>
+                    <em>(click me to focus the textarea)</em>
+                </Text>
+            </Stack>
+            <TextArea
+                label={null}
+                id="custom-textarea"
+                aria-describedby="custom-description"
+                rows={8}
+            />
+            <Stack space="small" id="custom-description">
+                <Text size="body">Custom description is down here</Text>
+                <Text size="caption" tone="secondary" aria-hidden>
+                    <em>(inspect the textarea accessibility properties if you are curious)</em>
+                </Text>
+            </Stack>
         </Stack>
     )
 }

--- a/src/new-components/text-area/text-area.test.tsx
+++ b/src/new-components/text-area/text-area.test.tsx
@@ -1,0 +1,272 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { TextArea } from './'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
+
+describe('TextArea', () => {
+    it('supports having an externally provided id attribute', () => {
+        render(<TextArea data-testid="text-area" id="custom-id" label="Tell us a bit about you" />)
+        expect(screen.getByTestId('text-area').id).toBe('custom-id')
+        // Makes sure that even with the custom id, the label is still associated to the input element
+        expect(screen.getByTestId('text-area')).toHaveAccessibleName('Tell us a bit about you')
+    })
+
+    it('is labelled by its label and secondary label', () => {
+        const { rerender } = render(
+            <TextArea data-testid="text-area" label="Tell us a bit about you" />,
+        )
+        expect(screen.getByTestId('text-area')).toHaveAccessibleName('Tell us a bit about you')
+
+        rerender(
+            <TextArea
+                data-testid="text-area"
+                label="Tell us a bit about you"
+                secondaryLabel="optional"
+            />,
+        )
+        expect(screen.getByTestId('text-area')).toHaveAccessibleName(
+            'Tell us a bit about you (optional)',
+        )
+    })
+
+    it('can be labelled via aria-label', () => {
+        render(
+            <TextArea
+                data-testid="text-area"
+                label="Biography"
+                aria-label="Tell us a bit about you"
+            />,
+        )
+        expect(screen.getByTestId('text-area')).toHaveAccessibleName('Tell us a bit about you')
+    })
+
+    it('can be labelled via aria-labelledby', () => {
+        render(
+            <>
+                <TextArea
+                    data-testid="text-area"
+                    label="Tell us a bit abouit you"
+                    aria-labelledby="custom-label"
+                />
+                <div id="custom-label">Biography</div>
+            </>,
+        )
+        expect(screen.getByTestId('text-area')).toHaveAccessibleName('Biography')
+    })
+
+    it('is described by its hint when provided', () => {
+        render(
+            <TextArea data-testid="text-area" label="Biography" hint="Tell us a bit about you" />,
+        )
+        expect(screen.getByTestId('text-area')).toHaveAccessibleDescription(
+            'Tell us a bit about you',
+        )
+    })
+
+    it('can be described by something else via aria-describedby', () => {
+        render(
+            <>
+                <TextArea
+                    data-testid="text-area"
+                    label="Tell us a bit about you"
+                    hint="Don't be shy"
+                    aria-describedby="custom-hint"
+                />
+                <div id="custom-hint">You can talk about your hobbies and personal preferences</div>
+            </>,
+        )
+        expect(screen.getByTestId('text-area')).toHaveAccessibleDescription(
+            'You can talk about your hobbies and personal preferences',
+        )
+    })
+
+    it('is marked as invalid and when tone="error"', () => {
+        render(<TextArea data-testid="text-area" label="Tell us a bit about you" tone="error" />)
+        expect(screen.getByTestId('text-area')).toBeInvalid()
+    })
+
+    it.each([['success' as const], ['loading' as const], ['neutral' as const], ['error' as const]])(
+        'uses the message as the description, when tone="%s"',
+        (tone) => {
+            render(
+                <TextArea
+                    data-testid="text-area"
+                    label="Tell us a bit about you"
+                    message={`Message with ${tone} tone`}
+                    tone={tone}
+                />,
+            )
+            expect(screen.getByTestId('text-area')).toHaveAccessibleDescription(
+                `Message with ${tone} tone`,
+            )
+        },
+    )
+
+    it('adds the message as part of the description, whenever the tone is not error', () => {
+        render(
+            <TextArea
+                data-testid="text-area"
+                label="Biography"
+                hint="Tell us a bit about you"
+                message="Changes saved successfully"
+                tone="success"
+            />,
+        )
+        expect(screen.getByTestId('text-area')).toHaveAccessibleDescription(
+            'Changes saved successfully Tell us a bit about you',
+        )
+    })
+
+    it('renders its auxiliary label', () => {
+        render(
+            <TextArea
+                label="Tell us a bit about you"
+                auxiliaryLabel={<a href="/help">Why we need this info?</a>}
+            />,
+        )
+        expect(screen.getByRole('link', { name: 'Why we need this info?' })).toBeInTheDocument()
+    })
+
+    it('does not use the auxiliary label for semantic labelling purposes', () => {
+        render(
+            <TextArea
+                label="Tell us a bit about you"
+                auxiliaryLabel={<a href="/help">Why we need this info?</a>}
+            />,
+        )
+        expect(
+            screen.queryByRole('textbox', { name: /why we need this info/i }),
+        ).not.toBeInTheDocument()
+        expect(screen.getByRole('textbox')).toHaveAccessibleName('Tell us a bit about you')
+        expect(screen.getByRole('textbox')).not.toHaveAccessibleDescription()
+    })
+
+    it('can have a placeholder text', () => {
+        render(
+            <TextArea
+                label="Tell us a bit about you"
+                data-testid="text-area"
+                placeholder="You can talk about your hobbies and personal preferences"
+            />,
+        )
+        expect(screen.getByTestId('text-area')).toBe(
+            screen.getByPlaceholderText('You can talk about your hobbies and personal preferences'),
+        )
+    })
+
+    it('is hidden when hidden={true}', () => {
+        const { rerender } = render(
+            <TextArea
+                data-testid="text-area"
+                label="Tell us a bit about you"
+                hint="You can talk about your hobbies and personal preferences"
+                hidden
+            />,
+        )
+
+        const textAreaElement = screen.getByTestId('text-area')
+        const hintElement = screen.getByText(/you can talk about your hobbies/i)
+
+        // check that it is rendered but not visible
+        expect(textAreaElement).not.toBeVisible()
+        expect(
+            screen.queryByRole('textbox', { name: 'Tell us a bit about you' }),
+        ).not.toBeInTheDocument()
+        expect(screen.getByText(/you can talk about your hobbies/i)).toBeInTheDocument()
+        expect(hintElement).not.toBeVisible()
+
+        // check that it becomes visible when hidden is removed
+        rerender(
+            <TextArea
+                data-testid="text-area"
+                label="Tell us a bit about you"
+                hint="You can talk about your hobbies and personal preferences"
+            />,
+        )
+        expect(textAreaElement).toBeVisible()
+        expect(screen.getByRole('textbox', { name: 'Tell us a bit about you' })).toBeInTheDocument()
+        expect(screen.getByText(/you can talk about your hobbies/i)).toBeInTheDocument()
+        expect(hintElement).toBeVisible()
+    })
+
+    it('forwards to the textarea element any extra props provided to it', () => {
+        render(
+            <TextArea
+                label="Visual label"
+                aria-label="Non-visual label"
+                data-testid="text-area"
+                data-something="whatever"
+                rows={4}
+            />,
+        )
+        const textareaElement = screen.getByTestId('text-area')
+        expect(textareaElement.tagName).toBe('TEXTAREA')
+        expect(textareaElement).toHaveAttribute('aria-label', 'Non-visual label')
+        expect(textareaElement).toHaveAttribute('data-testid', 'text-area')
+        expect(textareaElement).toHaveAttribute('data-something', 'whatever')
+        expect(textareaElement).toHaveAttribute('rows', '4')
+    })
+
+    it('allows to type text into it', () => {
+        render(<TextArea label="Tell us a bit about you" />)
+        const textareaElement = screen.getByRole('textbox', { name: 'Tell us a bit about you' })
+        expect(textareaElement).toHaveValue('')
+        userEvent.type(textareaElement, 'I love to travel around the world')
+        expect(textareaElement).toHaveValue('I love to travel around the world')
+    })
+
+    it('can be disabled', () => {
+        render(<TextArea label="Tell us a bit about you" disabled />)
+        const textareaElement = screen.getByRole('textbox', { name: 'Tell us a bit about you' })
+        expect(textareaElement).toBeDisabled()
+        expect(textareaElement).toHaveValue('')
+        userEvent.type(textareaElement, 'I love to travel around the world')
+        expect(textareaElement).toHaveValue('')
+    })
+
+    it('can be readonly', () => {
+        render(<TextArea label="Tell us a bit about you" readOnly />)
+        const textareaElement = screen.getByRole('textbox', { name: 'Tell us a bit about you' })
+        expect(textareaElement).not.toBeDisabled()
+        expect(textareaElement).toHaveValue('')
+        userEvent.type(textareaElement, 'I love to travel around the world')
+        expect(textareaElement).toHaveValue('')
+    })
+
+    it('can be a controlled field', () => {
+        function TestCase() {
+            const [value, setValue] = React.useState('')
+            return (
+                <>
+                    <TextArea
+                        label="Tell us a bit about you"
+                        value={value}
+                        onChange={(event) => setValue(event.currentTarget.value)}
+                    />
+                    <div data-testid="value">{value}</div>
+                </>
+            )
+        }
+
+        render(<TestCase />)
+        const textareaElement = screen.getByRole('textbox', { name: 'Tell us a bit about you' })
+        expect(textareaElement).toHaveValue('')
+        userEvent.type(textareaElement, 'I love to travel around the world')
+        expect(textareaElement).toHaveValue('I love to travel around the world')
+        expect(screen.getByTestId('value')).toHaveTextContent('I love to travel around the world')
+    })
+
+    describe('a11y', () => {
+        it('renders with no a11y violations', async () => {
+            const { container } = render(
+                <>
+                    <TextArea label="Biography" />
+                    <TextArea label="Biography" disabled />
+                    <TextArea label="Biography" hint="Tell us a bit about you" />
+                </>,
+            )
+            expect(await axe(container)).toHaveNoViolations()
+        })
+    })
+})

--- a/src/new-components/text-area/text-area.tsx
+++ b/src/new-components/text-area/text-area.tsx
@@ -18,6 +18,8 @@ function TextArea({
     message,
     tone,
     maxWidth,
+    hidden,
+    'aria-describedby': ariaDescribedBy,
     ...props
 }: TextAreaProps) {
     return (
@@ -30,6 +32,8 @@ function TextArea({
             hint={hint}
             message={message}
             tone={tone}
+            hidden={hidden}
+            aria-describedby={ariaDescribedBy}
             className={[
                 styles.container,
                 tone === 'error' ? styles.error : null,

--- a/src/new-components/text-field/text-field.stories.tsx
+++ b/src/new-components/text-field/text-field.stories.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react'
 import { selectWithNone, PartialProps } from '../storybook-helper'
+
+import { Stack } from '../stack'
+import { Text } from '../text'
 import { TextField } from './'
 
 import type { BoxMaxWidth } from '../box'
-import { Stack } from '../stack'
 
 export default {
     title: 'Design system/TextField',
@@ -109,6 +111,31 @@ export function MessageToneStory() {
                 tone="neutral"
                 maxWidth="small"
             />
+        </Stack>
+    )
+}
+
+export function WithoutLabelStory() {
+    return (
+        <Stack space="xlarge" dividers="secondary" maxWidth="small">
+            <Stack as="label" htmlFor="custom-textarea" space="small">
+                <Text size="subtitle">Custom label is up here</Text>
+                <Text size="caption" tone="secondary" aria-hidden>
+                    <em>(click me to focus the input element)</em>
+                </Text>
+            </Stack>
+            <TextField
+                label={null}
+                id="custom-textarea"
+                aria-describedby="custom-description"
+                placeholder="Text field without a built-in label"
+            />
+            <Stack space="small" id="custom-description">
+                <Text size="body">Custom description is down here</Text>
+                <Text size="caption" tone="secondary" aria-hidden>
+                    <em>(inspect the input element accessibility properties if you are curious)</em>
+                </Text>
+            </Stack>
         </Stack>
     )
 }

--- a/src/new-components/text-field/text-field.test.tsx
+++ b/src/new-components/text-field/text-field.test.tsx
@@ -100,9 +100,10 @@ describe('TextField', () => {
     })
 
     it('does not use the auxiliary label for semantic labelling purposes', () => {
-        render(<TextField label="VAT ID" auxiliaryLabel={<a href="/help">Whatʼs this?</a>} />)
-        expect(screen.getByRole('textbox', { name: 'VAT ID' })).toHaveAccessibleName('VAT ID')
-        expect(screen.getByRole('textbox', { name: 'VAT ID' })).not.toHaveAccessibleDescription()
+        render(<TextField label="VAT ID" auxiliaryLabel={<a href="/help">What is this?</a>} />)
+        expect(screen.queryByRole('textbox', { name: /what is this/i })).not.toBeInTheDocument()
+        expect(screen.getByRole('textbox')).toHaveAccessibleName('VAT ID')
+        expect(screen.getByRole('textbox')).not.toHaveAccessibleDescription()
     })
 
     it('can have a placeholder text', () => {


### PR DESCRIPTION
## Short description

A handful of improvements and fixes related to field components. Most prominently:

1. Allow them to render without a label.
    - This was already technically possible, but it rendered a gap at the top of the component, the spacing between it and its labels. That gap is now gone if there are no labels to render.
    - The label prop is still not optional. Users must be explicit about not wanting a label by passing `label=""` or `label={null}`
2. Add tests for `TextArea` and a couple of fixes uncovered by the new tests.
    - See `CHANGELOG` for details

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

This will be merged and queued to an upcoming release.

The changes here are not breaking. This PR on its own should involve a minor release, as it only introduces fixes and a new feature (the removal of the gap, making the labelless field possibility official).

## Demo

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

<img width="411" alt="CleanShot 2022-08-15 at 13 27 59@2x" src="https://user-images.githubusercontent.com/15199/184693480-d5dff934-ea16-4293-9bbd-0ce21a64bc24.png">

</td>
<td>

<img width="411" alt="CleanShot 2022-08-15 at 13 28 37@2x" src="https://user-images.githubusercontent.com/15199/184693487-3a5dda9e-3e6f-46cb-882b-e3a6ccc863df.png">

</td>
</tr>
</table>

