### PR TITLE
docs: document maxLength property in TextField component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# 27.0.1
+
+-   [Docs] Document the `maxLength` prop for the `TextField` component.
+
 # 27.0.0
 
 -   [BREAKING] Remove `Alert` component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "27.0.0",
+    "version": "27.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "27.0.0",
+            "version": "27.0.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "27.0.0",
+    "version": "27.0.1",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/base-field/base-field.tsx
+++ b/src/base-field/base-field.tsx
@@ -191,6 +191,13 @@ type BaseFieldProps = WithEnhancedClassName &
         maxWidth?: BoxProps['maxWidth']
 
         /**
+         * The maximum number of characters that the input field can accept.
+         * When this limit is reached, the input field will not accept any more characters.
+         * The counter element will turn red when the number of characters is within 10 of the maximum limit.
+         */
+        maxLength?: number
+
+        /**
          * Used internally by components composed using `BaseField`. It is not exposed as part of
          * the public props of such components.
          */

--- a/src/text-field/text-field.stories.mdx
+++ b/src/text-field/text-field.stories.mdx
@@ -324,3 +324,25 @@ Hence, the description is never needed when the field is not focused anyway.
         <WithTooltipExample />
     </Story>
 </Canvas>
+
+## Max length
+
+The `maxLength` prop is used to limit the number of characters that the user can input. When the user tries to input more characters than the maximum allowed, the field won't accept the input.
+
+export function WithMaxLengthExample() {
+    const [value, setValue] = React.useState('Doist')
+    return (
+        <TextField
+            label="Company name"
+            maxLength={30}
+            value={value}
+            onChange={(event) => setValue(event.currentTarget.value)}
+        />
+    )
+}
+
+<Canvas withToolbar>
+    <Story name="Max Length">
+        <WithMaxLengthExample />
+    </Story>
+</Canvas>

--- a/src/text-field/text-field.tsx
+++ b/src/text-field/text-field.tsx
@@ -13,6 +13,12 @@ interface TextFieldProps
     type?: TextFieldType
     startSlot?: React.ReactElement | string | number
     endSlot?: React.ReactElement | string | number
+    /**
+     * The maximum number of characters that the input field can accept.
+     * When this limit is reached, the input field will not accept any more characters.
+     * The counter element will turn red when the number of characters is within 10 of the maximum limit.
+     */
+    maxLength?: number
 }
 
 const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function TextField(


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

## Short description

Document the `maxLength` property in the TextField component on arguments able and a new story.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->

- [Docs] Document the `maxLength` prop for the `TextField` component.
