### PR TITLE
fix: Set Tab line-height to 21px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# 26.2.3
+
+-   [Fix] The `Tab` component's line height is now properly set to 21px.
+
 # 26.2.2
 
 -   [Fix] Vertically align the `Notice` component's icon with the first line of text

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "26.2.2",
+    "version": "26.2.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "26.2.2",
+            "version": "26.2.3",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "26.2.2",
+    "version": "26.2.3",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -15,6 +15,7 @@
     --reactist-tab-border-radius: 20px;
     --reactist-tab-border-width: 1px;
     --reactist-tab-height: 30px;
+    --reactist-tab-line-height: 21px;
 }
 
 .tab {
@@ -25,7 +26,7 @@
     cursor: pointer;
     font-size: var(--reactist-font-size-body);
     font-weight: var(--reactist-font-weight-medium);
-    line-height: var(--reactist-tab-height);
+    line-height: var(--reactist-tab-line-height);
     z-index: 1;
     text-decoration: none;
     border: var(--reactist-tab-border-width) solid transparent;


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Part of https://github.com/Doist/Issues/issues/15556

## Short description

Explicitly set the `line-height` of tabs to 21px per design. Otherwise, multi-line tabs (thank you, German) will look off.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [x] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

patch