### PR TITLE
revert: Modal alignment to middle at breakpoint adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# v23.2.2
+
+-   [Fix] Revert "Adjust modal alignment to the middle of the viewport at `800px` breakpoint for improved UX". Turns out that this is not something that we want to do.
+
 # v23.2.1
 
 -   [Fix] Adjust modal alignment to the middle of the viewport at `800px` breakpoint for improved UX.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "23.2.1",
+    "version": "23.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "23.2.1",
+            "version": "23.2.2",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "23.2.1",
+    "version": "23.2.2",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/modal/modal.module.css
+++ b/src/modal/modal.module.css
@@ -43,6 +43,9 @@
 .overlay.fitContent > [data-focus-lock-disabled] {
     padding-top: var(--reactist-modal-padding-top);
 }
+.overlay.fitContent > [data-focus-lock-disabled] .container {
+    max-height: calc(100vh - 2 * var(--reactist-modal-padding-top));
+}
 
 .container {
     box-shadow: 0px 2px 8px 0px rgba(0, 0, 0, 0.16);
@@ -112,19 +115,6 @@
     .overlay.expand .container {
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
-    }
-}
-
-@media (min-height: 800px) {
-    .overlay.fitContent > [data-focus-lock-disabled] .container {
-        max-height: calc(100vh - 2 * var(--reactist-modal-padding-top));
-    }
-}
-
-@media (max-height: 800px) {
-    .overlay.fitContent > [data-focus-lock-disabled] {
-        padding-top: var(--reactist-spacing-xxlarge);
-        justify-content: center;
     }
 }
 


### PR DESCRIPTION
## Short description

This reverts https://github.com/Doist/reactist/pull/821 because it turns out that this is not something that we want to do.

## PR Checklist

-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [x] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Patch