### PR TITLE
feat: Use link colors when inline code is wrapped in links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# v21.1.0
+
+-   [Feat] The `Prose` component now supports links applied to inline code.
+
 # v21.0.2
 
 -   [Fix] `Tabslist`'s default space `space='xsmall'` is removed to get rid of unnecessary gap between tabs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "21.0.2",
+    "version": "21.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "21.0.2",
+            "version": "21.1.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "21.0.2",
+    "version": "21.1.0",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/prose/prose-example.ts
+++ b/src/prose/prose-example.ts
@@ -8,8 +8,10 @@ multiple lines. This paragraph, for instance, should be long enough to do so in 
 screen sizes that are comfortable to read anyway.
 
 A second paragraph now. One that contains [a link to Doist.com](https://doist.com), and text
-formatting examples, such as **bold text**, _italic text_, and \`monospace\`. Now let’s continue
-with a list:
+formatting examples, such as **bold text**, _italic text_, ~~strikethrough text~~ and \`monospace\`.
+These can also be combined, like [using _italics_, \`monospace\`, or _\`both\`_ within a link](https://en.wikipedia.org/wiki/Typography).
+
+Now let’s continue with a list:
 
 -   this one
 -   that one

--- a/src/prose/prose.module.css
+++ b/src/prose/prose.module.css
@@ -245,7 +245,8 @@
 
 /* links */
 
-.prose a {
+.prose a,
+.prose a code {
     color: var(--reactist-prose-link-idle-tint);
     text-decoration-line: underline;
     text-decoration-style: solid;
@@ -254,7 +255,10 @@
 
 .prose a:hover,
 .prose a:focus,
-.prose a:active {
+.prose a:active,
+.prose a:hover code,
+.prose a:focus code,
+.prose a:active code {
     color: var(--reactist-prose-link-hover-tint);
     text-decoration-color: var(--reactist-prose-link-hover-underline);
 }


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->



## Short description

This will update the `Prose` component to apply link styles to inline code that are wrapped in a link. 

This should be updated in conjunction with https://github.com/Doist/typist/pull/309.

|Before|After|
|-|-|
|![image](https://github.com/Doist/reactist/assets/8531248/b2e4d708-1ceb-49bc-ab4a-1d0e6275e0d9)|![image](https://github.com/Doist/reactist/assets/8531248/caafeccd-a7db-4b79-8859-f5b07325237e)|

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [x] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Minor
