### PR TITLE
chore: Update ariakit dependency to 2.0.0-next.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
             "dependencies": {
                 "@reach/dialog": "^0.16.0",
                 "aria-hidden": "^1.2.1",
-                "ariakit": "2.0.0-next.27",
-                "ariakit-utils": "0.17.0-next.18",
+                "ariakit": "2.0.0-next.30",
+                "ariakit-utils": "0.17.0-next.21",
                 "dayjs": "^1.8.10",
                 "patch-package": "^6.4.6",
                 "react-focus-lock": "^2.9.1",
@@ -2274,16 +2274,16 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.1.tgz",
-            "integrity": "sha512-grcqEmI8DTIolufpxhJagVeJmvloxBXE6xxSrVnSXz/Wz1uUIsC85ad+UNBqAoBOvzLxE42wvDj3YkmSGqWRxA=="
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.3.tgz",
+            "integrity": "sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg=="
         },
         "node_modules/@floating-ui/dom": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.0.tgz",
-            "integrity": "sha512-PS75dnMg4GdWjDFOiOs15cDzYJpukRNHqQn0ugrBlsrpk2n+y8bwZ24XrsdLSL7kxshmxxr2nTNycLnmRIvV7g==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.3.tgz",
+            "integrity": "sha512-vpjWB1uC7rajvgA58uzlJZgtWqrdDQLw+XVA3w63ZTmsWwRmVd0Gl5Dy9VMAViI9cP7hBWaJt23Jy3AVgVYnoQ==",
             "dependencies": {
-                "@floating-ui/core": "^0.7.0"
+                "@floating-ui/core": "^0.7.3"
             }
         },
         "node_modules/@gar/promisify": {
@@ -9704,12 +9704,12 @@
             }
         },
         "node_modules/ariakit": {
-            "version": "2.0.0-next.27",
-            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.27.tgz",
-            "integrity": "sha512-PvZxNDARg6N/fKG1WW7L3UoOoXTBIeKYYTn6fUoBANbRS+K4u73wwkCVme8oWUzniUbNdx+w/pfvqZ8/cQyaUA==",
+            "version": "2.0.0-next.30",
+            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.30.tgz",
+            "integrity": "sha512-12CW6eY6i+3FPjB5ItIxRtet5pfLBML7bbCrrrDKEj1hIrUELvJu7HqFCvhNFTzODgVU8s1xr4rEUigaz/58rA==",
             "dependencies": {
-                "@floating-ui/dom": "0.5.0",
-                "ariakit-utils": "0.17.0-next.18"
+                "@floating-ui/dom": "0.5.3",
+                "ariakit-utils": "0.17.0-next.21"
             },
             "funding": {
                 "type": "opencollective",
@@ -9721,9 +9721,9 @@
             }
         },
         "node_modules/ariakit-utils": {
-            "version": "0.17.0-next.18",
-            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.18.tgz",
-            "integrity": "sha512-uDPWUW850ootTSIeYWkDU83bjJeM+QB3WAurw0RUoqOsUbJOFqxG5opVikDhvelRMR8+gV52MC2v2iy10wxb7Q==",
+            "version": "0.17.0-next.21",
+            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.21.tgz",
+            "integrity": "sha512-2zVBplN6O92WKDRy3RKafdl+BK0V7HtRpRX179YiWVG4ZTeeTNfj/m23d91SImue514U7PmxEp/DQb+LucQu+g==",
             "peerDependencies": {
                 "react": "^17.0.0 || ^18.0.0"
             }
@@ -37357,16 +37357,16 @@
             }
         },
         "@floating-ui/core": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.1.tgz",
-            "integrity": "sha512-grcqEmI8DTIolufpxhJagVeJmvloxBXE6xxSrVnSXz/Wz1uUIsC85ad+UNBqAoBOvzLxE42wvDj3YkmSGqWRxA=="
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.3.tgz",
+            "integrity": "sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg=="
         },
         "@floating-ui/dom": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.0.tgz",
-            "integrity": "sha512-PS75dnMg4GdWjDFOiOs15cDzYJpukRNHqQn0ugrBlsrpk2n+y8bwZ24XrsdLSL7kxshmxxr2nTNycLnmRIvV7g==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.3.tgz",
+            "integrity": "sha512-vpjWB1uC7rajvgA58uzlJZgtWqrdDQLw+XVA3w63ZTmsWwRmVd0Gl5Dy9VMAViI9cP7hBWaJt23Jy3AVgVYnoQ==",
             "requires": {
-                "@floating-ui/core": "^0.7.0"
+                "@floating-ui/core": "^0.7.3"
             }
         },
         "@gar/promisify": {
@@ -42950,18 +42950,18 @@
             }
         },
         "ariakit": {
-            "version": "2.0.0-next.27",
-            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.27.tgz",
-            "integrity": "sha512-PvZxNDARg6N/fKG1WW7L3UoOoXTBIeKYYTn6fUoBANbRS+K4u73wwkCVme8oWUzniUbNdx+w/pfvqZ8/cQyaUA==",
+            "version": "2.0.0-next.30",
+            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.30.tgz",
+            "integrity": "sha512-12CW6eY6i+3FPjB5ItIxRtet5pfLBML7bbCrrrDKEj1hIrUELvJu7HqFCvhNFTzODgVU8s1xr4rEUigaz/58rA==",
             "requires": {
-                "@floating-ui/dom": "0.5.0",
-                "ariakit-utils": "0.17.0-next.18"
+                "@floating-ui/dom": "0.5.3",
+                "ariakit-utils": "0.17.0-next.21"
             }
         },
         "ariakit-utils": {
-            "version": "0.17.0-next.18",
-            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.18.tgz",
-            "integrity": "sha512-uDPWUW850ootTSIeYWkDU83bjJeM+QB3WAurw0RUoqOsUbJOFqxG5opVikDhvelRMR8+gV52MC2v2iy10wxb7Q==",
+            "version": "0.17.0-next.21",
+            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.21.tgz",
+            "integrity": "sha512-2zVBplN6O92WKDRy3RKafdl+BK0V7HtRpRX179YiWVG4ZTeeTNfj/m23d91SImue514U7PmxEp/DQb+LucQu+g==",
             "requires": {}
         },
         "arr-diff": {

--- a/package.json
+++ b/package.json
@@ -130,8 +130,8 @@
     "dependencies": {
         "@reach/dialog": "^0.16.0",
         "aria-hidden": "^1.2.1",
-        "ariakit": "2.0.0-next.27",
-        "ariakit-utils": "0.17.0-next.18",
+        "ariakit": "2.0.0-next.30",
+        "ariakit-utils": "0.17.0-next.21",
         "dayjs": "^1.8.10",
         "patch-package": "^6.4.6",
         "react-focus-lock": "^2.9.1",


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

## Short description

Reactist is currently a blocker to the undergoing efforts to enable React v18 in Todoist (https://github.com/Doist/todoist-web/issues/4910). The reason is that one of its dependencies, Ariakit, throws at times a `Cannot call an event handler while rendering.` error from its own internal `useEvent` function, and it shouldn't. While visually it's not a breaking issue, several unit tests fail.

This problem has been fixed in Ariakit a while ago (https://github.com/ariakit/ariakit/pull/1481), but we froze Ariakit's version because newer versions brought breaking changes (https://github.com/Doist/reactist/issues/688). The good news is that the fix is present in a version (`2.0.0-next.30`) that was deployed just before the one that's problematic(`2.0.0-next.32`).

## Test plan

For peace of mind, you can run storybook and verify that the components run without errors. Special focus to the components that use Ariakit's `Dialog` underneath (`2.0.0-next.32` breaking changes modified some of its props).

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->

Minor
