### PR TITLE
build: Fix npm package provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
         types: [created]
     workflow_dispatch:
 
+permissions:
+    # Enable the use of OIDC for npm provenance
+    id-token: write
+
 jobs:
     publish:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Short description

This PR fixes npm package provenance when publishing to npmjs, it was missing an important permission for the whole thing to work (I'm assuming based on the documentation since the only way to test this is to publish a new version, which I'm not going to force).