### PR TITLE
feat: Allow defining a custom class on the Modal's overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# Next
+
+-   [Feat] Add support for providing a class to a `Modal` overlay
+
 # v17.1.0
 
 -   [Feat] Add support for `Menu` as a context menu

--- a/src/new-components/modal/modal.test.tsx
+++ b/src/new-components/modal/modal.test.tsx
@@ -48,6 +48,17 @@ describe('Modal', () => {
         expect(modal).not.toHaveClass('wrong')
     })
 
+    it('allows to exceptionally set a class on the overlay', () => {
+        render(
+            <Modal isOpen exceptionallySetOverlayClassName="customClass">
+                Hello
+            </Modal>,
+        )
+
+        const overlay = screen.getByTestId('modal-overlay')
+        expect(overlay).toHaveClass('customClass')
+    })
+
     it('renders its children as its content', () => {
         render(
             <Modal isOpen aria-label="modal">

--- a/src/new-components/modal/modal.tsx
+++ b/src/new-components/modal/modal.tsx
@@ -80,9 +80,13 @@ export type ModalProps = DivProps & {
      */
     autoFocus?: boolean
     /**
-     * A escape hatch in case you need to provide a custom class name to the container element.
+     * An escape hatch in case you need to provide a custom class name to the container element.
      */
     exceptionallySetClassName?: string
+    /**
+     * An escape hatch in case you need to provide a custom class name to the overlay element.
+     */
+    exceptionallySetOverlayClassName?: string
     /** Defines a string value that labels the current modal for assistive technologies. */
     'aria-label'?: string
     /** Identifies the element (or elements) that labels the current modal for assistive technologies. */
@@ -108,6 +112,7 @@ export function Modal({
     height = 'fitContent',
     width = 'medium',
     exceptionallySetClassName,
+    exceptionallySetOverlayClassName,
     autoFocus = true,
     children,
     ...props
@@ -169,7 +174,12 @@ export function Modal({
             <Box
                 data-testid="modal-overlay"
                 data-overlay
-                className={classNames(styles.overlay, styles[height], styles[width])}
+                className={classNames(
+                    styles.overlay,
+                    styles[height],
+                    styles[width],
+                    exceptionallySetOverlayClassName,
+                )}
                 onClick={handleBackdropClick}
                 ref={backdropRef}
             >


### PR DESCRIPTION
## Short description

We need a way for consumers to define custom classes on the new Modal's overlay. This is needed to support custom styling for the overlay (eg. both the command menu, and quick add modal in Todoist), and for adding custom animations.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Patch
