### PR TITLE
feat: Add support for Menu as context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# Next
+
+-   [Feat] Add support for `Menu` as a context menu
+
 # v17.0.1
 
 -   [Fix] Enforce minimum width for the checkbox icon in the `CheckboxField` element

--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -3,7 +3,7 @@ import type { MenuItemProps, SubMenuProps, MenuGroupProps } from './menu'
 export {
     Menu,
     MenuButton,
-    MenuContextMenuTrigger,
+    ContextMenuTrigger,
     MenuList,
     MenuItem,
     SubMenu,

--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -1,4 +1,12 @@
 import type { MenuItemProps, SubMenuProps, MenuGroupProps } from './menu'
 
-export { Menu, MenuButton, MenuList, MenuItem, SubMenu, MenuGroup } from './menu'
+export {
+    Menu,
+    MenuButton,
+    MenuContextMenuTrigger,
+    MenuList,
+    MenuItem,
+    SubMenu,
+    MenuGroup,
+} from './menu'
 export type { MenuItemProps, SubMenuProps, MenuGroupProps }

--- a/src/components/menu/menu.stories.tsx
+++ b/src/components/menu/menu.stories.tsx
@@ -5,7 +5,9 @@ import { Button } from '../../new-components/button'
 import { Inline } from '../../new-components/inline'
 import { Stack } from '../../new-components/stack'
 import { Columns, Column } from '../../new-components/columns'
-import { Menu, MenuButton, MenuList, MenuItem, MenuGroup, SubMenu } from '.'
+import { Menu, MenuButton, MenuContextMenuTrigger, MenuList, MenuItem, MenuGroup, SubMenu } from '.'
+import { ButtonLink } from '../../new-components/button-link'
+import { Text } from '../../new-components/text'
 
 function MenuIndicator() {
     return (
@@ -227,6 +229,42 @@ export function OverflowMenuExample() {
                 {items.map((item, index) => (
                     <Item key={index} {...item} />
                 ))}
+            </Stack>
+        </section>
+    )
+}
+
+export function ContextMenuExample() {
+    return (
+        <section className="story">
+            <Stack space="small">
+                <Text>Right click on the Settings button, or click on the more button:</Text>
+                <Menu>
+                    <Inline space="xsmall">
+                        <MenuContextMenuTrigger
+                            as={ButtonLink}
+                            variant="primary"
+                            width="xsmall"
+                            href="https://todoist.com/app/settings"
+                            openInNewTab
+                        >
+                            Settings
+                        </MenuContextMenuTrigger>
+
+                        <MenuButton
+                            as={Button}
+                            variant="secondary"
+                            icon={<MenuIndicator />}
+                            aria-label="More"
+                        />
+                    </Inline>
+
+                    <MenuList aria-label="Settings menu">
+                        <MenuItem onSelect={action('Account')}>Account</MenuItem>
+                        <MenuItem onSelect={action('General')}>General</MenuItem>
+                        <MenuItem onSelect={action('Advanced')}>Advanced</MenuItem>
+                    </MenuList>
+                </Menu>
             </Stack>
         </section>
     )

--- a/src/components/menu/menu.stories.tsx
+++ b/src/components/menu/menu.stories.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../new-components/button'
 import { Inline } from '../../new-components/inline'
 import { Stack } from '../../new-components/stack'
 import { Columns, Column } from '../../new-components/columns'
-import { Menu, MenuButton, MenuContextMenuTrigger, MenuList, MenuItem, MenuGroup, SubMenu } from '.'
+import { ContextMenuTrigger, Menu, MenuButton, MenuList, MenuItem, MenuGroup, SubMenu } from '.'
 import { ButtonLink } from '../../new-components/button-link'
 import { Text } from '../../new-components/text'
 
@@ -241,7 +241,7 @@ export function ContextMenuExample() {
                 <Text>Right click on the Settings button, or click on the more button:</Text>
                 <Menu>
                     <Inline space="xsmall">
-                        <MenuContextMenuTrigger
+                        <ContextMenuTrigger
                             as={ButtonLink}
                             variant="primary"
                             width="xsmall"
@@ -249,7 +249,7 @@ export function ContextMenuExample() {
                             openInNewTab
                         >
                             Settings
-                        </MenuContextMenuTrigger>
+                        </ContextMenuTrigger>
 
                         <MenuButton
                             as={Button}

--- a/src/components/menu/menu.test.tsx
+++ b/src/components/menu/menu.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Menu, MenuButton, MenuList, MenuItem } from './menu'
+import { Menu, MenuButton, MenuList, MenuItem, MenuContextMenuTrigger } from './menu'
 import { axe } from 'jest-axe'
 import { flushPromises } from '../../new-components/test-helpers'
 import { act } from 'react-dom/test-utils'
@@ -189,6 +189,27 @@ describe('Menu', () => {
         // Check that it closed the menu anyway
         expect(screen.queryByRole('menu')).not.toBeInTheDocument()
         expect(screen.queryByRole('menuitem')).not.toBeInTheDocument()
+    })
+
+    it('renders a context menu when used with a MenuContextMenuTrigger', () => {
+        render(
+            <Menu>
+                <MenuContextMenuTrigger>Options menu</MenuContextMenuTrigger>
+                <MenuList aria-label="Some options">
+                    <MenuItem>First option</MenuItem>
+                </MenuList>
+            </Menu>,
+        )
+
+        expect(screen.queryByText('First option')).not.toBeInTheDocument()
+
+        userEvent.click(screen.getByText('Options menu'), { button: 2 })
+
+        expect(screen.getByRole('menu')).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: 'First option' })).toBeInTheDocument()
+
+        // Close menu to avoid act warning after test ends
+        userEvent.keyboard('{Escape}')
     })
 
     describe('a11y', () => {

--- a/src/components/menu/menu.test.tsx
+++ b/src/components/menu/menu.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Menu, MenuButton, MenuList, MenuItem, MenuContextMenuTrigger } from './menu'
+import { ContextMenuTrigger, Menu, MenuButton, MenuList, MenuItem } from './menu'
 import { axe } from 'jest-axe'
 import { flushPromises } from '../../new-components/test-helpers'
 import { act } from 'react-dom/test-utils'
@@ -191,10 +191,10 @@ describe('Menu', () => {
         expect(screen.queryByRole('menuitem')).not.toBeInTheDocument()
     })
 
-    it('renders a context menu when used with a MenuContextMenuTrigger', () => {
+    it('renders a context menu when used with a ContextMenuTrigger', () => {
         render(
             <Menu>
-                <MenuContextMenuTrigger>Options menu</MenuContextMenuTrigger>
+                <ContextMenuTrigger>Options menu</ContextMenuTrigger>
                 <MenuList aria-label="Some options">
                     <MenuItem>First option</MenuItem>
                 </MenuList>

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -123,9 +123,9 @@ const MenuButton = polymorphicComponent<'button', MenuButtonProps>(function Menu
 })
 
 //
-// MenuContextMenuTrigger
+// ContextMenuTrigger
 //
-const MenuContextMenuTrigger = polymorphicComponent<'div', unknown>(function MenuContextMenuTrigger(
+const ContextMenuTrigger = polymorphicComponent<'div', unknown>(function ContextMenuTrigger(
     { as: component = 'div', ...props },
     ref,
 ) {
@@ -366,5 +366,5 @@ const MenuGroup = polymorphicComponent<'div', MenuGroupProps>(function MenuGroup
     )
 })
 
-export { Menu, MenuButton, MenuContextMenuTrigger, MenuList, MenuItem, SubMenu, MenuGroup }
+export { ContextMenuTrigger, Menu, MenuButton, MenuList, MenuItem, SubMenu, MenuGroup }
 export type { MenuButtonProps, MenuListProps, MenuItemProps, SubMenuProps, MenuGroupProps }

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -25,6 +25,7 @@ type NativeProps<E extends HTMLElement> = React.DetailedHTMLProps<React.HTMLAttr
 type MenuContextState = {
     state: Ariakit.MenuState
     handleItemSelect: (value: string | null | undefined) => void
+    handleAnchorRectChange: (value: { x: number; y: number } | null) => void
 }
 
 const MenuContext = React.createContext<MenuContextState>(
@@ -63,7 +64,20 @@ type MenuProps = Omit<Ariakit.MenuStateProps, 'visible'> & {
  * attribute to style the menu list, it is applied a `menubar` role instead in Safari.
  */
 function Menu({ children, onItemSelect, ...props }: MenuProps) {
-    const state = Ariakit.useMenuState({ focusLoop: true, gutter: 8, shift: 4, ...props })
+    const [anchorRect, handleAnchorRectChange] = React.useState<{ x: number; y: number } | null>(
+        null,
+    )
+    const getAnchorRect = React.useMemo(() => {
+        return anchorRect ? () => anchorRect : undefined
+    }, [anchorRect])
+
+    const state = Ariakit.useMenuState({
+        focusLoop: true,
+        gutter: 8,
+        shift: 4,
+        getAnchorRect,
+        ...props,
+    })
 
     const handleItemSelect = React.useCallback(
         function handleItemSelect(value: string | null | undefined) {
@@ -76,6 +90,7 @@ function Menu({ children, onItemSelect, ...props }: MenuProps) {
         () => ({
             state,
             handleItemSelect,
+            handleAnchorRectChange,
         }),
         [state, handleItemSelect],
     )
@@ -105,6 +120,26 @@ const MenuButton = polymorphicComponent<'button', MenuButtonProps>(function Menu
             className={classNames('reactist_menubutton', exceptionallySetClassName)}
         />
     )
+})
+
+//
+// MenuContextMenuTrigger
+//
+const MenuContextMenuTrigger = polymorphicComponent<'div', unknown>(function MenuContextMenuTrigger(
+    { as: component = 'div', ...props },
+    ref,
+) {
+    const { handleAnchorRectChange, state } = React.useContext(MenuContext)
+    const handleContextMenu = React.useCallback(
+        (event: React.MouseEvent) => {
+            event.preventDefault()
+            handleAnchorRectChange({ x: event.clientX, y: event.clientY })
+            state.show()
+        },
+        [handleAnchorRectChange, state],
+    )
+
+    return React.createElement(component, { ...props, onContextMenu: handleContextMenu, ref })
 })
 
 //
@@ -331,5 +366,5 @@ const MenuGroup = polymorphicComponent<'div', MenuGroupProps>(function MenuGroup
     )
 })
 
-export { Menu, MenuButton, MenuList, MenuItem, SubMenu, MenuGroup }
+export { Menu, MenuButton, MenuContextMenuTrigger, MenuList, MenuItem, SubMenu, MenuGroup }
 export type { MenuButtonProps, MenuListProps, MenuItemProps, SubMenuProps, MenuGroupProps }


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Closes https://github.com/Doist/Issues/issues/7077

## Short description

This adds a `<MenuContextMenuTrigger>` component to allow an element to open a menu as a context menu.

<img width="613" alt="image" src="https://user-images.githubusercontent.com/8531248/202071843-c7c48d55-a852-4672-9468-da69a7cf7c94.png">

Reference: https://ariakit.org/examples/menu-context-menu

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Test plan

- [x] Start storybook and go to the Menu story. In the context menu example, you should be able to trigger the menu using the right mouse button, or ctrl + click on a Mac, using the primary button. You can also trigger the same menu by clicking on the secondary button.

## Versioning

Minor
