### PR TITLE
chore: add support for Node v21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# v22.3.0
+
+-   [Build] Add support for Node v21
+
 # v22.2.0
 
 -   [Feat] The `Alert` component now has a new design. Input based components will now also expose a `--reactist-inputs-alert` CSS variable to customize their border colours when put into an error state

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "22.2.0",
+    "version": "22.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "22.2.0",
+            "version": "22.3.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -110,7 +110,7 @@
                 "webpack": "^4.43.0"
             },
             "engines": {
-                "node": "^16.0.0 || ^18.0.0 || ^20.0.0",
+                "node": "^16.0.0 || ^18.0.0 || ^20.0.0 || ^21.0.0",
                 "npm": "^8.3.0 || ^9.0.0 || ^10.0.0"
             },
             "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "22.2.0",
+    "version": "22.3.0",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {
@@ -28,7 +28,7 @@
         "styles"
     ],
     "engines": {
-        "node": "^16.0.0 || ^18.0.0 || ^20.0.0",
+        "node": "^16.0.0 || ^18.0.0 || ^20.0.0 || ^21.0.0",
         "npm": "^8.3.0 || ^9.0.0 || ^10.0.0"
     },
     "scripts": {


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->



## Short description

Adds support for Node v21.

Eventually it would be a good idea to remove support for legacy versions, like v16, but not doing that in this PR.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->

Requires a minor version bump.
