### PR TITLE
feat: Add TooltipContext to set global timeout values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
-# Next
+# 26.2.0
 
 -   [Feat] Add `TooltipContext` to allow `showTimeout` and `hideTimeout` to be set globally
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# Next
+
+-   [Feat] Add `TooltipContext` to allow `showTimeout` and `hideTimeout` to be set globally
+
 # v26.1.0
 
 -   [Feat] Expose `showTimeout` and `hideTimeout` props for `Tooltip`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "26.1.0",
+    "version": "26.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "26.1.0",
+            "version": "26.2.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "26.1.0",
+    "version": "26.2.0",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/tooltip/tooltip.stories.tsx
+++ b/src/tooltip/tooltip.stories.tsx
@@ -66,14 +66,14 @@ function StoryTemplate(props: Omit<TooltipProps, 'children'>) {
 }
 
 //
-// Playground story
+// Playground
 //
 
-export function TooltipPlaygroundStory(args: Omit<TooltipProps, 'children'>) {
+export function TooltipPlayground(args: Omit<TooltipProps, 'children'>) {
     return <StoryTemplate {...args} />
 }
 
-TooltipPlaygroundStory.args = {
+TooltipPlayground.args = {
     content: 'You did it!',
     position: 'top',
     gapSize: 5,
@@ -82,17 +82,17 @@ TooltipPlaygroundStory.args = {
     hideTimeout: 100,
 }
 
-TooltipPlaygroundStory.argTypes = {
+TooltipPlayground.argTypes = {
     position: {
         control: { type: 'select', options: positions },
     },
 }
 
 //
-// Rich content story
+// Rich content
 //
 
-export function TooltipRichContentStory({
+export function TooltipRichContent({
     position,
     gapSize,
     withArrow,
@@ -124,7 +124,7 @@ export function TooltipRichContentStory({
     )
 }
 
-TooltipRichContentStory.args = {
+TooltipRichContent.args = {
     position: 'bottom',
     gapSize: 10,
     withArrow: true,
@@ -132,7 +132,7 @@ TooltipRichContentStory.args = {
     hideTimeout: 100,
 }
 
-TooltipRichContentStory.argTypes = {
+TooltipRichContent.argTypes = {
     position: {
         control: { type: 'select', options: positions },
     },
@@ -141,7 +141,7 @@ TooltipRichContentStory.argTypes = {
 // This story sets a new z-index for the tooltip, but it will leak into other stories
 // when viewed from the Docs page, since all stories live in a single iframe.
 // Only in the Canvas page will stories be isolated from each other
-export function TooltipCustomZIndexStory() {
+export function TooltipCustomZIndex() {
     return (
         <>
             <PortalToHead>

--- a/src/tooltip/tooltip.stories.tsx
+++ b/src/tooltip/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 
-import { Tooltip, TooltipProps } from './tooltip'
+import { Tooltip, TooltipContext, TooltipProps } from './tooltip'
 import { Button } from '../button'
 import { Stack } from '../stack'
 import { TextField } from '../text-field'
@@ -138,9 +138,10 @@ TooltipRichContent.argTypes = {
     },
 }
 
-// This story sets a new z-index for the tooltip, but it will leak into other stories
-// when viewed from the Docs page, since all stories live in a single iframe.
-// Only in the Canvas page will stories be isolated from each other
+//
+// Custom Z Index
+//
+
 export function TooltipCustomZIndex() {
     return (
         <>
@@ -175,4 +176,44 @@ export function TooltipCustomZIndex() {
 
 function PortalToHead({ children }: React.PropsWithChildren<unknown>) {
     return createPortal(children, document.head)
+}
+
+//
+// Tooltip Global Context
+//
+
+export function TooltipGlobalContext({
+    showTimeout,
+    hideTimeout,
+}: Required<Pick<TooltipProps, 'showTimeout' | 'hideTimeout'>>) {
+    const contextValue = React.useMemo(() => ({ showTimeout, hideTimeout }), [
+        showTimeout,
+        hideTimeout,
+    ])
+
+    return (
+        <Stack space="medium">
+            <Text>
+                <code>{'<TooltipContext>'}</code> can be used to provide global settings to all
+                tooltips:
+            </Text>
+
+            <TooltipContext.Provider value={contextValue}>
+                <Box padding="large" display="flex" gap="medium">
+                    <Tooltip content="Click here to begin your journey">
+                        <Button variant="primary">Got it</Button>
+                    </Tooltip>
+
+                    <Tooltip content="Click here to return">
+                        <Button variant="secondary">Cancel</Button>
+                    </Tooltip>
+                </Box>
+            </TooltipContext.Provider>
+        </Stack>
+    )
+}
+
+TooltipGlobalContext.args = {
+    showTimeout: 1000,
+    hideTimeout: 2000,
 }

--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -13,6 +13,16 @@ import type { TooltipStoreState } from '@ariakit/react'
 import styles from './tooltip.module.css'
 import type { ObfuscatedClassName } from '../utils/common-types'
 
+type TooltipContextState = {
+    showTimeout: number
+    hideTimeout: number
+}
+
+const TooltipContext = React.createContext<TooltipContextState>({
+    showTimeout: 500,
+    hideTimeout: 100,
+})
+
 interface TooltipProps extends ObfuscatedClassName {
     /**
      * The element that triggers the tooltip. Generally a button or link.
@@ -69,12 +79,14 @@ interface TooltipProps extends ObfuscatedClassName {
 
     /**
      * The amount of time in milliseconds to wait before showing the tooltip
+     * Use `<TooltipContext.Provider>` to set a global value for all tooltips
      * @default 500
      */
     showTimeout?: number
 
     /**
      * The amount of time in milliseconds to wait before hiding the tooltip
+     * Use `<TooltipContext.Provider>` to set a global value for all tooltips
      * @default 100
      */
     hideTimeout?: number
@@ -86,11 +98,18 @@ function Tooltip({
     position = 'top',
     gapSize = 3,
     withArrow = false,
-    showTimeout = 500,
-    hideTimeout = 100,
+    showTimeout,
+    hideTimeout,
     exceptionallySetClassName,
 }: TooltipProps) {
-    const tooltip = useTooltipStore({ placement: position, showTimeout, hideTimeout })
+    const { showTimeout: globalShowTimeout, hideTimeout: globalHideTimeout } = React.useContext(
+        TooltipContext,
+    )
+    const tooltip = useTooltipStore({
+        placement: position,
+        showTimeout: showTimeout ?? globalShowTimeout,
+        hideTimeout: hideTimeout ?? globalHideTimeout,
+    })
     const isOpen = tooltip.useState('open')
 
     const child = React.Children.only(
@@ -135,4 +154,4 @@ function Tooltip({
 }
 
 export type { TooltipProps }
-export { Tooltip }
+export { Tooltip, TooltipContext }


### PR DESCRIPTION

## Short description

Back in https://github.com/Doist/reactist/pull/845, I exposed Ariakit's `showTimeout` and `hideTimeout` props to `Tooltip` to allow for customization, but it wasn't until I went to integrate it did I realize my mistake - we don't want to have to set this on every single tooltip instance 🥲 So we are adding a provider in order to be able to define these values just once in the app.

Ref: https://github.com/Doist/Issues/issues/15139

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Minor
