### PR TITLE
fix: Disable cross-frame focus lock in `<Modal>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# v25.1.1
+
+-   [Fix] Restrict focus locking in the `Modal` component to its containing document/iframe.
+
 # v25.1.0
 
 -   [Feat] Add `xsmall` size to the `Modal` component

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "25.1.0",
+    "version": "25.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "25.1.0",
+            "version": "25.1.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "25.1.0",
+    "version": "25.1.1",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/modal/modal.tsx
+++ b/src/modal/modal.tsx
@@ -247,7 +247,12 @@ export function Modal({
                 onPointerDown={hideOnInteractOutside ? handleBackdropClick : undefined}
                 ref={backdropRef}
             >
-                <FocusLock autoFocus={autoFocus} whiteList={isNotInternalFrame} returnFocus={true}>
+                <FocusLock
+                    autoFocus={autoFocus}
+                    whiteList={isNotInternalFrame}
+                    returnFocus={true}
+                    crossFrame={false}
+                >
                     <Dialog
                         {...props}
                         ref={dialogRef}


### PR DESCRIPTION
## Short description

When using `<Modal>` in a Storybook story, controls would stop working. This was determined to be caused by the `<FocusLock>` component, which would prevent interaction with Storybooks preview/add-ons pane once focus was established within the modal (which would happen automatically as `autoFocus` defaults to `true`). To fix this, we're limiting `<FocusLock>`'s focus trap to the document/iframe the Modal is contained within, preventing it from bleeding over into Storybook's preview pane.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->
