### PR TITLE
style: Apply a large right-padding to ModalHeader to match left side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# v21.1.1
+
+-   [Fix] Apply even right and left paddings for `ModalHeader`.
+
 # v21.1.0
 
 -   [Feat] The `Prose` component now supports links applied to inline code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "21.1.0",
+    "version": "21.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "21.1.0",
+            "version": "21.1.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "21.1.0",
+    "version": "21.1.1",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/modal/modal.tsx
+++ b/src/modal/modal.tsx
@@ -355,8 +355,7 @@ export function ModalHeader({
             <Box
                 {...props}
                 as="header"
-                paddingLeft="large"
-                paddingRight={button === false || button === null ? 'large' : 'small'}
+                paddingX="large"
                 paddingY="small"
                 className={exceptionallySetClassName}
             >


### PR DESCRIPTION
## Short description

Recently after working on the edit filter modal, it became obvious that the right hand side padding of the modal's header was much smaller, especially when our modal body's padding is set to large. 

![CleanShot 2023-07-05 at 10 24 00](https://github.com/Doist/reactist/assets/15801768/e011c895-883c-49dc-8265-448da3f20ab9)


I see we've done it to account for button padding, but have also witnessed this style being overriden in some cases in todoist  to align it with the left i.e. task detail header. 

I feel it would look better if we align these at the root component, and also that it's not necessarily this component's job to account for potentially large buttons within it. Instead, it should be handled by consumers if need be. Happy to discuss this further if there are any strong opinions on this change though. 

## PR Checklist

- [ ] The `ModalHeader` has a `large` padding on both right and left sides.

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Small fix, bumped to`v21.1.1`
