### PR TITLE
feat: Add the ability to open menus programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# next
+
+-   [Feat] Add the ability to open menus programmatically
+
 # v21.1.0
 
 -   [Feat] The `Prose` component now supports links applied to inline code.

--- a/src/menu/menu.stories.mdx
+++ b/src/menu/menu.stories.mdx
@@ -206,6 +206,56 @@ In the demo below, right click on the Settings button, or click on the more butt
     </Story>
 </Canvas>
 
+### Open menu programmatically
+
+You can pass a ref to the parent `Menu` component to have access to a `open` function that allows
+you to open the menu programmatically.
+
+export function OpenMenuWithKeyboard() {
+    const menuRef = React.useRef(null)
+    React.useEffect(() => {
+        function handleKeyDown(event) {
+            if (event.key === '$' && event.ctrlKey && event.shiftKey && menuRef.current) {
+                event.preventDefault()
+                event.stopPropagation()
+                menuRef.current.open()
+            }
+        }
+        window.addEventListener('keydown', handleKeyDown)
+        return () => window.removeEventListener('keydown', handleKeyDown)
+    }, [])
+    return (
+        <Stack space="medium">
+            <Text>
+                You can open the menu by pressing <code>Ctrl + Shift + $</code>
+            </Text>
+            <Menu ref={menuRef}>
+                <Inline space="xsmall">
+                    <MenuButton>Menu</MenuButton>
+                </Inline>
+                <MenuList aria-label="Settings menu">
+                    <MenuItem>Account</MenuItem>
+                    <MenuItem>General</MenuItem>
+                    <MenuItem>Advanced</MenuItem>
+                    <hr />
+                    <MenuItem>Logout</MenuItem>
+                </MenuList>
+            </Menu>
+        </Stack>
+    )
+}
+
+<Canvas>
+    <Story
+        name="Open Programmatically Story"
+        parameters={{
+            docs: { source: { type: 'dynamic' } },
+        }}
+    >
+        {OpenMenuWithKeyboard.bind({})}
+    </Story>
+</Canvas>
+
 ### Extra Features
 
 You may also use `<MenuGroup>` to group menu items, `disable` a menu item, or

--- a/src/menu/menu.tsx
+++ b/src/menu/menu.tsx
@@ -56,11 +56,18 @@ type MenuProps = Omit<Ariakit.MenuStateProps, 'visible'> & {
     onItemSelect?: (value: string | null | undefined) => void
 }
 
+type MenuHandle = {
+    open: () => void
+}
+
 /**
  * Wrapper component to control a menu. It does not render anything, only providing the state
  * management for the menu components inside it.
  */
-function Menu({ children, onItemSelect, ...props }: MenuProps) {
+const Menu = React.forwardRef<MenuHandle, MenuProps>(function Menu(
+    { children, onItemSelect, ...props },
+    ref,
+) {
     const [anchorRect, handleAnchorRectChange] = React.useState<{ x: number; y: number } | null>(
         null,
     )
@@ -75,6 +82,8 @@ function Menu({ children, onItemSelect, ...props }: MenuProps) {
         getAnchorRect,
         ...props,
     })
+
+    React.useImperativeHandle(ref, () => ({ open: state.show }))
 
     const handleItemSelect = React.useCallback(
         function handleItemSelect(value: string | null | undefined) {
@@ -93,7 +102,7 @@ function Menu({ children, onItemSelect, ...props }: MenuProps) {
     )
 
     return <MenuContext.Provider value={value}>{children}</MenuContext.Provider>
-}
+})
 
 //
 // MenuButton
@@ -368,4 +377,4 @@ const MenuGroup = polymorphicComponent<'div', MenuGroupProps>(function MenuGroup
 })
 
 export { ContextMenuTrigger, Menu, MenuButton, MenuList, MenuItem, SubMenu, MenuGroup }
-export type { MenuButtonProps, MenuListProps, MenuItemProps, MenuGroupProps }
+export type { MenuButtonProps, MenuListProps, MenuItemProps, MenuGroupProps, MenuHandle }


### PR DESCRIPTION
## Short description

Add the ability to open menus programmatically. This is needed, for instance, to make it possible to have keyboard shortcuts that open a dropdown menu.

## PR Checklist

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

> **Note**
> This PR's base branch is not `main`. So approving this does not yet mean it will be released. I'm planning a series of improvements to the menu component, that I'll gather in this base branch before I make a single release (or a handful of releases). This will allow me to test the changes with Todoist before comitting Reactist to the new features.
