### PR TITLE
fix: Export TooltipProvider as a component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# 26.2.1
+
+-   [Fix] Export `TooltipProvider` as a component
+
 # 26.2.0
 
 -   [Feat] Add `TooltipContext` to allow `showTimeout` and `hideTimeout` to be set globally

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "26.2.0",
+    "version": "26.2.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "26.2.0",
+            "version": "26.2.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "26.2.0",
+    "version": "26.2.1",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/tooltip/index.ts
+++ b/src/tooltip/index.ts
@@ -1,2 +1,2 @@
-export { Tooltip } from './tooltip'
+export { Tooltip, TooltipProvider } from './tooltip'
 export type { TooltipProps } from './tooltip'

--- a/src/tooltip/tooltip.stories.tsx
+++ b/src/tooltip/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 
-import { Tooltip, TooltipContext, TooltipProps } from './tooltip'
+import { Tooltip, TooltipProps, TooltipProvider } from './tooltip'
 import { Button } from '../button'
 import { Stack } from '../stack'
 import { TextField } from '../text-field'
@@ -186,11 +186,6 @@ export function TooltipGlobalContext({
     showTimeout,
     hideTimeout,
 }: Required<Pick<TooltipProps, 'showTimeout' | 'hideTimeout'>>) {
-    const contextValue = React.useMemo(() => ({ showTimeout, hideTimeout }), [
-        showTimeout,
-        hideTimeout,
-    ])
-
     return (
         <Stack space="medium">
             <Text>
@@ -198,7 +193,7 @@ export function TooltipGlobalContext({
                 tooltips:
             </Text>
 
-            <TooltipContext.Provider value={contextValue}>
+            <TooltipProvider showTimeout={showTimeout} hideTimeout={hideTimeout}>
                 <Box padding="large" display="flex" gap="medium">
                     <Tooltip content="Click here to begin your journey">
                         <Button variant="primary">Got it</Button>
@@ -208,7 +203,7 @@ export function TooltipGlobalContext({
                         <Button variant="secondary">Cancel</Button>
                     </Tooltip>
                 </Box>
-            </TooltipContext.Provider>
+            </TooltipProvider>
         </Stack>
     )
 }

--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -13,15 +13,30 @@ import type { TooltipStoreState } from '@ariakit/react'
 import styles from './tooltip.module.css'
 import type { ObfuscatedClassName } from '../utils/common-types'
 
+const defaultShowTimeout = 500
+const defaultHideTimeout = 100
+
 type TooltipContextState = {
     showTimeout: number
     hideTimeout: number
 }
 
 const TooltipContext = React.createContext<TooltipContextState>({
-    showTimeout: 500,
-    hideTimeout: 100,
+    showTimeout: defaultShowTimeout,
+    hideTimeout: defaultHideTimeout,
 })
+
+function TooltipProvider({
+    showTimeout = defaultShowTimeout,
+    hideTimeout = defaultHideTimeout,
+    children,
+}: React.PropsWithChildren<{
+    showTimeout?: number
+    hideTimeout?: number
+}>) {
+    const value = React.useMemo(() => ({ showTimeout, hideTimeout }), [showTimeout, hideTimeout])
+    return <TooltipContext.Provider value={value}>{children}</TooltipContext.Provider>
+}
 
 interface TooltipProps extends ObfuscatedClassName {
     /**
@@ -154,4 +169,4 @@ function Tooltip({
 }
 
 export type { TooltipProps }
-export { Tooltip, TooltipContext }
+export { Tooltip, TooltipProvider }


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Follow up to #845 and #846

## Short description

Hopefully, third time's the charm 🥲😥😅 I did not realize these barrel files were crucial to what's exposed from the library until I tried to bring it in-app. Figured I'd take this opportunity to provide a better interface as a component so consumers don't need to memorize the values.

## PR Checklist

<!--
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Patch
