### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Prepare Node.js environment
         uses: actions/setup-node@v3

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Read Node.js version from '.nvmrc'
         id: nvmrc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         # Based on historical data
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v4
             - name: Read Node.js version from '.nvmrc'
               id: nvmrc
               run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
         # Based on historical data
         timeout-minutes: 15
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v4
             - name: Read Node.js version from '.nvmrc'
               id: nvmrc
               run: |


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
