### PR TITLE
feat: feat: Add `variant` support to `SelectField`

### DIFF
--- a/src/new-components/select-field/select-field.module.css
+++ b/src/new-components/select-field/select-field.module.css
@@ -3,6 +3,13 @@
     position: relative;
 }
 
+.selectWrapper.bordered select {
+    padding: 0;
+    height: 24px;
+    border-color: transparent;
+    outline: none;
+}
+
 .selectWrapper svg {
     position: absolute;
     right: 10px;
@@ -42,14 +49,14 @@
     margin: 0;
 }
 
-.selectWrapper.error select {
+.selectWrapper:not(.bordered).error select {
     border-color: var(--reactist-alert-tone-critical-border) !important;
 }
 
-.selectWrapper option {
+.selectWrapper:not(.bordered) option {
     background-color: var(--reactist-bg-aside);
 }
 
-.selectWrapper select:focus {
+.selectWrapper:not(.bordered) select:focus {
     border-color: var(--reactist-divider-primary);
 }

--- a/src/new-components/select-field/select-field.stories.tsx
+++ b/src/new-components/select-field/select-field.stories.tsx
@@ -80,6 +80,11 @@ InteractivePropsStory.argTypes = {
         control: { type: 'inline-radio' },
         defaultValue: 'neutral',
     },
+    variant: {
+        options: ['default', 'bordered'],
+        control: { type: 'inline-radio' },
+        defaultValue: 'default',
+    },
     maxWidth: selectWithNone<BoxMaxWidth>(
         ['xsmall', 'small', 'medium', 'large', 'xlarge'],
         'small',

--- a/src/new-components/select-field/select-field.test.tsx
+++ b/src/new-components/select-field/select-field.test.tsx
@@ -246,6 +246,12 @@ describe('SelectField', () => {
         expect(screen.getByTestId('container')).toHaveAttribute('data-theme', 'light')
     })
 
+    it('supports providing a variant', () => {
+        render(<SelectField label="Email" type="email" variant="bordered" />)
+
+        expect(screen.getByTestId('select-wrapper')).toHaveClass('bordered')
+    })
+
     describe('a11y', () => {
         it('renders with no a11y violations', async () => {
             const { container } = render(

--- a/src/new-components/select-field/select-field.tsx
+++ b/src/new-components/select-field/select-field.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react'
-import { BaseField, FieldComponentProps } from '../base-field'
+import { BaseField, BaseFieldVariantProps, FieldComponentProps } from '../base-field'
 import { Box } from '../box'
 import styles from './select-field.module.css'
 
-type SelectFieldProps = FieldComponentProps<HTMLSelectElement>
+type SelectFieldProps = FieldComponentProps<HTMLSelectElement> & BaseFieldVariantProps
 
 const SelectField = React.forwardRef<HTMLSelectElement, SelectFieldProps>(function SelectField(
     {
+        variant = 'default',
         id,
         label,
         secondaryLabel,
@@ -24,6 +25,7 @@ const SelectField = React.forwardRef<HTMLSelectElement, SelectFieldProps>(functi
 ) {
     return (
         <BaseField
+            variant={variant}
             id={id}
             label={label}
             secondaryLabel={secondaryLabel}
@@ -36,7 +38,13 @@ const SelectField = React.forwardRef<HTMLSelectElement, SelectFieldProps>(functi
             aria-describedby={ariaDescribedBy}
         >
             {(extraProps) => (
-                <Box className={[styles.selectWrapper, tone === 'error' ? styles.error : null]}>
+                <Box
+                    className={[
+                        styles.selectWrapper,
+                        tone === 'error' ? styles.error : null,
+                        variant === 'bordered' ? styles.bordered : null,
+                    ]}
+                >
                     <select {...props} {...extraProps} ref={ref}>
                         {children}
                     </select>

--- a/src/new-components/select-field/select-field.tsx
+++ b/src/new-components/select-field/select-field.tsx
@@ -39,6 +39,7 @@ const SelectField = React.forwardRef<HTMLSelectElement, SelectFieldProps>(functi
         >
             {(extraProps) => (
                 <Box
+                    data-testid="select-wrapper"
                     className={[
                         styles.selectWrapper,
                         tone === 'error' ? styles.error : null,


### PR DESCRIPTION
## Short description

Adds `variant` support to `SelectField` similar to what we've done in `TextField`. I'm recently seeing more product mock-ups containing a bordered variant of the `SelectField` ([ref](https://www.figma.com/file/KCVzX67egZgoeXFzjE62wc/TD-Multiplayer-First-Mile-(Design)?node-id=1199%3A238458&t=faCKgFpYHKsAfYSG-0), [ref](https://www.figma.com/file/ei8tJRO09v5MUXpLgm6ZT0/TW-Delight%3A-Onboarding?node-id=346%3A124735&t=xMdkxq2OHp7eFDri-0)). Given this, along with the fact `TextField` already supports it, I couldn't see a reason why not to bring support to this component too.

![Screenshot 2022-12-08 at 15 28 13](https://user-images.githubusercontent.com/15801768/206472034-43ad1a6b-092a-455b-82e0-4532986856dd.png)

## Test plan
- Select the `bordered` variant of the `SelectField`
- [x] The select field border wraps around the whole field (it resembles the bordered `TextField`)
- [x] You can focus as usual
- [x] Changing the tone to `error` changes the new outer border to red
- [x] In terms of functionality, the field works as in production

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

Minor