### PR TITLE
fix: create documentation for TextLink and adjust style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Reactist follows [semantic versioning](https://semver.org/) and doesn't introduce breaking changes (API-wise) in minor or patch releases. However, the appearance of a component might change in a minor or patch release so keep an eye on redesigns and make sure your app still looks and feels like you expect it.
 
+# 27.2.0
+
+-   [Feat] Document `TextLink` component in Storybook and change default styling.
+
 # 27.1.0
 
 -   [Feat] Expose CSS variables for customizng the icon color of the `Banner` component system types.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/reactist",
-    "version": "27.1.0",
+    "version": "27.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/reactist",
-            "version": "27.1.0",
+            "version": "27.2.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "email": "henning@doist.com",
         "url": "http://doist.com"
     },
-    "version": "27.1.0",
+    "version": "27.2.0",
     "license": "MIT",
     "homepage": "https://github.com/Doist/reactist#readme",
     "repository": {

--- a/src/text-link/text-link.module.css
+++ b/src/text-link/text-link.module.css
@@ -1,7 +1,7 @@
 :root {
-    --reactist-text-link-idle-tint: rgb(36, 111, 224);
-    --reactist-text-link-hover-tint: var(--reactist-text-link-idle-tint);
-    --reactist-text-link-idle-decoration: none;
+    --reactist-text-link-idle-tint: var(--reactist-actionable-tertiary-idle-tint);
+    --reactist-text-link-hover-tint: var(--reactist-actionable-tertiary-hover-tint);
+    --reactist-text-link-idle-decoration: underline;
     --reactist-text-link-hover-decoration: underline;
 }
 

--- a/src/text-link/text-link.stories.mdx
+++ b/src/text-link/text-link.stories.mdx
@@ -26,6 +26,14 @@ A component used to create text-based hyperlinks.
             <TextLink href="https://www.doist.com/" openInNewTab={true}>
                 open in new tab
             </TextLink>
+            <TextLink
+                as="button"
+                onClick={() => {
+                    alert('clicked')
+                }}
+            >
+                button link
+            </TextLink>
         </Stack>
     </Story>
 </Canvas>

--- a/src/text-link/text-link.stories.mdx
+++ b/src/text-link/text-link.stories.mdx
@@ -1,0 +1,35 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
+import { Stack } from '../stack'
+import { TextLink } from './text-link'
+
+<Meta
+    title="Design system/TextLink"
+    component={TextLink}
+    parameters={{
+        badges: ['accessible'],
+    }}
+/>
+
+# TextLink
+
+A component used to create text-based hyperlinks.
+
+<Canvas>
+    <Story
+        name="Main demo"
+        parameters={{
+            docs: { source: { type: 'code' } },
+        }}
+    >
+        <Stack space="medium" align="start">
+            <TextLink href="https://www.doist.com/">regular</TextLink>
+            <TextLink href="https://www.doist.com/" openInNewTab={true}>
+                open in new tab
+            </TextLink>
+        </Stack>
+    </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={TextLink} />

--- a/src/text-link/text-link.test.tsx
+++ b/src/text-link/text-link.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import * as React from 'react'
+import { TextLink } from './text-link'
+
+describe('TextLink', () => {
+    it('renders a link with the provided href', () => {
+        render(<TextLink href="https://example.com">Click me</TextLink>)
+
+        const link = screen.getByText('Click me')
+        expect(link).toHaveAttribute('href', 'https://example.com')
+    })
+
+    it('opens in new tab when openInNewTab is true', () => {
+        render(
+            <TextLink href="https://example.com" openInNewTab>
+                External link
+            </TextLink>,
+        )
+
+        const link = screen.getByText('External link')
+        expect(link).toHaveAttribute('target', '_blank')
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('does not add target or rel attributes when openInNewTab is false', () => {
+        render(
+            <TextLink href="https://example.com" openInNewTab={false}>
+                Internal link
+            </TextLink>,
+        )
+
+        const link = screen.getByText('Internal link')
+        expect(link).not.toHaveAttribute('target')
+        expect(link).not.toHaveAttribute('rel')
+    })
+
+    it('can be rendered as a different element using the as prop', () => {
+        render(
+            <TextLink
+                as="button"
+                onClick={() => {
+                    // noop
+                }}
+            >
+                Button link
+            </TextLink>,
+        )
+
+        const button = screen.getByText('Button link')
+        expect(button.tagName).toBe('BUTTON')
+    })
+
+    it('applies custom className while preserving default styles', () => {
+        render(
+            <TextLink href="#" exceptionallySetClassName="custom-class">
+                Styled link
+            </TextLink>,
+        )
+
+        const link = screen.getByText('Styled link')
+        expect(link).toHaveClass('custom-class')
+        // Verify it still has the default container class
+        expect(link).toHaveClass('container')
+    })
+})


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

## Short description

- Add Storybook documentation for the TextLink component
- Change default styling to use tertiary actionable colors and underline decoration

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Executed `npm run validate` and made sure no errors / warnings were shown
-   [x] Described changes in `CHANGELOG.md`
-   [x] Bumped version in `package.json` and `package-lock.json` (`npm --no-git-tag-version version <major|minor|patch>`) [ref](https://docs.npmjs.com/cli/v6/commands/npm-version)
-   [x] Reviewed and approved Chromatic visual regression tests in CI

## Versioning

<!--
Please state if this is a breaking change, a new feature, a bug fix, or if it
does not require a new version being published at all (e.g. README update, etc.)
-->
