### PR TITLE
build: Fix npm package provenance (GitHub Packages)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
                   node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
                   registry-url: https://npm.pkg.github.com/
                   scope: '@doist'
-            - run: npm publish
+            - run: npm publish --provenance
               env:
                   NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
## Short description

Forgot to add `--provenance` when publishing to GitHub Packages on the [previous PR](https://github.com/Doist/reactist/pull/774). This one fixes that.