### PR TITLE
ci: Remove deprecated set-output usage

### DIFF
--- a/.github/workflows/coverage-reporting.yml
+++ b/.github/workflows/coverage-reporting.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Read Node.js version from '.nvmrc'
               id: nvmrc
               run: |
-                  echo "::set-output name=NODE_VERSION::$(cat .nvmrc)"
+                  echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
             - uses: actions/setup-node@v1
               with:
                   node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Read Node.js version from '.nvmrc'
               id: nvmrc
               run: |
-                  echo "::set-output name=NODE_VERSION::$(cat .nvmrc)"
+                  echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
             - uses: actions/setup-node@v1
               with:
                   node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Read Node.js version from '.nvmrc'
               id: nvmrc
               run: |
-                  echo "::set-output name=NODE_VERSION::$(cat .nvmrc)"
+                  echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
             - uses: actions/setup-node@v1
               with:
                   node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}


### PR DESCRIPTION
## Overview

`set-output` is being deprecated and will cause failures June 2023. Updated to the recommended approach.

## Reference

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.com/Doist/infrastructure-backlog/issues/481

