### PR TITLE
fix: Set correct height for tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# Next
+
+-   [Fix] Add top and bottom paddings to the `Tab` component.
+
 # 26.2.4
 
 -   [Fix] The `Prose` component's horizontal rule color is now properly set to the primary divider color.

--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -14,20 +14,20 @@
     --reactist-tab-track-border-width: 2px;
     --reactist-tab-border-radius: 20px;
     --reactist-tab-border-width: 1px;
-    --reactist-tab-height: 30px;
+    --reactist-tab-padding-x: var(--reactist-spacing-medium);
+    --reactist-tab-padding-y: var(--reactist-spacing-small);
     --reactist-tab-line-height: 21px;
 }
 
 .tab {
     box-sizing: border-box;
-    padding: 0 var(--reactist-spacing-medium);
+    padding: var(--reactist-tab-padding-y) var(--reactist-tab-padding-x);
     border: none;
     background: none;
     cursor: pointer;
     font-size: var(--reactist-font-size-body);
     font-weight: var(--reactist-font-weight-medium);
     line-height: var(--reactist-tab-line-height);
-    min-height: var(--reactist-tab-height);
     z-index: 1;
     text-decoration: none;
     border: var(--reactist-tab-border-width) solid transparent;

--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -27,6 +27,7 @@
     font-size: var(--reactist-font-size-body);
     font-weight: var(--reactist-font-weight-medium);
     line-height: var(--reactist-tab-line-height);
+    min-height: var(--reactist-tab-height);
     z-index: 1;
     text-decoration: none;
     border: var(--reactist-tab-border-width) solid transparent;

--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -146,7 +146,9 @@ Their size can also be customized with:
 --reactist-tab-track-border-width
 --reactist-tab-border-radius
 --reactist-tab-border-width
---reactist-tab-height
+--reactist-tab-padding-x
+--reactist-tab-padding-y
+--reactist-tab-line-height
 ```
 
 ## Stories


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->



## Short description

Following up from https://github.com/Doist/reactist/pull/851, this adds top/bottom paddings to the tabs so that they render at the same height as before the line-height change. Paddings are used over min-height so that they remain consistent even if multiple lines of text are rendered in the tabs.

|Before|After|
|-|-|
|<img width="214" alt="image" src="https://github.com/user-attachments/assets/a0ac82fd-bbc0-407e-a9d8-549dae7b244a" />|<img width="211" alt="image" src="https://github.com/user-attachments/assets/56f8dbaa-c7bd-470a-944e-a914ef0ce848" />|
|<img width="225" alt="image" src="https://github.com/user-attachments/assets/280bc014-a37b-4ef1-b82b-888e05136bc7" />|<img width="231" alt="image" src="https://github.com/user-attachments/assets/1f43cc84-3912-432c-9b05-5fa990035a74" />|


## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [ ] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [x] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

Patch
