### PR TITLE
chore: Fix links to Reactist components in storybook stories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# v21.2.1
+
+-   [Chore] Fix links to Reactist components in storybook stories.
+
 # v21.2.0
 
 -   [Feat] `Textfield`, `PasswordField`, `SelectField`, and `TextArea` will now use two new CSS variables to define their border colors: `--reactist-inputs-focus`, `--reactist-inputs-idle`. If they were previously set using `--reactist-divider-primary` and `--reactist-divider-secondary`, they will continue to work as well.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Reactist follows [semantic versioning](https://semver.org/) and doesn't introduc
 
 # v21.2.1
 
--   [Chore] Fix links to Reactist components in storybook stories.
+-   [Docs] Fix links to Reactist components in storybook stories.
 
 # v21.2.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "21.2.0",
+    "version": "21.2.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "21.2.0",
+            "version": "21.2.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "21.2.0",
+    "version": "21.2.1",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/stories/components/Dropdown.stories.tsx
+++ b/stories/components/Dropdown.stories.tsx
@@ -19,7 +19,7 @@ export const DropdownStory = () => (
         <Stack as="section" exceptionallySetClassName="story" space="large">
             <Alert tone="critical">
                 <strong>Deprecated:</strong> While not a 1:1 replacement, consider using{' '}
-                <a href="/?path=/docs/components-menu">Menu</a> as an alternative
+                <a href="reactist/?path=/docs/components-menu">Menu</a> as an alternative
             </Alert>
 
             <Dropdown.Box>

--- a/stories/components/Dropdown.stories.tsx
+++ b/stories/components/Dropdown.stories.tsx
@@ -19,7 +19,8 @@ export const DropdownStory = () => (
         <Stack as="section" exceptionallySetClassName="story" space="large">
             <Alert tone="critical">
                 <strong>Deprecated:</strong> While not a 1:1 replacement, consider using{' '}
-                <a href="reactist/?path=/docs/components-menu">Menu</a> as an alternative
+                <a href={`${window.location.origin}?path=/docs/components-menu`}>Menu</a> as an
+                alternative
             </Alert>
 
             <Dropdown.Box>

--- a/stories/components/Input.stories.tsx
+++ b/stories/components/Input.stories.tsx
@@ -21,7 +21,10 @@ export const InputStory = () => (
         <div className="story-info">
             <Alert tone="critical">
                 <strong>Deprecated:</strong> Please use{' '}
-                <a href="reactist/?path=/docs/design-system-textfield">TextField</a> instead
+                <a href={`${window.location.origin}?path=/docs/design-system-textfield`}>
+                    TextField
+                </a>{' '}
+                instead
             </Alert>
             <p>
                 This component is a dumb wrapper around the

--- a/stories/components/Input.stories.tsx
+++ b/stories/components/Input.stories.tsx
@@ -21,7 +21,7 @@ export const InputStory = () => (
         <div className="story-info">
             <Alert tone="critical">
                 <strong>Deprecated:</strong> Please use{' '}
-                <a href="/?path=/docs/design-system-textfield">TextField</a> instead
+                <a href="reactist/?path=/docs/design-system-textfield">TextField</a> instead
             </Alert>
             <p>
                 This component is a dumb wrapper around the

--- a/stories/components/Select.stories.tsx
+++ b/stories/components/Select.stories.tsx
@@ -32,7 +32,10 @@ export function SelectStory() {
         <Stack as="section" exceptionallySetClassName="story" space="large">
             <Alert tone="critical">
                 <strong>Deprecated:</strong> Please use{' '}
-                <a href="reactist/?path=/docs/design-system-selectfield">SelectField</a> instead
+                <a href={`${window.location.origin}?path=/docs/design-system-selectfield`}>
+                    SelectField
+                </a>{' '}
+                instead
             </Alert>
 
             <Select value={value} options={options} onChange={setValue} />

--- a/stories/components/Select.stories.tsx
+++ b/stories/components/Select.stories.tsx
@@ -32,7 +32,7 @@ export function SelectStory() {
         <Stack as="section" exceptionallySetClassName="story" space="large">
             <Alert tone="critical">
                 <strong>Deprecated:</strong> Please use{' '}
-                <a href="/?path=/docs/design-system-selectfield">SelectField</a> instead
+                <a href="reactist/?path=/docs/design-system-selectfield">SelectField</a> instead
             </Alert>
 
             <Select value={value} options={options} onChange={setValue} />


### PR DESCRIPTION
## Short description

While browsing a couple of Reactist storybook stories, I've noticed that there are some broken links that don't include the path "reactist":

https://github.com/Doist/reactist/assets/1509326/26b1d8cf-3c44-41c7-97aa-b26bcb4fa96e

This PR should fix those links so that do include the correct path and therefore lead the viewer to the right place. 

## PR Checklist

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Bumped patch.