### PR TITLE
chore: Fix links to Reactist components in storybook stories using LinkTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# v21.2.2
+
+-   [Docs] Fix links to Reactist components in storybook stories.
+
 # v21.2.1
 
 -   [Docs] Fix links to Reactist components in storybook stories.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "21.2.1",
+    "version": "21.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "21.2.1",
+            "version": "21.2.2",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "21.2.1",
+    "version": "21.2.2",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/stories/components/Dropdown.stories.tsx
+++ b/stories/components/Dropdown.stories.tsx
@@ -4,6 +4,7 @@ import Button from '../../src/components/deprecated-button'
 import Dropdown from '../../src/components/deprecated-dropdown'
 import { Alert } from '../../src/alert'
 import { Stack } from '../../src/stack'
+import LinkTo from '@storybook/addon-links/react'
 
 export default {
     title: 'Components/Dropdown',
@@ -19,8 +20,7 @@ export const DropdownStory = () => (
         <Stack as="section" exceptionallySetClassName="story" space="large">
             <Alert tone="critical">
                 <strong>Deprecated:</strong> While not a 1:1 replacement, consider using{' '}
-                <a href={`${window.location.origin}?path=/docs/components-menu`}>Menu</a> as an
-                alternative
+                <LinkTo kind="design-system-menu">Menu</LinkTo> as an alternative
             </Alert>
 
             <Dropdown.Box>

--- a/stories/components/Input.stories.tsx
+++ b/stories/components/Input.stories.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import Input from '../../src/components/deprecated-input'
 import { Alert } from '../../src/alert'
 import './styles/input_story.less'
+import LinkTo from '@storybook/addon-links/react'
 
 // Story setup ================================================================
 
@@ -21,10 +22,7 @@ export const InputStory = () => (
         <div className="story-info">
             <Alert tone="critical">
                 <strong>Deprecated:</strong> Please use{' '}
-                <a href={`${window.location.origin}?path=/docs/design-system-textfield`}>
-                    TextField
-                </a>{' '}
-                instead
+                <LinkTo kind="design-system-textfield">TextField</LinkTo> instead
             </Alert>
             <p>
                 This component is a dumb wrapper around the

--- a/stories/components/Select.stories.tsx
+++ b/stories/components/Select.stories.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import Select from '../../src/components/deprecated-select'
 import { Alert } from '../../src/alert'
 import { Stack } from '../../src/stack'
+import LinkTo from '@storybook/addon-links/react'
 
 const options = [
     { value: 'intro', text: 'Select a fruit', disabled: true },
@@ -32,10 +33,7 @@ export function SelectStory() {
         <Stack as="section" exceptionallySetClassName="story" space="large">
             <Alert tone="critical">
                 <strong>Deprecated:</strong> Please use{' '}
-                <a href={`${window.location.origin}?path=/docs/design-system-selectfield`}>
-                    SelectField
-                </a>{' '}
-                instead
+                <LinkTo kind="design-system-selectfield">SelectField</LinkTo> instead
             </Alert>
 
             <Select value={value} options={options} onChange={setValue} />


### PR DESCRIPTION
## Short description

Follow-up to https://github.com/Doist/reactist/pull/794 where I tried to fix a couple of broken links in our storybook stories.

> While browsing a couple of Reactist storybook stories, I've noticed that there are some broken links that don't include the path "reactist":
> 
> https://github.com/Doist/reactist/assets/1509326/26b1d8cf-3c44-41c7-97aa-b26bcb4fa96e

It turns out I didn't actually fix anything at all as the links are still missing the appropriate `/reactist` path which it seems not to be included in `window.location.origin` 😅

In this PR, I initially tried to address this by concatenating `window.location.origin` with `window.location.pathname` to (hopefully) get the correct Reactist URL path. However, that doesn't work either, because `pathname` will include `/iframe.html` as well (since the link is inside an iframe) so what I'm doing in this PR doesn't work either. To be fair, even if the concatenation had worked, it would not have looked great in our code 😅

I changed my approach to actually use the official Reactist add-on that "should" be used to link from a story to another story: https://storybook.js.org/addons/@storybook/addon-links (https://github.com/storybookjs/storybook/issues/8618) and hopefully that will do the trick (for real, this time).

This seems to be working well when testing on the storybook dev version deployed via Chromatic (linked in the builds below) 

https://github.com/Doist/reactist/assets/1509326/018d7b54-7431-4f70-9779-c8fc279bc2c0

...so I have hopes it will work when it gets deployed to https://doist.github.io/reactist/

## PR Checklist

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Bumped patch. This is just a doc change.