### PR TITLE
fix: Fixes to the startIcon feature on TextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# next
+
+-   [Fix] TextField's `startIcon` is now properly aligned when using variant="bordered".
+-   [Fix] TextField is now properly focused when clicking anywhere inside its bordered area.
+
 # v20.3.0
 
 -   [Feat] Toasts wrapped in `ToastsProvider` are now dismissed when their action `onClick` handler fires.

--- a/src/text-field/text-field.module.css
+++ b/src/text-field/text-field.module.css
@@ -1,4 +1,5 @@
 .inputWrapper {
+    cursor: text;
     height: var(--reactist-input-wrapper-height);
 }
 
@@ -62,8 +63,4 @@
 
 .inputWrapper:not(.bordered) input {
     padding: var(--tmp-vertical-padding) 10px;
-}
-
-.startIcon {
-    cursor: text;
 }

--- a/src/text-field/text-field.module.css
+++ b/src/text-field/text-field.module.css
@@ -62,5 +62,5 @@
 }
 
 .inputWrapper:not(.bordered) input {
-    padding: var(--tmp-vertical-padding) 10px;
+    padding: var(--tmp-vertical-padding) var(--reactist-spacing-small);
 }

--- a/src/text-field/text-field.stories.tsx
+++ b/src/text-field/text-field.stories.tsx
@@ -168,11 +168,16 @@ export function WithoutLabelStory() {
 
 export function IconStory() {
     return (
-        <Box maxWidth="small">
+        <Box maxWidth="small" display="flex" flexDirection="column" gap="large">
             <TextField
-                label="Search"
+                label="Search (default variant)"
                 startIcon={<Icon />}
-                id="textfield-with-icon"
+                placeholder="Text field with an icon"
+            />
+            <TextField
+                variant="bordered"
+                label="Search (bordered variant)"
+                startIcon={<Icon />}
                 placeholder="Text field with an icon"
             />
         </Box>

--- a/src/text-field/text-field.stories.tsx
+++ b/src/text-field/text-field.stories.tsx
@@ -16,6 +16,17 @@ export default {
     },
 }
 
+function Icon() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
+            <path
+                d="M10.5 3a7.5 7.5 0 015.645 12.438l4.709 4.708a.502.502 0 01-.708.708l-4.708-4.709A7.5 7.5 0 1110.5 3zm0 1a6.5 6.5 0 100 13 6.5 6.5 0 000-13z"
+                fill="currentColor"
+            />
+        </svg>
+    )
+}
+
 function preventDefault(event: React.SyntheticEvent) {
     event.preventDefault()
 }
@@ -23,8 +34,9 @@ function preventDefault(event: React.SyntheticEvent) {
 export function InteractivePropsStory({
     label,
     auxiliaryLabel,
+    startIcon = false,
     ...props
-}: PartialProps<typeof TextField>) {
+}: Omit<PartialProps<typeof TextField>, 'startIcon'> & { startIcon?: boolean }) {
     return (
         <TextField
             {...props}
@@ -37,6 +49,7 @@ export function InteractivePropsStory({
                     </a>
                 ) : undefined
             }
+            startIcon={startIcon ? <Icon /> : undefined}
         />
     )
 }
@@ -85,6 +98,10 @@ InteractivePropsStory.argTypes = {
         ['xsmall', 'small', 'medium', 'large', 'xlarge'],
         'small',
     ),
+    startIcon: {
+        control: { type: 'boolean' },
+        defaultValue: false,
+    },
 }
 
 export function MessageToneStory() {
@@ -146,17 +163,6 @@ export function WithoutLabelStory() {
                 </Text>
             </Stack>
         </Stack>
-    )
-}
-
-function Icon() {
-    return (
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
-            <path
-                d="M10.5 3a7.5 7.5 0 015.645 12.438l4.709 4.708a.502.502 0 01-.708.708l-4.708-4.709A7.5 7.5 0 1110.5 3zm0 1a6.5 6.5 0 100 13 6.5 6.5 0 000-13z"
-                fill="currentColor"
-            />
-        </svg>
     )
 }
 

--- a/src/text-field/text-field.tsx
+++ b/src/text-field/text-field.tsx
@@ -67,7 +67,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
                     onClick={handleClick}
                 >
                     {startIcon ? (
-                        <Box display="flex" marginRight="-xsmall" marginLeft="small" aria-hidden>
+                        <Box display="flex" marginRight="-xsmall" marginLeft="xsmall" aria-hidden>
                             {startIcon}
                         </Box>
                     ) : null}

--- a/src/text-field/text-field.tsx
+++ b/src/text-field/text-field.tsx
@@ -67,7 +67,12 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
                     onClick={handleClick}
                 >
                     {startIcon ? (
-                        <Box display="flex" marginRight="-xsmall" marginLeft="xsmall" aria-hidden>
+                        <Box
+                            display="flex"
+                            marginRight={variant === 'bordered' ? 'xsmall' : '-xsmall'}
+                            marginLeft={variant === 'bordered' ? '-xsmall' : 'xsmall'}
+                            aria-hidden
+                        >
                             {startIcon}
                         </Box>
                     ) : null}

--- a/src/text-field/text-field.tsx
+++ b/src/text-field/text-field.tsx
@@ -35,8 +35,10 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
     const internalRef = React.useRef<HTMLInputElement>(null)
     const combinedRef = useMergeRefs([ref, internalRef])
 
-    function focusOnIconClick() {
-        internalRef.current?.focus()
+    function handleClick(event: React.MouseEvent) {
+        if (event.currentTarget !== combinedRef.current) {
+            internalRef.current?.focus()
+        }
     }
 
     return (
@@ -62,16 +64,10 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
                         tone === 'error' ? styles.error : null,
                         variant === 'bordered' ? styles.bordered : null,
                     ]}
+                    onClick={handleClick}
                 >
                     {startIcon ? (
-                        <Box
-                            display="flex"
-                            className={styles.startIcon}
-                            onClick={focusOnIconClick}
-                            marginRight="-xsmall"
-                            marginLeft="small"
-                            aria-hidden
-                        >
+                        <Box display="flex" marginRight="-xsmall" marginLeft="small" aria-hidden>
                             {startIcon}
                         </Box>
                     ) : null}


### PR DESCRIPTION
## Short description

While attempting to look into adding a new feature to the `TextField`[^1], I noticed a couple of issues with the text field `startIcon`:

1. The "click to focus" functionality was still not entirely accurate if one managed to click on the thin padding around the icon. This PR fixes it by capturing the click event on the input element wrapper that covers the entire area inside the borders.
2. The `startIcon` feature was tailored only for the default text field variant. When the text field was set in bordered mode, the icon placement does not look good.

[^1]: The new feature I'm looking into is related to enabling the text field to also have a slot on the right side, similar to the one for `startIcon`. However, the slot in question is for more than just icons. It's about enabling the text field to have a button on its right side, for instance. Anyway, this PR is not at all about that.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Updated all static build artifacts (`npm run build-all`)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Patch release

## Demo

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

<img width="423" alt="CleanShot 2023-05-08 at 08 00 48@2x" src="https://user-images.githubusercontent.com/15199/236818488-63dd53f1-ea6c-4e79-ac25-26b2c82bee17.png">

</td>
<td>

<img width="423" alt="CleanShot 2023-05-08 at 07 58 38@2x" src="https://user-images.githubusercontent.com/15199/236818098-7f0b20c8-1b65-443d-a28d-c23fd3881350.png">

</td>
</tr>
</table>
