### PR TITLE
fix: Prefer flipping submenu to left side over to the bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
-# Next
+# 26.2.5
 
 -   [Fix] Add top and bottom paddings to the `Tab` component.
+-   [Fix] `SubMenu` will only render at the bottom when there isn't enough space in either side of the parent menu.
 
 # 26.2.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "26.2.4",
+    "version": "26.2.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "26.2.4",
+            "version": "26.2.5",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "26.2.4",
+    "version": "26.2.5",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/menu/menu.stories.mdx
+++ b/src/menu/menu.stories.mdx
@@ -126,7 +126,7 @@ be changed by passing `modal={false}` to `<MenuList>`
 
 You may nest the `<SubMenu>` component within `<Menu>` to create submenus.
 
-On smaller viewports where there isn't enough space to render the submenu on the side, it will be rendered under its parent menu item instead.
+On smaller viewports where there isn't enough space to render the submenu on either side, it will be rendered under its parent menu item instead.
 
 <Canvas>
     <Story

--- a/src/menu/menu.tsx
+++ b/src/menu/menu.tsx
@@ -172,7 +172,7 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(function MenuLi
                 className={classNames('reactist_menulist', exceptionallySetClassName)}
                 getAnchorRect={getAnchorRect ?? undefined}
                 modal={modal}
-                flip={flip ?? (isSubMenu ? 'bottom' : undefined)}
+                flip={flip ?? (isSubMenu ? 'left bottom' : undefined)}
             />
         </Portal>
     ) : null


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->



## Short description

In https://github.com/Doist/reactist/pull/844, submenus were set up to render on the bottom if there isn't enough space to the right. Visually this doesn't look quite correct when the menu is placed closer to the right side of the screen and that there's space on the left, so having the left side as the first fallback should be preferred.

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/80dadb1c-9cef-42be-a8b0-1c0f7770b50f)|![image](https://github.com/user-attachments/assets/e6810cfa-9b59-4112-bf03-dc2265cdab0e)|

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [x] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Patch
