### PR TITLE
feat: add an option for a custom className for toasts container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# v21.3.0
+
+-   [Feat] `ToastProvider` accepts an optional `containerClassName` property, which let's you to add your own class for the container of all toasts.
+
 # v21.2.3
 
 -   [Fix] Prevent horizontal expansion of `TextArea` with `autoExpand={true}`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "21.2.3",
+    "version": "21.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "21.2.3",
+            "version": "21.3.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "21.2.3",
+    "version": "21.3.0",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/toast/toast.test.tsx
+++ b/src/toast/toast.test.tsx
@@ -47,6 +47,17 @@ describe('useToast', () => {
         }
     }
 
+    describe('ToastsProvider', () => {
+        it('allows to pass a custom className for the container', () => {
+            const { showToast } = renderTestCase({
+                containerClassName: 'customContainerClassName',
+            })
+            showToast()
+
+            expect(screen.getByTestId('toasts-container')).toHaveClass('customContainerClassName')
+        })
+    })
+
     it('renders a semantic alert with the given message', () => {
         const { showToast } = renderTestCase()
         showToast({ message: 'Project has been published' })

--- a/src/toast/use-toasts.tsx
+++ b/src/toast/use-toasts.tsx
@@ -186,6 +186,11 @@ type ToastsProviderProps = {
      * The app wrapped by the provider.
      */
     children: NonNullable<React.ReactNode>
+
+    /**
+     * Custom classname for the toasts container, if you need to fine-tune the position or other styles
+     */
+    containerClassName?: string
 }
 
 /**
@@ -200,6 +205,7 @@ function ToastsProvider({
     padding = 'large',
     defaultAutoDismissDelay = 10 /* seconds */,
     defaultDismissLabel = 'Close',
+    containerClassName,
 }: ToastsProviderProps) {
     const [toasts, setToasts] = React.useState<ToastsList>([])
     const { mappedRef, animateRemove } = useToastsAnimation()
@@ -240,11 +246,12 @@ function ToastsProvider({
             <Portal>
                 {toasts.length === 0 ? null : (
                     <Box
-                        className={styles.stackedToastsView}
+                        className={[styles.stackedToastsView, containerClassName]}
                         position="fixed"
                         width="full"
                         paddingX={padding}
                         paddingBottom={padding}
+                        data-testid="toasts-container"
                     >
                         <Stack space="medium">
                             {toasts.map(({ toastId, ...props }) => (


### PR DESCRIPTION
## Short description

Allow to provide a custom classname for toasts container.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)

## Versioning

This is a new feature, so a minor version update.
