### PR TITLE
fix: Render submenus at the bottom when there isn't enough space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
-# Next
+# v26.1.0
 
 -   [Feat] Expose `showTimeout` and `hideTimeout` props for `Tooltip`
 -   [Fix] The center alignment between the `Alert` component's icon and message is now more accurate when the message is only one-line long.
+-   [Fix] Render submenus at the bottom when there isn't enough space
 
 # v26.0.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "26.0.0",
+    "version": "26.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "26.0.0",
+            "version": "26.1.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "26.0.0",
+    "version": "26.1.0",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/menu/menu.stories.mdx
+++ b/src/menu/menu.stories.mdx
@@ -126,6 +126,8 @@ be changed by passing `modal={false}` to `<MenuList>`
 
 You may nest the `<SubMenu>` component within `<Menu>` to create submenus.
 
+On smaller viewports where there isn't enough space to render the submenu on the side, it will be rendered under its parent menu item instead.
+
 <Canvas>
     <Story
         name="SubMenu Story"

--- a/src/menu/menu.tsx
+++ b/src/menu/menu.tsx
@@ -34,6 +34,8 @@ const MenuContext = React.createContext<MenuContextState>({
     setAnchorRect: () => undefined,
 })
 
+const SubMenuContext = React.createContext<{ isSubMenu: boolean }>({ isSubMenu: false })
+
 //
 // Menu
 //
@@ -147,13 +149,15 @@ interface MenuListProps
  * The dropdown menu itself, containing a list of menu items.
  */
 const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(function MenuList(
-    { exceptionallySetClassName, modal = true, ...props },
+    { exceptionallySetClassName, modal = true, flip, ...props },
     ref,
 ) {
     const { menuStore, getAnchorRect } = React.useContext(MenuContext)
     if (!menuStore) {
         throw new Error('MenuList must be wrapped in <Menu/>')
     }
+
+    const { isSubMenu } = React.useContext(SubMenuContext)
 
     const isOpen = menuStore.useState('open')
 
@@ -168,6 +172,7 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(function MenuLi
                 className={classNames('reactist_menulist', exceptionallySetClassName)}
                 getAnchorRect={getAnchorRect ?? undefined}
                 modal={modal}
+                flip={flip ?? (isSubMenu ? 'bottom' : undefined)}
             />
         </Portal>
     ) : null
@@ -324,13 +329,14 @@ const SubMenu = React.forwardRef<HTMLDivElement, SubMenuProps>(function SubMenu(
 
     const [button, list] = React.Children.toArray(children)
     const buttonElement = button as React.ReactElement<MenuButtonProps>
+    const subMenuContextValue = React.useMemo(() => ({ isSubMenu: true }), [])
 
     return (
         <Menu onItemSelect={handleSubItemSelect}>
             <AriakitMenuItem store={menuStore} ref={ref} hideOnClick={false} render={buttonElement}>
                 {buttonElement.props.children}
             </AriakitMenuItem>
-            {list}
+            <SubMenuContext.Provider value={subMenuContextValue}>{list}</SubMenuContext.Provider>
         </Menu>
     )
 })


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

## Short description

This makes the `MenuList` component render with `flip="bottom"` as a default when it's a part of a submenu.

This will replace the fixes done in https://github.com/Doist/todoist-web/pull/11835

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/fbd41fc2-588b-4e54-a6c0-d661d1a12928)|![image](https://github.com/user-attachments/assets/340177fb-8ce6-41a1-aee2-b4ee3728c79d)|

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [x] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Patch
