### PR TITLE
chore: Explicitely enforce Chromatic build node version

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Prepare Node.js environment
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
             node-version-file: '.nvmrc'
             registry-url: https://npm.pkg.github.com

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,6 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Prepare Node.js environment
+        uses: actions/setup-node@v1
+        with:
+            node-version-file: '.nvmrc'
+            registry-url: https://npm.pkg.github.com
+            scope: '@doist'
       - name: Install dependencies
         run: npm install
       - name: Publish to Chromatic

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,15 +6,19 @@ jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
       - name: Prepare Node.js environment
         uses: actions/setup-node@v1
         with:
             node-version-file: '.nvmrc'
             registry-url: https://npm.pkg.github.com
             scope: '@doist'
+
       - name: Install dependencies
         run: npm install
+      
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:


### PR DESCRIPTION
## Short description

When working on https://github.com/Doist/reactist/pull/757, I noticed en error in the ["Publish to Chromatic" build](https://github.com/Doist/reactist/actions/runs/4224987339/jobs/7336654969):

```
Error: error:0308010C:digital envelope routines::unsupported
```

Based on ["the internet"](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported), it seems like this is due to fact that that build is running on Node v18, even though we're not (yet) intentionally supporting it in Reactist.

It actually started failing even before this PR, when I merged [my previous PR](https://github.com/Doist/reactist/pull/755). See this build: https://github.com/Doist/reactist/actions/runs/4224761740/jobs/7336138735

The best solution here seems to be to ensure that, before running the Chromatic publish step, we actually select the intended Node version, instead of relying on the default Node version that's brought in by `ubuntu-latest`, which apparently recently switched from Node 16 to Node 18.

I actually "took" this fix from todoist-web (cypress build): https://github.com/Doist/todoist-web/blob/main/.github/workflows/check-cypress-automation.yml#L92-L97

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->
