### PR TITLE
feat: Structured menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 # next
 
 -   [Feat] Add the ability to open menus programmatically
+-   [BREAKING] The `MenuItem` component now supports generating its content by using new props (`label`, `description`, `icon`, and `shortcut`) to achieve a more uniform and structured look.
+    -   The traditional way of using the `MenuItem`'s `children` prop remains available if needed, to achieve custom menu item layouts.
+    -   Although, the layout inside a `MenuItem` is broken for those that were using it with an icon and text, so it is required migrating those `MenuItem` elements to use the new props instead.
 
 # v21.1.0
 

--- a/src/menu/menu.less
+++ b/src/menu/menu.less
@@ -20,6 +20,7 @@
         outline: none;
         text-align: left;
         display: flex;
+        gap: var(--reactist-spacing-small);
         align-items: center;
         padding: 5px 10px;
         color: inherit;
@@ -35,6 +36,8 @@
     }
 
     [role='menuitem'] {
+        cursor: pointer;
+        flex-direction: column;
         width: 100%;
         box-sizing: border-box;
         &:hover,
@@ -69,4 +72,18 @@
         background-color: var(--reactist-bg-selected);
         margin: 4px 0;
     }
+}
+
+.reactist_menulist [role='menuitem'] .reactist_menuitem_icon {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.reactist_menulist [role='menuitem'] .reactist_menuitem_label {
+    width: 100%;
+}
+.reactist_menulist [role='menuitem'] .reactist_menuitem_description {
+    white-space: normal;
 }

--- a/src/menu/menu.stories.mdx
+++ b/src/menu/menu.stories.mdx
@@ -7,6 +7,8 @@ import { Columns, Column } from '../columns'
 import { ContextMenuTrigger, Menu, MenuButton, MenuList, MenuItem, MenuGroup, SubMenu } from '.'
 import { ButtonLink } from '../button-link'
 import { Text } from '../text'
+import { Box } from '../box'
+import { Avatar } from '../avatar'
 
 <Meta
     title="Design system/Menu"
@@ -45,6 +47,23 @@ export function ArrowRight() {
     )
 }
 
+export function LeaveIcon() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
+            <g fill="none" fillRule="evenodd">
+                <path
+                    stroke="currentColor"
+                    d="M6.5 8.3V5.63c0-1.17.9-2.13 2-2.13h7c1.1 0 2 .95 2 2.13v11.74c0 1.17-.9 2.13-2 2.13h-7c-1.1 0-2-.95-2-2.13V14.7"
+                />
+                <path
+                    fill="currentColor"
+                    d="M12.8 11l-2.15-2.15a.5.5 0 1 1 .7-.7L14 10.79a1 1 0 0 1 0 1.42l-2.65 2.64a.5.5 0 0 1-.7-.7L12.79 12H4.5a.5.5 0 0 1 0-1h8.3z"
+                />
+            </g>
+        </svg>
+    )
+}
+
 # Menu
 
 A set of components that provide the means to construct a menu that can be triggered
@@ -62,11 +81,11 @@ via an element or as a context menu.
                 Simple menu
             </MenuButton>
             <MenuList aria-label="Simple menu">
-                <MenuItem>Edit</MenuItem>
-                <MenuItem>Copy</MenuItem>
-                <MenuItem>Paste</MenuItem>
-                <MenuItem>Duplicate</MenuItem>
-                <MenuItem>Remove</MenuItem>
+                <MenuItem label="Edit" />
+                <MenuItem label="Copy" />
+                <MenuItem label="Paste" />
+                <MenuItem label="Duplicate" />
+                <MenuItem label="Remove" />
             </MenuList>
         </Menu>
     </Story>
@@ -88,11 +107,11 @@ The `tooltip` prop allows a tooltip to be shown over the menu button.
                 Focus on or hover over me
             </MenuButton>
             <MenuList aria-label="Tooltip menu">
-                <MenuItem>Edit</MenuItem>
-                <MenuItem>Copy</MenuItem>
-                <MenuItem>Paste</MenuItem>
-                <MenuItem>Duplicate</MenuItem>
-                <MenuItem>Remove</MenuItem>
+                <MenuItem label="Edit" />
+                <MenuItem label="Copy" />
+                <MenuItem label="Paste" />
+                <MenuItem label="Duplicate" />
+                <MenuItem label="Remove" />
             </MenuList>
         </Menu>
     </Story>
@@ -115,11 +134,11 @@ be changed by passing `modal={false}` to `<MenuList>`
                 Menu
             </MenuButton>
             <MenuList aria-label="Outside interaction menu" modal={false}>
-                <MenuItem>Edit</MenuItem>
-                <MenuItem>Copy</MenuItem>
-                <MenuItem>Paste</MenuItem>
-                <MenuItem>Duplicate</MenuItem>
-                <MenuItem>Remove</MenuItem>
+                <MenuItem label="Edit" />
+                <MenuItem label="Copy" />
+                <MenuItem label="Paste" />
+                <MenuItem label="Duplicate" />
+                <MenuItem label="Remove" />
             </MenuList>
         </Menu>
     </Story>
@@ -146,11 +165,10 @@ You may nest the `<SubMenu>` component within `<Menu>` to create submenus.
                     href="https://github.com/Doist/reactist"
                     target="_blank"
                     rel="noreferrer noopener"
-                >
-                    Reactist on Github
-                </MenuItem>
-                <MenuItem>About Reactist…</MenuItem>
-                <MenuItem>Check for updates…</MenuItem>
+                    label="Reactist on Github"
+                />
+                <MenuItem label="About Reactist…" />
+                <MenuItem label="Check for updates…" />
                 <hr />
                 <SubMenu>
                     <MenuButton>
@@ -158,10 +176,10 @@ You may nest the `<SubMenu>` component within `<Menu>` to create submenus.
                         <ArrowRight />
                     </MenuButton>
                     <MenuList>
-                        <MenuItem>Settings</MenuItem>
-                        <MenuItem>Extensions</MenuItem>
+                        <MenuItem label="Settings" />
+                        <MenuItem label="Extensions" />
                         <hr />
-                        <MenuItem>Notifications</MenuItem>
+                        <MenuItem label="Notifications" />
                     </MenuList>
                 </SubMenu>
             </MenuList>
@@ -197,9 +215,9 @@ In the demo below, right click on the Settings button, or click on the more butt
                     />
                 </Inline>
                 <MenuList aria-label="Settings menu">
-                    <MenuItem>Account</MenuItem>
-                    <MenuItem>General</MenuItem>
-                    <MenuItem>Advanced</MenuItem>
+                    <MenuItem label="Account" />
+                    <MenuItem label="General" />
+                    <MenuItem label="Advanced" />
                 </MenuList>
             </Menu>
         </Stack>
@@ -234,11 +252,11 @@ export function OpenMenuWithKeyboard() {
                     <MenuButton>Menu</MenuButton>
                 </Inline>
                 <MenuList aria-label="Settings menu">
-                    <MenuItem>Account</MenuItem>
-                    <MenuItem>General</MenuItem>
-                    <MenuItem>Advanced</MenuItem>
+                    <MenuItem label="Account" />
+                    <MenuItem label="General" />
+                    <MenuItem label="Advanced" />
                     <hr />
-                    <MenuItem>Logout</MenuItem>
+                    <MenuItem label="Logout" />
                 </MenuList>
             </Menu>
         </Stack>
@@ -259,7 +277,8 @@ export function OpenMenuWithKeyboard() {
 ### Extra Features
 
 You may also use `<MenuGroup>` to group menu items, `disable` a menu item, or
-return `false` from `onSelect` to prevent the menu from closing when an item is selected.
+return `false` from `onSelect` to prevent the menu from closing when an item is selected. Moreover,
+you can achieve richer menu items with icons, shortcut info, description, etc.
 
 <Canvas>
     <Story
@@ -273,46 +292,48 @@ return `false` from `onSelect` to prevent the menu from closing when an item is 
                 With extra features
             </MenuButton>
             <MenuList aria-label="Menu with extra features">
-                <MenuItem>
-                    <StructuredMenuItem icon="✏" label="Edit" />
+                <MenuItem
+                    label="Settings"
+                    icon="⚙️"
+                    shortcut={<KeyboardShortcut>O then S</KeyboardShortcut>}
+                >
+                    <Box display="flex" alignItems="center" gap="small">
+                        <Avatar user={{ name: 'Jane Doe', email: 'jane.doe@example.com' }} />
+                        <Stack space="small">
+                            <Text weight="semibold">Jane Doe</Text>
+                            <Text tone="secondary">jane.doe@example.com</Text>
+                        </Stack>
+                    </Box>
                 </MenuItem>
-                <MenuItem>
-                    <StructuredMenuItem icon="👯‍♀️️" label="Duplicate" shortcut="Cmd + D" />
-                </MenuItem>
+                <hr />
+                <MenuItem icon="✏" label="Edit" />
+                <MenuItem
+                    icon="👯‍♀️️"
+                    label="Duplicate"
+                    shortcut={<KeyboardShortcut>Cmd + D</KeyboardShortcut>}
+                />
                 <MenuItem
                     onSelect={() => {
                         return false // This prevents the menu from closing
                     }}
-                >
-                    <StructuredMenuItem icon="👀" label="This will not close the menu" />
-                </MenuItem>
+                    icon="👀"
+                    label="This will not close the menu"
+                    shortcut={<KeyboardShortcut>Cmd + S</KeyboardShortcut>}
+                />
                 <hr />
                 <MenuGroup label="Dangerous options">
-                    <MenuItem>Remove first</MenuItem>
-                    <MenuItem>Remove completed</MenuItem>
-                    <MenuItem disabled>Remove all (disabled)</MenuItem>
+                    <MenuItem label="Remove first" />
+                    <MenuItem label="Remove completed" />
+                    <MenuItem disabled label="Remove all (disabled)" />
                 </MenuGroup>
+                <hr />
+                <MenuItem
+                    label="Logout"
+                    description="When you logout, all changes will be saved"
+                    icon={<LeaveIcon />}
+                    shortcut={<KeyboardShortcut>Cmd + X</KeyboardShortcut>}
+                />
             </MenuList>
         </Menu>
     </Story>
 </Canvas>
-
-export function StructuredMenuItem({ icon, label, shortcut }) {
-    return (
-        <Columns space="small" width="full" flexGrow={1}>
-            {icon ? (
-                <Column width="content" aria-hidden>
-                    {icon}
-                </Column>
-            ) : null}
-            <Column width="auto">
-                <Text size="copy">{label}</Text>
-            </Column>
-            {shortcut ? (
-                <Column width="content">
-                    <KeyboardShortcut>{shortcut}</KeyboardShortcut>
-                </Column>
-            ) : null}
-        </Columns>
-    )
-}

--- a/src/menu/menu.test.tsx
+++ b/src/menu/menu.test.tsx
@@ -29,7 +29,7 @@ describe('Menu', () => {
                     // To allow interaction with the menu button
                     modal={false}
                 >
-                    <MenuItem>First option</MenuItem>
+                    <MenuItem label="First option" />
                 </MenuList>
             </Menu>,
         )
@@ -52,11 +52,13 @@ describe('Menu', () => {
             <Menu>
                 <MenuButton>Options menu</MenuButton>
                 <MenuList aria-label="Some options">
-                    <MenuItem onSelect={() => undefined}>First option</MenuItem>
-                    <MenuItem onSelect={() => false}>Second option</MenuItem>
-                    <MenuItem onSelect={() => undefined} hideOnSelect={false}>
-                        Third option
-                    </MenuItem>
+                    <MenuItem onSelect={() => undefined} label="First option" />
+                    <MenuItem onSelect={() => false} label="Second option" />
+                    <MenuItem
+                        onSelect={() => undefined}
+                        hideOnSelect={false}
+                        label="Third option"
+                    />
                 </MenuList>
             </Menu>,
         )
@@ -89,12 +91,16 @@ describe('Menu', () => {
             <Menu onItemSelect={onItemSelect}>
                 <MenuButton>Options menu</MenuButton>
                 <MenuList aria-label="Some options">
-                    <MenuItem value="1st" onSelect={() => onSelect('1st option')}>
-                        1st option
-                    </MenuItem>
-                    <MenuItem value="2nd" onSelect={() => onSelect('2nd option')}>
-                        2nd option
-                    </MenuItem>
+                    <MenuItem
+                        value="1st"
+                        label="1st option"
+                        onSelect={() => onSelect('1st option')}
+                    />
+                    <MenuItem
+                        value="2nd"
+                        label="2nd option"
+                        onSelect={() => onSelect('2nd option')}
+                    />
                 </MenuList>
             </Menu>,
         )
@@ -118,15 +124,21 @@ describe('Menu', () => {
             <Menu onItemSelect={onItemSelect}>
                 <MenuButton>Options menu</MenuButton>
                 <MenuList aria-label="Some options">
-                    <MenuItem value="1st" onSelect={() => onSelect('1st option')}>
-                        1st option
-                    </MenuItem>
-                    <MenuItem value="2nd" onSelect={() => onSelect('2nd option')}>
-                        2nd option
-                    </MenuItem>
-                    <MenuItem value="3rd" onSelect={() => onSelect('3rd option')}>
-                        3rd option
-                    </MenuItem>
+                    <MenuItem
+                        value="1st"
+                        label="1st option"
+                        onSelect={() => onSelect('1st option')}
+                    />
+                    <MenuItem
+                        value="2nd"
+                        label="2nd option"
+                        onSelect={() => onSelect('2nd option')}
+                    />
+                    <MenuItem
+                        value="3rd"
+                        label="3rd option"
+                        onSelect={() => onSelect('3rd option')}
+                    />
                 </MenuList>
             </Menu>,
         )
@@ -162,9 +174,7 @@ describe('Menu', () => {
             <Menu>
                 <MenuButton>Links</MenuButton>
                 <MenuList aria-label="Some options">
-                    <MenuItem as="a" href="https://github.com/Doist/reactist">
-                        Github repo
-                    </MenuItem>
+                    <MenuItem as="a" href="https://github.com/Doist/reactist" label="Github repo" />
                 </MenuList>
             </Menu>,
         )
@@ -182,6 +192,64 @@ describe('Menu', () => {
         // supported in jsdom, so we'd need to mock window.location or something
     })
 
+    it('uses the description as the semantic description of the menu item', () => {
+        render(
+            <Menu>
+                <MenuButton>Options menu</MenuButton>
+                <MenuList aria-label="Some options">
+                    <MenuItem
+                        label="Sign-out"
+                        description="All your work is saved before signing out"
+                    />
+                </MenuList>
+            </Menu>,
+        )
+        userEvent.click(screen.getByRole('button', { name: 'Options menu' }))
+        expect(screen.getByRole('menuitem', { name: 'Sign-out' })).toHaveAccessibleDescription(
+            'All your work is saved before signing out',
+        )
+    })
+
+    it('allows to override the aria label and description of the menu item', () => {
+        render(
+            <>
+                <Menu>
+                    <MenuButton>Options menu</MenuButton>
+                    <MenuList aria-label="Some options">
+                        <MenuItem
+                            aria-label="Alternative label"
+                            aria-describedby="logout-description"
+                            label="Sign-out"
+                            description="All your work is saved before signing out"
+                        />
+                    </MenuList>
+                </Menu>
+                <div id="logout-description">Alternative description</div>
+            </>,
+        )
+        userEvent.click(screen.getByRole('button', { name: 'Options menu' }))
+        expect(
+            screen.getByRole('menuitem', { name: 'Alternative label' }),
+        ).toHaveAccessibleDescription('Alternative description')
+    })
+
+    it('supports rendering custom menu item content using the `children` prop', () => {
+        render(
+            <Menu>
+                <MenuButton>Options menu</MenuButton>
+                <MenuList aria-label="Some options">
+                    <MenuItem label="Edit">Custom edit content</MenuItem>
+                    <MenuItem>Delete</MenuItem>
+                </MenuList>
+            </Menu>,
+        )
+        userEvent.click(screen.getByRole('button', { name: 'Options menu' }))
+        expect(screen.getByRole('menuitem', { name: 'Edit' })).toHaveTextContent(
+            'Custom edit content',
+        )
+        expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument()
+    })
+
     it('allows to intercept clicks and prevent the onSelect action to occur', async () => {
         const onSelect = jest.fn()
         render(
@@ -189,11 +257,10 @@ describe('Menu', () => {
                 <MenuButton>Options menu</MenuButton>
                 <MenuList aria-label="Some options">
                     <MenuItem
+                        label="Click me"
                         onClick={(event: React.MouseEvent) => event.preventDefault()}
                         onSelect={() => onSelect()}
-                    >
-                        Click me
-                    </MenuItem>
+                    />
                 </MenuList>
             </Menu>,
         )
@@ -214,7 +281,7 @@ describe('Menu', () => {
             <Menu>
                 <ContextMenuTrigger>Options menu</ContextMenuTrigger>
                 <MenuList aria-label="Some options">
-                    <MenuItem>First option</MenuItem>
+                    <MenuItem label="First option" />
                 </MenuList>
             </Menu>,
         )
@@ -240,9 +307,9 @@ describe('Menu', () => {
                     <SubMenu>
                         <MenuButton>More options</MenuButton>
                         <MenuList aria-label="More options">
-                            <MenuItem onSelect={handleSave}>Save</MenuItem>
-                            <MenuItem>Discard</MenuItem>
-                            <MenuItem>Exit</MenuItem>
+                            <MenuItem label="Save" onSelect={handleSave} />
+                            <MenuItem label="Discard" />
+                            <MenuItem label="Exit" />
                         </MenuList>
                     </SubMenu>
                 </MenuList>
@@ -273,9 +340,9 @@ describe('Menu', () => {
                     <SubMenu>
                         <MenuButton>More options</MenuButton>
                         <MenuList>
-                            <MenuItem onSelect={handleSave}>Save</MenuItem>
-                            <MenuItem>Discard</MenuItem>
-                            <MenuItem>Exit</MenuItem>
+                            <MenuItem label="Save" onSelect={handleSave} />
+                            <MenuItem label="Discard" />
+                            <MenuItem label="Exit" />
                         </MenuList>
                     </SubMenu>
                 </MenuList>
@@ -348,13 +415,11 @@ describe('Menu', () => {
                 <Menu>
                     <MenuButton>Options menu</MenuButton>
                     <MenuList aria-label="Some options">
-                        <MenuItem>First option</MenuItem>
+                        <MenuItem label="First option" />
                     </MenuList>
                 </Menu>,
             )
-            const results = await axe(container)
-
-            expect(results).toHaveNoViolations()
+            expect(await axe(container)).toHaveNoViolations()
         })
 
         it('renders with no a11y violations while open', async () => {
@@ -362,16 +427,13 @@ describe('Menu', () => {
                 <Menu>
                     <MenuButton>Options menu</MenuButton>
                     <MenuList aria-label="Some options">
-                        <MenuItem onSelect={() => undefined}>First option</MenuItem>
+                        <MenuItem onSelect={() => undefined} label="First option" />
                     </MenuList>
                 </Menu>,
             )
 
-            // Open menu
             userEvent.click(screen.getByRole('button', { name: 'Options menu' }))
-
-            const results = await axe(container)
-            expect(results).toHaveNoViolations()
+            expect(await axe(container)).toHaveNoViolations()
         })
 
         it('focuses on the MenuButton when Menu closes', async () => {
@@ -379,7 +441,7 @@ describe('Menu', () => {
                 <Menu>
                     <MenuButton>Options menu</MenuButton>
                     <MenuList aria-label="Some options">
-                        <MenuItem onSelect={() => undefined}>First option</MenuItem>
+                        <MenuItem onSelect={() => undefined} label="First option" />
                     </MenuList>
                 </Menu>,
             )


### PR DESCRIPTION
## Short description

This PR enhances the `MenuItem` component to have props targeted at generating a more structured content inside it, rather than leaving it to the consumer of the component to build the menu item's content by using `children`.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

```jsx
<MenuItem>
  <CoolIcon />
  Click me to learn more…
</MenuItem>
```

</td>
<td>

```jsx
<MenuItem
  icon={<CoolIcon />}
  label="Click me to learn more…"
/>
```

</td>
</tr>
</table>

The ability to use the component `children` instead of this new props is kept. It may prove useful in the future, so it is likely a feature we won't remove. It will give the freedom to consumers of the menu components to carve out custom menu items when they need it.

Still, this is a breaking change. The inner layout of a menu item changes in ways that would break the layout in the Todoist app if we adopt this without migrating most `MenuItem` elements to use the new props.

### Why?

A few reasons:

- We now need menu items with label and description. We've been achieving them manually in the apps, but the code is cumbersome and not reusable.
- This allows us to standardize the spacing, and control the size of the icon area, which until now is kept uniform by virtue of using uniformly-sized icons. But the consumer can easily break the layout.
- We now standardize the "shortcut" area of a menu item. Until now, consumer apps have been needing to solve this in-app.

## PR Checklist

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`

## Versioning

> **Note**
> This PR's base branch is not `main`. So approving this does not yet mean it will be released. I'm planning a series of improvements to the menu component, that I'll gather in this base branch before I make a single release (or a handful of releases). This will allow me to test the changes with Todoist before comitting Reactist to the new features.

## Demo

<img width="399" alt="CleanShot 2023-07-04 at 11 49 48@2x" src="https://github.com/Doist/reactist/assets/15199/e038745e-69cc-42cc-b5c7-a2bde9299028">
