### PR TITLE
chore: Add support for Node v18 and npm v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
         "styles"
     ],
     "engines": {
-        "node": "^16.0.0",
-        "npm": "^8.3.0"
+        "node": "^16.0.0 || ^18.0.0",
+        "npm": "^8.3.0 || ^9.0.0"
     },
     "scripts": {
         "postinstall": "patch-package",


### PR DESCRIPTION
## Short description

Add support for Node v18 and npm v9 to the `engines` field on `package.json`