### PR TITLE
fix: Prevent badge text from wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# v22.3.2
+
+-   [Fix] Text inside a `Badge` no longer wraps into multiple lines.
+
 # v22.3.1
 
 -   [Tweak] Increase showing tooltip delay to 1 second from 500ms

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "22.3.1",
+    "version": "22.3.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "22.3.1",
+            "version": "22.3.2",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "22.3.1",
+    "version": "22.3.2",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/badge/badge.module.css
+++ b/src/badge/badge.module.css
@@ -25,6 +25,7 @@
     color: var(--reactist-badge-tint);
     background-color: var(--reactist-badge-fill);
     line-height: calc(var(--reactist-badge-font-size) + 3px);
+    white-space: nowrap;
 }
 
 .badge-info {


### PR DESCRIPTION
## Short description

Text inside a `Badge` should never wrap into multiple lines.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features (N/A)
-   [ ] Updated docs (storybooks, readme) (N/A)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

New patch release.
