### PR TITLE
test: Fix flaky Time component test by freezing clock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
                 "@types/cheerio": "^0.22.22",
                 "@types/classnames": "^2.2.10",
                 "@types/enzyme": "^3.10.7",
+                "@types/jest": "28.1.8",
                 "@types/jest-axe": "^3.5.3",
                 "@types/marked": "^4.0.8",
                 "@types/react": "^17.0.45",
@@ -9269,13 +9270,13 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "25.2.3",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-            "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+            "version": "28.1.8",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+            "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
             "dev": true,
             "dependencies": {
-                "jest-diff": "^25.2.1",
-                "pretty-format": "^25.2.1"
+                "expect": "^28.0.0",
+                "pretty-format": "^28.0.0"
             }
         },
         "node_modules/@types/jest-axe": {
@@ -9295,160 +9296,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/@types/jest/node_modules/@jest/types": {
-            "version": "25.5.0",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-            "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-            "dev": true,
-            "dependencies": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^1.1.1",
-                "@types/yargs": "^15.0.0",
-                "chalk": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8.3"
-            }
-        },
-        "node_modules/@types/jest/node_modules/@types/yargs": {
-            "version": "15.0.14",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-            "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/@types/jest/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@types/jest/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@types/jest/node_modules/chalk": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@types/jest/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/@types/jest/node_modules/diff-sequences": {
-            "version": "25.2.6",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-            "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8.3"
-            }
-        },
-        "node_modules/@types/jest/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@types/jest/node_modules/jest-diff": {
-            "version": "25.5.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
-            "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^3.0.0",
-                "diff-sequences": "^25.2.6",
-                "jest-get-type": "^25.2.6",
-                "pretty-format": "^25.5.0"
-            },
-            "engines": {
-                "node": ">= 8.3"
-            }
-        },
-        "node_modules/@types/jest/node_modules/jest-get-type": {
-            "version": "25.2.6",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-            "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8.3"
-            }
-        },
-        "node_modules/@types/jest/node_modules/pretty-format": {
-            "version": "25.5.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-            "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-            "dev": true,
-            "dependencies": {
-                "@jest/types": "^25.5.0",
-                "ansi-regex": "^5.0.0",
-                "ansi-styles": "^4.0.0",
-                "react-is": "^16.12.0"
-            },
-            "engines": {
-                "node": ">= 8.3"
-            }
-        },
-        "node_modules/@types/jest/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true
-        },
-        "node_modules/@types/jest/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/@types/jsdom": {
@@ -34650,6 +34497,16 @@
                 }
             }
         },
+        "node_modules/tsdx/node_modules/@types/jest": {
+            "version": "25.2.3",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
+            "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+            "dev": true,
+            "dependencies": {
+                "jest-diff": "^25.2.1",
+                "pretty-format": "^25.2.1"
+            }
+        },
         "node_modules/tsdx/node_modules/@types/yargs": {
             "version": "15.0.14",
             "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
@@ -44987,133 +44844,13 @@
             }
         },
         "@types/jest": {
-            "version": "25.2.3",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-            "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+            "version": "28.1.8",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+            "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
             "dev": true,
             "requires": {
-                "jest-diff": "^25.2.1",
-                "pretty-format": "^25.2.1"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "25.5.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^3.0.0"
-                    }
-                },
-                "@types/yargs": {
-                    "version": "15.0.14",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-                    "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/yargs-parser": "*"
-                    }
-                },
-                "ansi-regex": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "diff-sequences": {
-                    "version": "25.2.6",
-                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-                    "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "jest-diff": {
-                    "version": "25.5.0",
-                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
-                    "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^3.0.0",
-                        "diff-sequences": "^25.2.6",
-                        "jest-get-type": "^25.2.6",
-                        "pretty-format": "^25.5.0"
-                    }
-                },
-                "jest-get-type": {
-                    "version": "25.2.6",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "25.5.0",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-                    "dev": true,
-                    "requires": {
-                        "@jest/types": "^25.5.0",
-                        "ansi-regex": "^5.0.0",
-                        "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
-                    }
-                },
-                "react-is": {
-                    "version": "16.13.1",
-                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
+                "expect": "^28.0.0",
+                "pretty-format": "^28.0.0"
             }
         },
         "@types/jest-axe": {
@@ -64583,6 +64320,16 @@
                     "requires": {
                         "@babel/helper-module-imports": "^7.10.4",
                         "@rollup/pluginutils": "^3.1.0"
+                    }
+                },
+                "@types/jest": {
+                    "version": "25.2.3",
+                    "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
+                    "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+                    "dev": true,
+                    "requires": {
+                        "jest-diff": "^25.2.1",
+                        "pretty-format": "^25.2.1"
                     }
                 },
                 "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "@types/cheerio": "^0.22.22",
         "@types/classnames": "^2.2.10",
         "@types/enzyme": "^3.10.7",
+        "@types/jest": "28.1.8",
         "@types/jest-axe": "^3.5.3",
         "@types/marked": "^4.0.8",
         "@types/react": "^17.0.45",

--- a/src/components/time/time.test.tsx
+++ b/src/components/time/time.test.tsx
@@ -7,6 +7,15 @@ import { Time } from './time'
 import userEvent from '@testing-library/user-event'
 
 describe('Time', () => {
+    beforeAll(() => {
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date('2023-03-14T12:00:00.000Z'))
+    })
+
+    afterAll(() => {
+        jest.useRealTimers()
+    })
+
     const testDate = dayjs(new Date('March 22, 1991 13:37:42')).unix()
 
     it('renders without crashing', () => {
@@ -116,6 +125,10 @@ describe('Time', () => {
     })
 
     describe('a11y', () => {
+        beforeAll(() => {
+            jest.useRealTimers()
+        })
+
         it('renders with no a11y violations', async () => {
             const { container } = render(<Time time={dayjs().unix()} />)
             const results = await axe(container)


### PR DESCRIPTION


## Short description

Fixes a flaky test caused by the time proceeding when asserting against time-specific output:

![image](https://user-images.githubusercontent.com/8531248/234390550-6a67d475-e1b4-4756-9757-b0874985f991.png)


## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

No release needed
