### PR TITLE
chore: Fix version number in `package-lock.json` file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "24.1.4",
+            "version": "24.1.5-beta",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
## Short description

A follow-up to https://github.com/Doist/reactist/pull/824 to fix the version number in the `package-lock.json` file.