### PR TITLE
chore: Sample story to repro Tooltip not working when wrapping Tab component

### DIFF
--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -3,6 +3,7 @@ import { Tabs, TabList, Tab, TabPanel, TabAwareSlot } from './tabs'
 import { Box } from '../box'
 import { Text } from '../text'
 import { Columns, Column } from '../columns'
+import { Tooltip } from '../tooltip'
 
 <Meta
     title="Design system/Tabs"
@@ -287,6 +288,44 @@ Note that when combined with the `renderMode="active"` prop, the entire tabpanel
                 <Column>Column 1</Column>
                 <Column>Column 2</Column>
                 <Column>Column 3</Column>
+            </TabPanel>
+        </Tabs>
+    </Story>
+</Canvas>
+
+### Wrapped by Tooltip component
+
+This is just a sample story to show you that Tooltip outside Tab does not work, but Tooltip inside Tab works.
+
+<Canvas withToolbar>
+    <Story parameters={{ docs: { source: { type: 'code' } } }} name="Wrapped by Tooltip component">
+        <Tabs>
+            <TabList aria-label="Multiple tablist example tabs">
+                <Tooltip content={'Tooltip for Tab 1'}>
+                    <Tab id="tab1">
+                        <Box>Tab 1</Box>
+                    </Tab>
+                </Tooltip>
+
+                <Tab id="tab2">
+                    <Tooltip content={'Tooltip for Tab 2'}>
+                        <Box>Tab 2</Box>
+                    </Tooltip>
+                </Tab>
+            </TabList>
+            <TabPanel
+                id="tab1"
+                renderMode="active"
+                render={<Box paddingX="small" paddingY="xlarge" />}
+            >
+                <Text>Content of tab 1</Text>
+            </TabPanel>
+            <TabPanel
+                id="tab2"
+                renderMode="active"
+                render={<Box paddingX="small" paddingY="xlarge" />}
+            >
+                <Text>Content of tab 2</Text>
             </TabPanel>
         </Tabs>
     </Story>

--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -301,31 +301,26 @@ This is just a sample story to show you that Tooltip outside Tab does not work, 
     <Story parameters={{ docs: { source: { type: 'code' } } }} name="Wrapped by Tooltip component">
         <Tabs>
             <TabList aria-label="Multiple tablist example tabs">
-                <Tooltip content={'Tooltip for Tab 1'}>
+                <Tooltip content="Tooltip outside Tab">
                     <Tab id="tab1">
                         <Box>Tab 1</Box>
                     </Tab>
                 </Tooltip>
-
                 <Tab id="tab2">
-                    <Tooltip content={'Tooltip for Tab 2'}>
+                    <Tooltip content="Tooltip inside Tab">
                         <Box>Tab 2</Box>
                     </Tooltip>
                 </Tab>
             </TabList>
-            <TabPanel
-                id="tab1"
-                renderMode="active"
-                render={<Box paddingX="small" paddingY="xlarge" />}
-            >
-                <Text>Content of tab 1</Text>
+            <TabPanel id="tab1">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 1</Text>
+                </Box>
             </TabPanel>
-            <TabPanel
-                id="tab2"
-                renderMode="active"
-                render={<Box paddingX="small" paddingY="xlarge" />}
-            >
-                <Text>Content of tab 2</Text>
+            <TabPanel id="tab2">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 2</Text>
+                </Box>
             </TabPanel>
         </Tabs>
     </Story>

--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -300,7 +300,7 @@ This is just a sample story to show you that Tooltip outside Tab does not work, 
 <Canvas withToolbar>
     <Story parameters={{ docs: { source: { type: 'code' } } }} name="Wrapped by Tooltip component">
         <Tabs>
-            <TabList aria-label="Multiple tablist example tabs">
+            <TabList aria-label="Wrapped by Tooltip component">
                 <Tooltip content="Tooltip outside Tab">
                     <Tab id="tab1">
                         <Box>Tab 1</Box>


### PR DESCRIPTION
DO NOT MERGE

Just a sample story to repro the issue described in https://github.com/Doist/reactist/issues/834

See Storybook Publish > Details > Tabs > "Wrapped by Tooltip component" story (last story)