### PR TITLE
fix: Vertical alignment of inline code inside a `Prose` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# v22.3.3
+
+-   [Fix] Vertical alignment of inline code elements inside a `Prose` component
+
 # v22.3.2
 
 -   [Fix] Text inside a `Badge` no longer wraps into multiple lines.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "22.3.2",
+    "version": "22.3.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "22.3.2",
+            "version": "22.3.3",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "22.3.2",
+    "version": "22.3.3",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/prose/prose.module.css
+++ b/src/prose/prose.module.css
@@ -198,7 +198,6 @@
 
 .prose :not(pre) > code {
     padding: 2px 4px;
-    vertical-align: text-top;
 }
 
 .prose pre {


### PR DESCRIPTION
## Short description

Removes the `vertical-align: text-top` style from inline code elements inside a `Prose` component.

## Long description

The style `vertical-align` top is not needed. It causes an almost imperceptible misalignment in most browsers:

<details><summary>Screen recording</summary>
<p>

![CleanShot 2024-01-05 at 12 41 41](https://github.com/Doist/reactist/assets/15199/c62e125b-2705-413f-b363-c86ef3fdda35)

</p>
</details> 

But what's worse, in some situation (e.g. a certain Firefox version in Linux, or perhaps any Firefox in Linux), it does this, which is much more extreme:

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/Doist/reactist/assets/15199/995b902e-98c4-4d69-bbee-e095e9ffe5c7)

</p>
</details> 

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features (N/A)
-   [ ] Updated docs (storybooks, readme) (N/A)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Patch release
