### PR TITLE
fix: Tooltip no longer re-created anchor when tooltip content changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 # next
 
 -   [Fix] `TextArea` with `autoExpand={true}` applies it initially, acknowledging any initial value that the field may have.
+-   [Fix] Avoid tooltip re-creating the anchor element when the tooltip content switches being present or not.
 
 # v21.0.0
 

--- a/src/text-field/text-field.stories.tsx
+++ b/src/text-field/text-field.stories.tsx
@@ -8,6 +8,7 @@ import { TextField } from './'
 
 import type { BoxMaxWidth } from '../box'
 import { Button } from '../button'
+import { Tooltip } from '../tooltip'
 
 export default {
     title: 'Design system/TextField',
@@ -243,4 +244,41 @@ export function ActionButtonStory() {
 
 ActionButtonStory.parameters = {
     chromatic: { disableSnapshot: false },
+}
+
+export function WithTooltipStory() {
+    const [value, setValue] = React.useState('')
+    const isValidNumber = /^\s*(\d{1,3})?\s*$/.test(value)
+
+    return (
+        <Box display="flex" flexDirection="column" gap="xlarge">
+            <Box display="flex" flexDirection="column" gap="small">
+                <Text>
+                    As an alternative to the <code>`message`</code> prop, you can also use tooltips
+                    to associate a description to a text field.{' '}
+                    <strong>This is not recommended in general</strong>, because the description
+                    will not be visible unless you’re hovering or focusing on the field.
+                </Text>
+                <Text>
+                    However, it can work in a situation like the following: the description is only
+                    needed to convey that the value being typed is invalid, and at the same time,
+                    the field forces the value back to valid when blurred. Hence, the description is
+                    never needed when the field is not focused anyway.
+                </Text>
+            </Box>
+            <Tooltip content={isValidNumber ? null : 'Invalid age'} position="top-end">
+                <TextField
+                    label="What’s your age?"
+                    value={value}
+                    onChange={(event) => setValue(event.currentTarget.value)}
+                    tone={isValidNumber ? 'neutral' : 'error'}
+                    hint="This field acceps only numeric inputs. Try typing valid and invalid values to see how it behaves."
+                    maxWidth="small"
+                    onBlur={() => {
+                        setValue(isValidNumber ? value.trim() : '')
+                    }}
+                />
+            </Tooltip>
+        </Box>
+    )
 }

--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -107,7 +107,7 @@ function Tooltip({
         children as React.FunctionComponentElement<JSX.IntrinsicElements['div']> | null,
     )
 
-    if (!content || !child) {
+    if (!child) {
         return child
     }
 
@@ -157,7 +157,7 @@ function Tooltip({
                     })
                 }}
             </TooltipAnchor>
-            {state.open ? (
+            {state.open && content ? (
                 <Box
                     as={AriakitTooltip}
                     state={state}


### PR DESCRIPTION
## Short description

The design team recently suggested that they are considering using tooltips to convey that a field has an invalid value. Normally we'd use the `message` prop, but in the case they're looking into, a tooltip would be convenient.

When exploring if that would work (given that it sounds unconventional to have a tooltip attached to a text field) it was all mostly good. For instance, the tooltip is correctly associated as the accessible description of the field. However, there was a problem with the field loosing focus as soon as I typed the character that made the tooltip appears due to the value being invalid.

When investigating why, I found that it was caused by the tooltip anchor element being re-created (re-mounted a new instance of the component, in React lingo). But we really wanted the element to stay the same, and just update its state. This was caused by how the `Tooltip` component changes its behavior based on whether the tooltip content was empty/null or not.

This PR fixes that, so that the anchor element is always present and stays the same component instance all the time.

## PR Checklist

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Patch release.

## Demo

https://github.com/Doist/reactist/assets/15199/a61c3851-7d6d-4bc2-8d47-8c2d497db22c
