### PR TITLE
chore: increase show tooltip delay to 1 second

### DIFF
--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -77,7 +77,7 @@ type TooltipProps = {
 }
 
 // These are exported to be used in the tests, they are not meant to be exported publicly
-export const SHOW_DELAY = 500
+export const SHOW_DELAY = 1000
 export const HIDE_DELAY = 100
 
 function useDelayedTooltipState(initialState: AriakitTooltipStateProps) {


### PR DESCRIPTION
## Short description

Increase tooltip show delay to 1 second

## PR Checklist

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Executed `npm run validate` and made sure no errors / warnings were shown
-   [ ] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

This is a patch change.