### PR TITLE
fix horizontal expansion of textarea with autoexpand={true}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# v21.2.3
+
+-   [Fix] `overflow-wrap: anywhere` is added to stop unnecessary horizontal expansion of `TextArea` when `autoExpand={true}`.
+
 # v21.2.2
 
 -   [Docs] Fix links to Reactist components in storybook stories.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "21.2.2",
+    "version": "21.2.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "21.2.2",
+            "version": "21.2.3",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "21.2.2",
+    "version": "21.2.3",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/text-area/text-area.module.css
+++ b/src/text-area/text-area.module.css
@@ -27,6 +27,7 @@ See https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
     font: inherit;
     width: 100%;
     resize: vertical;
+    overflow-wrap: anywhere; /* to stop unnecessary horizontal expansion of text-area when `autoExpand` is enabled.*/
 }
 
 .textAreaContainer:not(.bordered) .innerContainer::after,


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Closes #776 

## Short description

`overflow-wrap: anywhere` is added to stop the horizontal expansion of `TextArea` with `autoExpand={true}`.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors/warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

It's a bug fix.
