### PR TITLE
feat: Reduce default height for Tabs, expose custom property for customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # Next
 
+-   [Feat] `Tabs` by default have a shorter height, but this can be customized by overriding an exposed css variable
+
+# v14.0.0
+
 -   [Breaking] The `color` prop has been removed from `Tabs`, and `variant` now only supports `themed` and `neutral` as options.
 -   [Fix] `Tooltip` will now correctly use an anchor component with an `as` prop
 

--- a/src/new-components/tabs/tabs.module.css
+++ b/src/new-components/tabs/tabs.module.css
@@ -14,6 +14,7 @@
     --reactist-tab-track-border-width: 2px;
     --reactist-tab-border-radius: 20px;
     --reactist-tab-border-width: 1px;
+    --reactist-tab-height: 30px;
 }
 
 .tab {
@@ -24,7 +25,7 @@
     cursor: pointer;
     font-size: var(--reactist-font-size-body);
     font-weight: var(--reactist-font-weight-medium);
-    line-height: 32px;
+    line-height: var(--reactist-tab-height);
     z-index: 1;
     text-decoration: none;
     border: var(--reactist-tab-border-width) solid transparent;

--- a/src/new-components/tabs/tabs.stories.mdx
+++ b/src/new-components/tabs/tabs.stories.mdx
@@ -139,6 +139,15 @@ The following CSS custom properties are available so that the tabs' colors can b
 --reactist-tab-themed-border
 ```
 
+Their size can also be customized with:
+
+```
+--reactist-tab-track-border-width
+--reactist-tab-border-radius
+--reactist-tab-border-width
+--reactist-tab-height
+```
+
 ## Stories
 
 ### Themed variant


### PR DESCRIPTION

<!--
Include a link to related issues, or more importantly, any issue this may close.
-->



## Short description

Reduces the tab's height as requested at https://twist.com/a/1585/ch/1329/t/3688056/c/78152818

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Minor
