### PR TITLE
feat: Enhance the `label` property in `CheckboxField` to be of the type `React.ReactNode`

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -32,6 +32,10 @@ module.exports = {
         return {
             ...config,
             resolve: resolveConfig,
+            // Storybook does not compile on WSL2 without this
+            node: {
+                fs: 'empty',
+            },
             module: {
                 ...config.module,
                 rules: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# Next
+
+-   [Feat] Enhance the `label` property in `CheckboxField` to be of type `React.ReactNode`
+
 # v15.1.0
 
 -   [Feat] Fields without label show no spacing above the field

--- a/src/new-components/checkbox-field/checkbox-field.stories.mdx
+++ b/src/new-components/checkbox-field/checkbox-field.stories.mdx
@@ -16,6 +16,17 @@ import { Inline } from '../inline'
     }}
 />
 
+export function Icon() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path
+                fill="currentColor"
+                d="M6 6.653a1 1 0 011.464-.886l10.246 5.37a1 1 0 01-.002 1.773L7.46 18.24a1 1 0 01-1.461-.887V13l6.96-.674a.328.328 0 000-.652L6 11V6.653z"
+            />
+        </svg>
+    )
+}
+
 # CheckboxField
 
 A checkbox field with a built-in label element.
@@ -48,6 +59,26 @@ export const Template = ({
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledby,
 }) => <CheckboxField disabled={disabled} indeterminate={indeterminate} label={label} />
+
+### ReactNode as Label
+
+A checkbox field with an icon and a string for the built-in label element.
+
+<Canvas>
+    <Story
+        parameters={{ docs: { source: { type: 'dynamic' } } }}
+        name="ReactNode as Label"
+        args={{
+            label: (
+                <>
+                    <Icon /> Label with icon
+                </>
+            ),
+        }}
+    >
+        {Template.bind({})}
+    </Story>
+</Canvas>
 
 ### Indeterminate Example
 

--- a/src/new-components/checkbox-field/checkbox-field.test.tsx
+++ b/src/new-components/checkbox-field/checkbox-field.test.tsx
@@ -54,12 +54,12 @@ describe('CheckboxField', () => {
         expect(screen.getByTestId('checkbox-field')).toHaveAccessibleName('Show unread badge')
     })
 
-    it('is labelled by its `String` label', () => {
+    it('is labelled by its label (string)', () => {
         render(<CheckboxField data-testid="checkbox-field" label="Show completed tasks" />)
         expect(screen.getByTestId('checkbox-field')).toHaveAccessibleName('Show completed tasks')
     })
 
-    it('is labelled by its `ReactNode` label', () => {
+    it('is labelled by its label (ReactNode)', () => {
         render(
             <CheckboxField
                 data-testid="checkbox-field"
@@ -67,7 +67,7 @@ describe('CheckboxField', () => {
             />,
         )
         expect(screen.getByTestId('checkbox-field')).toHaveAccessibleName('Show completed tasks')
-        expect(screen.getByTestId('react-node-label')).toHaveTextContent('Show completed tasks')
+        expect(screen.getByTestId('react-node-label')).toBeInTheDocument()
     })
 
     it('issues a warning if no label is given', () => {

--- a/src/new-components/checkbox-field/checkbox-field.test.tsx
+++ b/src/new-components/checkbox-field/checkbox-field.test.tsx
@@ -54,9 +54,20 @@ describe('CheckboxField', () => {
         expect(screen.getByTestId('checkbox-field')).toHaveAccessibleName('Show unread badge')
     })
 
-    it('is labelled by its label', () => {
+    it('is labelled by its `String` label', () => {
         render(<CheckboxField data-testid="checkbox-field" label="Show completed tasks" />)
         expect(screen.getByTestId('checkbox-field')).toHaveAccessibleName('Show completed tasks')
+    })
+
+    it('is labelled by its `ReactNode` label', () => {
+        render(
+            <CheckboxField
+                data-testid="checkbox-field"
+                label={<span data-testid="react-node-label">Show completed tasks</span>}
+            />,
+        )
+        expect(screen.getByTestId('checkbox-field')).toHaveAccessibleName('Show completed tasks')
+        expect(screen.getByTestId('react-node-label')).toHaveTextContent('Show completed tasks')
     })
 
     it('issues a warning if no label is given', () => {

--- a/src/new-components/checkbox-field/checkbox-field.tsx
+++ b/src/new-components/checkbox-field/checkbox-field.tsx
@@ -28,7 +28,7 @@ type CheckboxFieldProps = Omit<
     /** Defines whether or not the checkbox is disabled. */
     disabled?: boolean
     /** The label for the checkbox element. */
-    label?: string
+    label?: React.ReactNode
     /** Defines whether or not the checkbox can be of a `mixed` state. */
     indeterminate?: boolean
 }
@@ -104,7 +104,7 @@ const CheckboxField = React.forwardRef<HTMLInputElement, CheckboxFieldProps>(fun
                 indeterminate={indeterminate}
                 aria-hidden
             />
-            {label ? <Text>{label}</Text> : null}
+            {label ? typeof label === 'string' ? <Text>{label}</Text> : label : null}
         </Box>
     )
 })

--- a/src/new-components/checkbox-field/checkbox-field.tsx
+++ b/src/new-components/checkbox-field/checkbox-field.tsx
@@ -104,7 +104,7 @@ const CheckboxField = React.forwardRef<HTMLInputElement, CheckboxFieldProps>(fun
                 indeterminate={indeterminate}
                 aria-hidden
             />
-            {label ? typeof label === 'string' ? <Text>{label}</Text> : label : null}
+            {label ? <Text>{label}</Text> : null}
         </Box>
     )
 })


### PR DESCRIPTION
## Short description

This change enhances the `label` property in the `CheckboxField` component to be of the type `React.ReactNode`, allowing one to use a React component as label, instead of only a `string`.

This will permit that the checkbox, icon, and text label, in the items such as the ones below, are all clickable (thus toggling the check state on and off):

![image](https://user-images.githubusercontent.com/96476/187984374-8b234c72-b05c-460f-986c-8ed9a5249d3c.png)

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Minor: `v15.1.0`
