### PR TITLE
fix: Set max-height on reactist_menulist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # Next
 
+-   [Fix] Set `min-height` and `max-height` on `.reactist_menulist`.
+
 # v14.1.1
 
 -   [Fix] Pins the ariakit dependencies.

--- a/src/components/menu/menu.less
+++ b/src/components/menu/menu.less
@@ -4,6 +4,9 @@
 // Ref: https://github.com/ariakit/ariakit/blob/454aef1237ada31e8292ee4966adca3ed0f6e299/packages/ariakit/src/menu/menu-list.ts#L150
 .reactist_menulist[role='menu'],
 .reactist_menulist[role='menubar'] {
+    min-height: 44px; // minimum accessible target area
+    max-height: var(--popover-available-height); // defined by ariakit
+    overflow: auto;
     display: block;
     white-space: nowrap;
     background: hsla(0, 100%, 100%, 0.99);

--- a/src/components/menu/menu.stories.tsx
+++ b/src/components/menu/menu.stories.tsx
@@ -78,6 +78,8 @@ export function SimpleMenuExample() {
                     </MenuButton>
                     <MenuList aria-label="Simple menu">
                         <MenuItem onSelect={action('Edit')}>Edit</MenuItem>
+                        <MenuItem onSelect={action('Copy')}>Copy</MenuItem>
+                        <MenuItem onSelect={action('Paste')}>Paste</MenuItem>
                         <MenuItem onSelect={action('Duplicate')}>Duplicate</MenuItem>
                         <MenuItem onSelect={action('Remove')}>Remove</MenuItem>
                     </MenuList>


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Closes https://github.com/Doist/Issues/issues/7375

## Short description

Applies `min-height: 44px` and `max-height: var(--popover-available-height)` to `.reactist_menulist` in order to allow the menu list popover to scroll when it's height is greater than the viewport.

The min-height is set according to the [minimum target size for pointer inputs](https://www.w3.org/TR/WCAG21/#target-size).

This fixed is based on the ariakit [menu example implementation](https://github.com/ariakit/ariakit/blob/9b2af70dc86fa767ffb8fb268ade591bc988cce7/packages/ariakit/src/menu/__examples__/menu/style.css#L4).

## Test plan

-   Run the Reactist storybook
- Navigate into the `Components > Menu > Simple Menu Example` canvas tab.
- Expand the Simple Menu
- [x] After reducing the canvas height the simple menu popover contents become scrollable.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->
