### PR TITLE
feat: Add support for preventing Modal from hiding when clicking overlay

### DIFF
--- a/src/new-components/modal/modal-stories-components.tsx
+++ b/src/new-components/modal/modal-stories-components.tsx
@@ -17,6 +17,7 @@ function Link({ children, ...props }: JSX.IntrinsicElements['a']) {
 
 type ModalStoryState = Pick<ModalProps, 'width' | 'height'> & {
     button: 'true' | 'false' | 'custom'
+    hideOnOverlayClick: boolean
     withScrollableContent: boolean
 }
 
@@ -24,6 +25,7 @@ const defaultInitialState: ModalStoryState = {
     width: 'medium',
     height: 'expand',
     button: 'true',
+    hideOnOverlayClick: true,
     withScrollableContent: false,
 }
 
@@ -99,9 +101,14 @@ function ScrollableContent({ label = 'Item', count = 20 }: { label?: string; cou
 }
 
 function ModalOptionsForm({ title }: { title?: React.ReactNode }) {
-    const { button, width, height, withScrollableContent, onChange } = React.useContext(
-        ModalStoryContext,
-    )
+    const {
+        button,
+        width,
+        height,
+        hideOnOverlayClick,
+        withScrollableContent,
+        onChange,
+    } = React.useContext(ModalStoryContext)
     return (
         <Stack space="large">
             {title}
@@ -124,6 +131,13 @@ function ModalOptionsForm({ title }: { title?: React.ReactNode }) {
                 <option value="fitContent">fitContent</option>
                 <option value="expand">expand</option>
             </SelectField>
+
+            <SwitchField
+                name="hideOnOverlayClick"
+                label="Hide on overlay click"
+                checked={hideOnOverlayClick}
+                onChange={onChange}
+            />
 
             <SwitchField
                 name="withScrollableContent"
@@ -174,13 +188,16 @@ ModalButton.displayName = 'Button'
 type WithOptionals<Props, Keys extends keyof Props> = Omit<Props, Keys> & Partial<Pick<Props, Keys>>
 
 function Modal(props: WithOptionals<ModalProps, 'isOpen' | 'onDismiss' | 'width' | 'height'>) {
-    const { isOpen, closeModal, width, height } = React.useContext(ModalStoryContext)
+    const { isOpen, closeModal, width, height, hideOnOverlayClick } = React.useContext(
+        ModalStoryContext,
+    )
     return (
         <ModalComponents.Modal
             isOpen={isOpen}
             onDismiss={closeModal}
             width={width}
             height={height}
+            hideOnOverlayClick={hideOnOverlayClick}
             {...props}
         />
     )

--- a/src/new-components/modal/modal-stories-components.tsx
+++ b/src/new-components/modal/modal-stories-components.tsx
@@ -17,7 +17,7 @@ function Link({ children, ...props }: JSX.IntrinsicElements['a']) {
 
 type ModalStoryState = Pick<ModalProps, 'width' | 'height'> & {
     button: 'true' | 'false' | 'custom'
-    hideOnOverlayClick: boolean
+    hideOn: 'escapeAndOverlay' | 'escape' | 'overlay'
     withScrollableContent: boolean
 }
 
@@ -25,7 +25,7 @@ const defaultInitialState: ModalStoryState = {
     width: 'medium',
     height: 'expand',
     button: 'true',
-    hideOnOverlayClick: true,
+    hideOn: 'escapeAndOverlay',
     withScrollableContent: false,
 }
 
@@ -101,14 +101,9 @@ function ScrollableContent({ label = 'Item', count = 20 }: { label?: string; cou
 }
 
 function ModalOptionsForm({ title }: { title?: React.ReactNode }) {
-    const {
-        button,
-        width,
-        height,
-        hideOnOverlayClick,
-        withScrollableContent,
-        onChange,
-    } = React.useContext(ModalStoryContext)
+    const { button, width, height, hideOn, withScrollableContent, onChange } = React.useContext(
+        ModalStoryContext,
+    )
     return (
         <Stack space="large">
             {title}
@@ -132,12 +127,11 @@ function ModalOptionsForm({ title }: { title?: React.ReactNode }) {
                 <option value="expand">expand</option>
             </SelectField>
 
-            <SwitchField
-                name="hideOnOverlayClick"
-                label="Hide on overlay click"
-                checked={hideOnOverlayClick}
-                onChange={onChange}
-            />
+            <SelectField label="Hide on" name="hideOn" value={hideOn} onChange={onChange}>
+                <option value="escapeAndOverlay">escape and overlay click</option>
+                <option value="overlay">overlay click</option>
+                <option value="escape">escape</option>
+            </SelectField>
 
             <SwitchField
                 name="withScrollableContent"
@@ -188,16 +182,15 @@ ModalButton.displayName = 'Button'
 type WithOptionals<Props, Keys extends keyof Props> = Omit<Props, Keys> & Partial<Pick<Props, Keys>>
 
 function Modal(props: WithOptionals<ModalProps, 'isOpen' | 'onDismiss' | 'width' | 'height'>) {
-    const { isOpen, closeModal, width, height, hideOnOverlayClick } = React.useContext(
-        ModalStoryContext,
-    )
+    const { isOpen, closeModal, width, height, hideOn } = React.useContext(ModalStoryContext)
     return (
         <ModalComponents.Modal
             isOpen={isOpen}
             onDismiss={closeModal}
             width={width}
             height={height}
-            hideOnOverlayClick={hideOnOverlayClick}
+            hideOnEscape={hideOn === 'escapeAndOverlay' || hideOn === 'escape'}
+            hideOnInteractOutside={hideOn === 'escapeAndOverlay' || hideOn === 'overlay'}
             {...props}
         />
     )

--- a/src/new-components/modal/modal.test.tsx
+++ b/src/new-components/modal/modal.test.tsx
@@ -476,7 +476,7 @@ describe('a11y', () => {
         expect(onDismiss).toHaveBeenCalledTimes(1)
     })
 
-    it("doesn't call the modal's onDismiss callback when 'Esc' is pressed and hideOnEscape='false'", () => {
+    it("doesn't call the modal's onDismiss callback when 'Esc' is pressed and hideOnEscape is false", () => {
         const onDismiss = jest.fn()
         render(
             <Modal isOpen onDismiss={onDismiss} aria-label="modal" hideOnEscape={false}>

--- a/src/new-components/modal/modal.test.tsx
+++ b/src/new-components/modal/modal.test.tsx
@@ -100,10 +100,10 @@ describe('Modal', () => {
         expect(screen.queryByRole('dialog', { name: 'modal' })).not.toBeInTheDocument()
     })
 
-    it('is not dismissed when clicking in the overlay if hideOnOverlayClick="false"', () => {
+    it('is not dismissed when clicking in the overlay if hideOnInteractOutside="false"', () => {
         const onDismiss = jest.fn()
         render(
-            <Modal isOpen hideOnOverlayClick={false} onDismiss={onDismiss}>
+            <Modal isOpen hideOnInteractOutside={false} onDismiss={onDismiss}>
                 <button type="button">Close me</button>
             </Modal>,
         )
@@ -474,5 +474,19 @@ describe('a11y', () => {
         expect(onDismiss).not.toHaveBeenCalled()
         userEvent.type(modal, '{esc}')
         expect(onDismiss).toHaveBeenCalledTimes(1)
+    })
+
+    it("doesn't call the modal's onDismiss callback when 'Esc' is pressed and hideOnEscape='false'", () => {
+        const onDismiss = jest.fn()
+        render(
+            <Modal isOpen onDismiss={onDismiss} aria-label="modal" hideOnEscape={false}>
+                <ModalHeader>Hello</ModalHeader>
+            </Modal>,
+        )
+        const modal = screen.getByRole('dialog', { name: 'modal' })
+
+        expect(onDismiss).not.toHaveBeenCalled()
+        userEvent.type(modal, '{esc}')
+        expect(onDismiss).not.toHaveBeenCalled()
     })
 })

--- a/src/new-components/modal/modal.test.tsx
+++ b/src/new-components/modal/modal.test.tsx
@@ -100,6 +100,17 @@ describe('Modal', () => {
         expect(screen.queryByRole('dialog', { name: 'modal' })).not.toBeInTheDocument()
     })
 
+    it('is not dismissed when clicking in the overlay if hideOnOverlayClick="false"', () => {
+        const onDismiss = jest.fn()
+        render(
+            <Modal isOpen hideOnOverlayClick={false} onDismiss={onDismiss}>
+                <button type="button">Close me</button>
+            </Modal>,
+        )
+        userEvent.click(screen.getByTestId('modal-overlay'))
+        expect(onDismiss).not.toHaveBeenCalled()
+    })
+
     it('focuses on the first focusable element', () => {
         render(
             <Modal isOpen>

--- a/src/new-components/modal/modal.test.tsx
+++ b/src/new-components/modal/modal.test.tsx
@@ -100,7 +100,7 @@ describe('Modal', () => {
         expect(screen.queryByRole('dialog', { name: 'modal' })).not.toBeInTheDocument()
     })
 
-    it('is not dismissed when clicking in the overlay if hideOnInteractOutside="false"', () => {
+    it('is not dismissed when clicking in the overlay if hideOnInteractOutside is false', () => {
         const onDismiss = jest.fn()
         render(
             <Modal isOpen hideOnInteractOutside={false} onDismiss={onDismiss}>

--- a/src/new-components/modal/modal.tsx
+++ b/src/new-components/modal/modal.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import FocusLock from 'react-focus-lock'
 import { hideOthers } from 'aria-hidden'
 
-import { Dialog, useDialogState } from 'ariakit/dialog'
+import { Dialog, DialogOptions, useDialogState } from 'ariakit/dialog'
 import { Portal } from 'ariakit/portal'
 
 import { CloseIcon } from '../icons/close-icon'
@@ -80,9 +80,13 @@ export type ModalProps = DivProps & {
      */
     autoFocus?: boolean
     /**
+     * Controls if the modal is dismissed when pressing "Escape".
+     */
+    hideOnEscape?: DialogOptions['hideOnEscape']
+    /**
      * Controls if the modal is dismissed when clicking outside the modal body, on the overlay.
      */
-    hideOnOverlayClick?: boolean
+    hideOnInteractOutside?: DialogOptions['hideOnInteractOutside']
     /**
      * An escape hatch in case you need to provide a custom class name to the container element.
      */
@@ -118,7 +122,8 @@ export function Modal({
     exceptionallySetClassName,
     exceptionallySetOverlayClassName,
     autoFocus = true,
-    hideOnOverlayClick = true,
+    hideOnEscape = true,
+    hideOnInteractOutside = true,
     children,
     ...props
 }: ModalProps) {
@@ -185,7 +190,7 @@ export function Modal({
                     styles[width],
                     exceptionallySetOverlayClassName,
                 )}
-                onClick={hideOnOverlayClick ? handleBackdropClick : undefined}
+                onClick={hideOnInteractOutside ? handleBackdropClick : undefined}
                 ref={backdropRef}
             >
                 <FocusLock autoFocus={autoFocus} whiteList={isNotInternalFrame} returnFocus={true}>
@@ -194,7 +199,7 @@ export function Modal({
                         ref={dialogRef}
                         as={Box}
                         state={state}
-                        hideOnEscape
+                        hideOnEscape={hideOnEscape}
                         preventBodyScroll
                         borderRadius="full"
                         background="default"

--- a/src/new-components/modal/modal.tsx
+++ b/src/new-components/modal/modal.tsx
@@ -80,6 +80,10 @@ export type ModalProps = DivProps & {
      */
     autoFocus?: boolean
     /**
+     * Controls if the modal is dismissed when clicking outside the modal body, on the overlay.
+     */
+    hideOnOverlayClick?: boolean
+    /**
      * An escape hatch in case you need to provide a custom class name to the container element.
      */
     exceptionallySetClassName?: string
@@ -114,6 +118,7 @@ export function Modal({
     exceptionallySetClassName,
     exceptionallySetOverlayClassName,
     autoFocus = true,
+    hideOnOverlayClick = true,
     children,
     ...props
 }: ModalProps) {
@@ -180,7 +185,7 @@ export function Modal({
                     styles[width],
                     exceptionallySetOverlayClassName,
                 )}
-                onClick={handleBackdropClick}
+                onClick={hideOnOverlayClick ? handleBackdropClick : undefined}
                 ref={backdropRef}
             >
                 <FocusLock autoFocus={autoFocus} whiteList={isNotInternalFrame} returnFocus={true}>


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

## Short description

Certain Todoist modals are not dismissable if their overlay is clicked. We're adding here a new prop, `hideOnOverlayClick`, to control that behavior.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->

Minor