### PR TITLE
feat: New menu styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 -   [BREAKING] The `MenuItem` component now supports generating its content by using new props (`label`, `description`, `icon`, and `shortcut`) to achieve a more uniform and structured look.
     -   The traditional way of using the `MenuItem`'s `children` prop remains available if needed, to achieve custom menu item layouts.
     -   Although, the layout inside a `MenuItem` is broken for those that were using it with an icon and text, so it is required migrating those `MenuItem` elements to use the new props instead.
+-   [BREAKING] Introduces new `SubMenuItem` and `SubMenuList`, which now must be used in place of `MenuButton` and `MenuList` when creating sub-menus.
+-   [Feat] Updated menu styles
 
 # v21.1.1
 

--- a/src/menu/index.ts
+++ b/src/menu/index.ts
@@ -1,10 +1,1 @@
-export {
-    Menu,
-    MenuButton,
-    ContextMenuTrigger,
-    MenuList,
-    MenuItem,
-    SubMenu,
-    MenuGroup,
-} from './menu'
-export type { MenuItemProps, MenuGroupProps } from './menu'
+export * from './menu'

--- a/src/menu/menu.module.css
+++ b/src/menu/menu.module.css
@@ -1,0 +1,154 @@
+.menuList {
+    background-color: var(--reactist-bg-raised);
+    border-color: var(--reactist-divider-secondary);
+    border-radius: var(--reactist-border-radius-large);
+    border: 1px solid var(--reactist-divider-secondary);
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.12);
+    color: var(--reactist-content-primary);
+    display: block;
+    font-size: var(--reactist-font-size-copy);
+    line-height: normal;
+    margin: -4px; /* Required to add spacing between the viewport, used in conjunction with unstable_offset */
+    max-height: var(--popover-available-height); /* defined by ariakit */
+    max-width: 350px;
+    min-height: 44px; /* minimum accessible target area */
+    min-width: 280px;
+    outline: none;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: 6px 0;
+    white-space: nowrap;
+    width: auto;
+    z-index: var(--reactist-stacking-order-menu);
+}
+
+.subMenuList {
+    /**
+     * This aims to align the sub-menu items vertically with the corresponding parent menu item that
+     * activates the sub-menu.
+     */
+    margin-top: -11px;
+}
+
+.menuList hr {
+    background-color: var(--reactist-divider-primary);
+    border: none;
+    height: 1px;
+    margin: 4px 0;
+}
+
+/* So we do not need to worry about rendering more than one consecutive dividers */
+.menuList hr + hr {
+    display: none;
+}
+
+.menuItem {
+    background-color: transparent;
+    border-radius: var(--reactist-border-radius-small);
+    border: none;
+    box-sizing: border-box;
+    color: inherit;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    font-family: var(--reactist-font-family);
+    font-size: var(--reactist-font-size-copy);
+    gap: var(--reactist-spacing-small);
+    justify-content: center;
+    margin: 0 6px;
+    max-width: calc(100% - 12px);
+    min-height: 32px;
+    outline: none;
+    padding: 0 6px;
+    text-align: left;
+    user-select: none;
+    width: 100%;
+}
+
+a.menuItem {
+    cursor: pointer;
+    text-decoration: none;
+}
+a.menuItem:hover {
+    text-decoration: none;
+}
+
+.menuItem .legacyLayout {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    justify-content: flex-start;
+    padding: 0 10px;
+}
+
+.menuItem:hover,
+.menuItem:focus,
+.menuItem[aria-expanded='true'] {
+    color: var(--reactist-content-primary);
+    background-color: var(--reactist-bg-highlight);
+}
+
+.menuItem[aria-disabled='true'],
+.menuItem:disabled {
+    opacity: 1;
+    color: var(--reactist-content-secondary) !important;
+    cursor: default;
+}
+
+.menuGroupLabel {
+    align-items: center;
+    background-color: transparent;
+    border: none;
+    color: var(--reactist-content-secondary);
+    display: flex;
+    font-family: var(--reactist-font-family);
+    font-size: var(--reactist-font-size-copy);
+    gap: var(--reactist-spacing-small);
+    outline: none;
+    padding: 5px 10px;
+    text-align: left;
+    user-select: none;
+}
+
+.menuItemIcon {
+    color: var(--product-library-display-secondary-idle-tint);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.menuItemIcon,
+.menuItemIcon img,
+.menuItemIcon svg {
+    width: 24px;
+    height: 24px;
+}
+
+.menuItemIcon img {
+    box-sizing: border-box;
+    padding: 4px;
+}
+
+.menuItemLabel {
+    width: 100%;
+}
+
+.menuItemDescription {
+    white-space: normal;
+}
+
+.destructive,
+.destructive .menuItemLabel,
+.destructive .menuItemIcon {
+    color: var(--reactist-actionable-secondary-destructive-idle-tint) !important;
+}
+
+.destructive:hover,
+.destructive:focus,
+.destructive:hover .menuItemLabel,
+.destructive:focus .menuItemLabel,
+.destructive:hover .menuItemIcon,
+.destructive:focus .menuItemIcon {
+    color: var(--reactist-actionable-secondary-destructive-hover-tint) !important;
+}

--- a/src/menu/menu.stories.mdx
+++ b/src/menu/menu.stories.mdx
@@ -4,7 +4,17 @@ import { Button } from '../button'
 import { Inline } from '../inline'
 import { Stack } from '../stack'
 import { Columns, Column } from '../columns'
-import { ContextMenuTrigger, Menu, MenuButton, MenuList, MenuItem, MenuGroup, SubMenu } from '.'
+import {
+    ContextMenuTrigger,
+    Menu,
+    MenuButton,
+    MenuList,
+    MenuItem,
+    MenuGroup,
+    SubMenu,
+    SubMenuItem,
+    SubMenuList,
+} from './menu'
 import { ButtonLink } from '../button-link'
 import { Text } from '../text'
 import { Box } from '../box'
@@ -85,6 +95,7 @@ via an element or as a context menu.
                 <MenuItem label="Copy" />
                 <MenuItem label="Paste" />
                 <MenuItem label="Duplicate" />
+                <hr />
                 <MenuItem label="Remove" />
             </MenuList>
         </Menu>
@@ -171,16 +182,13 @@ You may nest the `<SubMenu>` component within `<Menu>` to create submenus.
                 <MenuItem label="Check for updates…" />
                 <hr />
                 <SubMenu>
-                    <MenuButton>
-                        Preferences
-                        <ArrowRight />
-                    </MenuButton>
-                    <MenuList>
+                    <SubMenuItem label="Preferences" />
+                    <SubMenuList>
                         <MenuItem label="Settings" />
                         <MenuItem label="Extensions" />
                         <hr />
                         <MenuItem label="Notifications" />
-                    </MenuList>
+                    </SubMenuList>
                 </SubMenu>
             </MenuList>
         </Menu>

--- a/src/styles/design-tokens.css
+++ b/src/styles/design-tokens.css
@@ -61,9 +61,10 @@
     --reactist-bg-default: rgb(255, 255, 255);
     --reactist-bg-brand: rgb(36, 111, 224);
     --reactist-bg-aside: rgb(250, 250, 250);
-    --reactist-bg-highlight: rgb(242, 242, 242);
+    --reactist-bg-highlight: rgb(238, 238, 238);
     --reactist-bg-selected: rgb(230, 230, 230);
     --reactist-bg-toast: rgb(40, 40, 40);
+    --reactist-bg-raised: rgb(255, 255, 255);
 
     /* colors */
     --reactist-framework-fill-background: rgb(250, 250, 250);


### PR DESCRIPTION
## Short description

This brings in from Todoist the CSS styles we use for menus in Todoist and Twist.

Up until now, we've had the menus in Reactist styles in more basic ways, and dealt with the style changes as CSS overrides in the app code. This PR now makes Reactist provide the menu styling, as Reactist does for all its other components.

### New sub-menu components

Additionally, this introduces two new menu components: `SubMenuItem` and `SubMenuList`. This was necessary for a few reasons:

1. These had specific styling needs that could not be addressed in the way we used to do sub-menus. The app was dealing with this in an ad-hoc way, but to achieve the library providing it, we needed the dedicated components.
2. In the specific case of `SubMenuItem`, we needed it because we needed a component that acted as a sub-menu button, but with an interface and styling closer to that of the `MenuItem`.
3. In the specific case of the `SubMenuList`, it needs a tiny but important dedicated CSS rule to have it be aligned with the sub menu item that triggered the sub-menu (see screenshot below, including the added orange lines to show what I'm alignment this is about):
    ![CleanShot 2023-07-07 at 14 30 57@2x](https://github.com/Doist/reactist/assets/15199/3d10f0f9-5b01-40b9-afd2-cef682379154)

## Test plan (IMPORTANT)

Even though this is not going to be released after merging (see note in the "Versioning" section below) it is very important that you help me validate that this is good to go to use in the apps.

I'll assign as reviewer in Todoist the same reviewer as this PR, so that you can execute the test plan I'll put over there.

## PR Checklist

-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`

## Versioning

> **Note**
> This PR's base branch is not `main`. So approving this does not yet mean it will be released right away. I'm planning a series of improvements to the menu component, that I'll gather in this base branch before I make a single release (or a handful of releases). This will allow me to test the changes with Todoist before comitting Reactist to the new features.