### PR TITLE
chore: Sample story to show that Tooltip worked both inside and outside Tab component

### DIFF
--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -3,6 +3,7 @@ import { Tabs, TabList, Tab, TabPanel, TabAwareSlot } from './tabs'
 import { Box } from '../box'
 import { Text } from '../text'
 import { Columns, Column } from '../columns'
+import { Tooltip } from '../tooltip'
 
 <Meta
     title="Design system/Tabs"
@@ -291,7 +292,7 @@ This is just a sample story to show you that Tooltip works both outside and insi
 <Canvas withToolbar>
     <Story parameters={{ docs: { source: { type: 'code' } } }} name="Wrapped by Tooltip component">
         <Tabs>
-            <TabList aria-label="Multiple tablist example tabs">
+            <TabList aria-label="Wrapped by Tooltip component">
                 <Tooltip content="Tooltip outside Tab">
                     <Tab id="tab1">
                         <Box>Tab 1</Box>

--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -283,3 +283,36 @@ Note that when combined with the `render="active"` prop, the entire tabpanel wil
         </Tabs>
     </Story>
 </Canvas>
+
+### Wrapped by Tooltip component
+
+This is just a sample story to show you that Tooltip works both outside and inside Tab.
+
+<Canvas withToolbar>
+    <Story parameters={{ docs: { source: { type: 'code' } } }} name="Wrapped by Tooltip component">
+        <Tabs>
+            <TabList aria-label="Multiple tablist example tabs">
+                <Tooltip content="Tooltip outside Tab">
+                    <Tab id="tab1">
+                        <Box>Tab 1</Box>
+                    </Tab>
+                </Tooltip>
+                <Tab id="tab2">
+                    <Tooltip content="Tooltip inside Tab">
+                        <Box>Tab 2</Box>
+                    </Tooltip>
+                </Tab>
+            </TabList>
+            <TabPanel id="tab1">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 1</Text>
+                </Box>
+            </TabPanel>
+            <TabPanel id="tab2">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 2</Text>
+                </Box>
+            </TabPanel>
+        </Tabs>
+    </Story>
+</Canvas>


### PR DESCRIPTION
DO NOT MERGE

Just a sample story to repro that the issue described in https://github.com/Doist/reactist/issues/834 doesn't happen on `main`.

See Storybook Publish > Details > Tabs > "Wrapped by Tooltip component" story (last story)