### PR TITLE
fix: TextArea now controls the width and only allows resizing vertically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 -   [Feat] Fields without label show no spacing above the field
 -   [Fix] `TextArea` can now be hidden
 -   [Fix] `TextArea` now properly support receiving an explicit alternative aria-describedby attribute
+-   [Fix] TextArea is changed to only allow resizing vertically. This ensures that the consumer of the component can control the width via the maxWidth prop.
 
 # v15.0.0
 

--- a/src/new-components/text-area/text-area.module.css
+++ b/src/new-components/text-area/text-area.module.css
@@ -1,35 +1,33 @@
-.container {
-    width: min-content;
-}
-
-.container textarea {
+.textAreaContainer textarea {
     outline: none; /* we're taking care of the outline styles ourselves */
     border: none;
     padding: 0;
     box-sizing: border-box;
     font-family: var(--reactist-font-family);
+    width: 100%;
+    resize: vertical;
 }
 
-.container:not(.bordered) textarea {
+.textAreaContainer:not(.bordered) textarea {
     border-radius: var(--reactist-border-radius-small);
     padding: var(--reactist-spacing-small);
 }
 
-.container.bordered {
+.textAreaContainer.bordered {
     border-radius: var(--reactist-border-radius-large);
 }
 
-.container:not(.bordered) textarea,
-.container.bordered {
+.textAreaContainer:not(.bordered) textarea,
+.textAreaContainer.bordered {
     border: 1px solid var(--reactist-divider-secondary);
 }
 
-.container:not(.bordered) textarea:focus,
-.container.bordered:focus-within {
+.textAreaContainer:not(.bordered) textarea:focus,
+.textAreaContainer.bordered:focus-within {
     border-color: var(--reactist-divider-primary);
 }
 
-.container.error:not(.bordered) textarea,
-.container.bordered.error {
+.textAreaContainer.error:not(.bordered) textarea,
+.textAreaContainer.bordered.error {
     border-color: var(--reactist-alert-tone-critical-border) !important;
 }

--- a/src/new-components/text-area/text-area.stories.tsx
+++ b/src/new-components/text-area/text-area.stories.tsx
@@ -77,7 +77,7 @@ InteractivePropsStory.argTypes = {
         defaultValue: 'Tell us something about yourself. Don’t be shy.',
     },
     maxWidth: selectWithNone<BoxMaxWidth>(
-        ['xsmall', 'small', 'medium', 'large', 'xlarge'],
+        ['xsmall', 'small', 'medium', 'large', 'xlarge', 'full'],
         'small',
     ),
 }

--- a/src/new-components/text-area/text-area.tsx
+++ b/src/new-components/text-area/text-area.tsx
@@ -35,7 +35,7 @@ function TextArea({
             hidden={hidden}
             aria-describedby={ariaDescribedBy}
             className={[
-                styles.container,
+                styles.textAreaContainer,
                 tone === 'error' ? styles.error : null,
                 variant === 'bordered' ? styles.bordered : null,
             ]}


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

## Short description

Fixes an issue that @engfragui brought up before in the context of their use of Reactist TextArea in the adaptive cards components. The issue then was resolved differently, due to certain circumstances with adaptive cards. But the issue remained. Now it appears again, and it's blocking me from merging https://github.com/Doist/todoist-web/pull/4988.

So here's the fix.

### What's the problem and the fix

The text area is incompatible with horizontal resizing alongside us wanting it to stretch horizontally, which is what we want most of the time. This very text area in GitHub where I'm typing this has the same problem. So the fix was to add `width: 100%; resize: vertical;` to the `<textarea />` element of the `<TextArea />` component. Everything else in the diff is not about the fix, but a refactor of the CSS modules class name and adding a missing value in storybooks.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

A patch release is enough.
