### PR TITLE
fix: Allow submenus to be rendered and support keyboard navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 # Next
 
 -   [Feat] Add support for `Menu` as a context menu
+-   [Fix] Allow `SubMenu`s to be rendered and support keyboard navigation
 
 # v17.0.1
 

--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -1,5 +1,3 @@
-import type { MenuItemProps, SubMenuProps, MenuGroupProps } from './menu'
-
 export {
     Menu,
     MenuButton,
@@ -9,4 +7,4 @@ export {
     SubMenu,
     MenuGroup,
 } from './menu'
-export type { MenuItemProps, SubMenuProps, MenuGroupProps }
+export type { MenuItemProps, MenuGroupProps } from './menu'

--- a/src/components/menu/menu.test.tsx
+++ b/src/components/menu/menu.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { ContextMenuTrigger, Menu, MenuButton, MenuList, MenuItem } from './menu'
+import { ContextMenuTrigger, Menu, MenuButton, MenuList, MenuItem, SubMenu } from './menu'
 import { axe } from 'jest-axe'
 import { flushPromises } from '../../new-components/test-helpers'
 import { act } from 'react-dom/test-utils'
@@ -210,6 +210,36 @@ describe('Menu', () => {
 
         // Close menu to avoid act warning after test ends
         userEvent.keyboard('{Escape}')
+    })
+
+    it('renders a submenu when a nested menu button is clicked', () => {
+        const handleSave = jest.fn()
+        render(
+            <Menu>
+                <MenuButton>Options menu</MenuButton>
+                <MenuList aria-label="Some options">
+                    <MenuItem>New</MenuItem>
+                    <SubMenu>
+                        <MenuButton>More options</MenuButton>
+                        <MenuList>
+                            <MenuItem onSelect={handleSave}>Save</MenuItem>
+                            <MenuItem>Discard</MenuItem>
+                            <MenuItem>Exit</MenuItem>
+                        </MenuList>
+                    </SubMenu>
+                </MenuList>
+            </Menu>,
+        )
+
+        userEvent.click(screen.getByRole('button', { name: 'Options menu' }))
+        userEvent.click(screen.getByRole('menuitem', { name: 'More options' }))
+
+        expect(screen.getByRole('menuitem', { name: 'Save' })).toBeVisible()
+
+        userEvent.click(screen.getByRole('menuitem', { name: 'Save' }))
+
+        expect(handleSave).toHaveBeenCalled()
+        expect(screen.queryByText('More options')).not.toBeInTheDocument()
     })
 
     describe('a11y', () => {

--- a/src/components/menu/menu.test.tsx
+++ b/src/components/menu/menu.test.tsx
@@ -242,6 +242,41 @@ describe('Menu', () => {
         expect(screen.queryByText('More options')).not.toBeInTheDocument()
     })
 
+    it('focuses on the submenu when the right arrow key is pressed', () => {
+        const handleSave = jest.fn()
+        render(
+            <Menu>
+                <MenuButton>Options menu</MenuButton>
+                <MenuList aria-label="Some options">
+                    <MenuItem>New</MenuItem>
+                    <SubMenu>
+                        <MenuButton>More options</MenuButton>
+                        <MenuList>
+                            <MenuItem onSelect={handleSave}>Save</MenuItem>
+                            <MenuItem>Discard</MenuItem>
+                            <MenuItem>Exit</MenuItem>
+                        </MenuList>
+                    </SubMenu>
+                </MenuList>
+            </Menu>,
+        )
+
+        userEvent.click(screen.getByRole('button', { name: 'Options menu' }))
+        userEvent.keyboard('{ArrowDown}')
+        userEvent.keyboard('{ArrowDown}')
+
+        expect(screen.getByRole('menuitem', { name: 'More options' })).toHaveFocus()
+
+        userEvent.keyboard('{ArrowRight}')
+
+        expect(screen.getByRole('menuitem', { name: 'Save' })).toHaveFocus()
+
+        userEvent.keyboard('{Enter}')
+
+        expect(handleSave).toHaveBeenCalled()
+        expect(screen.queryByText('More options')).not.toBeInTheDocument()
+    })
+
     describe('a11y', () => {
         it('renders with no a11y violations', async () => {
             const { container } = render(

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import classNames from 'classnames'
-import FocusLock from 'react-focus-lock'
 
 import { polymorphicComponent } from '../../utils/polymorphism'
 
@@ -159,14 +158,12 @@ const MenuList = polymorphicComponent<'div', MenuListProps>(function MenuList(
 
     return state.visible ? (
         <Portal preserveTabOrder>
-            <FocusLock returnFocus>
-                <Ariakit.Menu
-                    {...props}
-                    state={state}
-                    ref={ref}
-                    className={classNames('reactist_menulist', exceptionallySetClassName)}
-                />
-            </FocusLock>
+            <Ariakit.Menu
+                {...props}
+                state={state}
+                ref={ref}
+                className={classNames('reactist_menulist', exceptionallySetClassName)}
+            />
         </Portal>
     ) : null
 })

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -17,7 +17,6 @@ import * as Ariakit from 'ariakit/menu'
 import { Portal } from 'ariakit/portal'
 
 import './menu.less'
-import { useMenuItem } from 'ariakit/menu'
 
 type NativeProps<E extends HTMLElement> = React.DetailedHTMLProps<React.HTMLAttributes<E>, E>
 
@@ -297,7 +296,7 @@ type SubMenuProps = Pick<MenuProps, 'children' | 'onItemSelect'>
  * The `MenuButton` will become a menu item in the current menu items list, and it will lead to
  * opening a sub-menu with the menu items list below it.
  */
-const SubMenu = React.forwardRef<HTMLButtonElement, SubMenuProps>(function SubMenu(
+const SubMenu = React.forwardRef<HTMLDivElement, SubMenuProps>(function SubMenu(
     { children, onItemSelect },
     ref,
 ) {
@@ -315,15 +314,20 @@ const SubMenu = React.forwardRef<HTMLButtonElement, SubMenuProps>(function SubMe
 
     const [button, list] = React.Children.toArray(children)
 
-    const menuProps = useMenuItem({ state })
+    // Ariakit needs to be able to pass props to the MenuButton
+    // and combine it with the MenuItem component
+    const renderMenuButton = React.useCallback(
+        function renderMenuButton(props: MenuButtonProps) {
+            return React.cloneElement(button as React.ReactElement, props)
+        },
+        [button],
+    )
 
     return (
         <Menu onItemSelect={handleSubItemSelect}>
-            {React.cloneElement(button as React.ReactElement, {
-                ...menuProps,
-                className: classNames(menuProps.className, 'reactist_submenu_button'),
-                ref,
-            })}
+            <Ariakit.MenuItem as="div" state={state} ref={ref} hideOnClick={false}>
+                {renderMenuButton}
+            </Ariakit.MenuItem>
             {list}
         </Menu>
     )
@@ -364,4 +368,4 @@ const MenuGroup = polymorphicComponent<'div', MenuGroupProps>(function MenuGroup
 })
 
 export { ContextMenuTrigger, Menu, MenuButton, MenuList, MenuItem, SubMenu, MenuGroup }
-export type { MenuButtonProps, MenuListProps, MenuItemProps, SubMenuProps, MenuGroupProps }
+export type { MenuButtonProps, MenuListProps, MenuItemProps, MenuGroupProps }


### PR DESCRIPTION
## Short description

This fixes submenus which were previously broken. The main cause is the `<FocusLock>` on the menu, as it causes the menu to be closed as soon as the submenu's menu button is hovered over. It was originally added with https://github.com/Doist/reactist/pull/686 to ensure menus can be used properly when rendered within a modal, but I couldn't see what's broken when testing it with the focus lock removed now.

<img width="405" alt="image" src="https://user-images.githubusercontent.com/8531248/202354944-2264d526-14c8-45d3-9837-f07ccf414626.png">

Ariakit example: https://ariakit.org/examples/menu-nested

## Test plan

- [x] In the [Modal with standard actions footer](http://localhost:6006/?path=/docs/design-system-modal--modal-with-standard-actions-footer) story, ensure you can open and traverse through the menu in the modal
- [x] In the [Simple menu example](http://localhost:6006/?path=/story/components-menu--simple-menu-example) story, test that you can open the submenu and select its options. Also, test that you can traverse to the submenu using arrow keys.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Patch
