### PR TITLE
fix: Ensure Tooltips work with anchors that have an `as` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # Next
 
+-   [Fix] `Tooltip` will now correctly use an anchor component with an `as` prop
+
 # v13.0.0
 
 -   [Breaking] Button's `tooltipGapSize` prop is no longer supported. When wanting to customize the tooltip appearance, consumers should take ownership of rendering the tooltip manually.

--- a/src/components/tooltip/tooltip.test.tsx
+++ b/src/components/tooltip/tooltip.test.tsx
@@ -4,6 +4,8 @@ import { axe } from 'jest-axe'
 import userEvent from '@testing-library/user-event'
 import { Tooltip, SHOW_DELAY, HIDE_DELAY } from './tooltip'
 import { flushPromises } from '../../new-components/test-helpers'
+import { Box } from '../../new-components/box'
+import { Button } from '../../new-components/button'
 
 // Runs the same test abstracting how the tooltip is triggered (can be via mouse or keyboard)
 async function testShowHide({
@@ -178,14 +180,34 @@ describe('Tooltip', () => {
         const buttonRef = React.createRef<HTMLButtonElement>()
 
         render(
-            <>
-                <Tooltip content="tooltip content here">
-                    <button ref={buttonRef}>Click me</button>
-                </Tooltip>
-            </>,
+            <Tooltip content="tooltip content here">
+                <button ref={buttonRef}>Click me</button>
+            </Tooltip>,
         )
 
         expect(buttonRef.current).toBe(screen.getByRole('button'))
+    })
+
+    it('supports components with an "as" prop as the anchor', async () => {
+        render(
+            <Tooltip content="tooltip content here">
+                <Box as={Button} variant="primary">
+                    Click me
+                </Box>
+            </Tooltip>,
+        )
+
+        const button = screen.getByRole('button', { name: 'Click me' })
+        expect(button).toBeVisible()
+
+        await testShowHide({
+            triggerShow() {
+                userEvent.hover(button)
+            },
+            triggerHide() {
+                userEvent.unhover(button)
+            },
+        })
     })
 
     describe('a11y', () => {


### PR DESCRIPTION
## Short description

This fixes an issue where if you used a tooltip anchor with an `as` prop, it gets doubly applied, creates a nested element, and loses the anchor's children in the process 😬

Example:
```TSX
<Tooltip content="Some helpful info">
  <Box as={Link} to="/help">Hover me for info</Box>
</Tooltip>
```

...would result in something like:

```TSX
<a href="/help">
  <a href="/help"> />
<a>
```

You could test this in storybook by undoing the fix, then using `<Box as={Button}>` as an anchor.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Patch release
