### PR TITLE
ci: change dependabot commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+    - package-ecosystem: npm
+      directory: /
+      interval: daily
+      commit-message:
+          prefix: 'build(deps):'

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,15 +1,10 @@
 {
     "packages": {
         ".": {
-            "changelog-path": "CHANGELOG.md",
-            "release-type": "node",
-            "bump-minor-pre-major": false,
-            "bump-patch-for-minor-pre-major": false,
-            "draft": false,
-            "prerelease": false,
-            "include-component-in-tag": false
+            "changelog-path": "CHANGELOG.md"
         }
     },
+    "include-component-in-tag": false,
     "changelog-sections": [
         {
             "section": "🚀 Features",
@@ -26,14 +21,6 @@
         {
             "section": "🐛 Bug Fixes",
             "type": "perf"
-        },
-        {
-            "section": "⬆️ Dependency updates",
-            "type": "deps"
-        },
-        {
-            "section": "🧰 Maintenance",
-            "type": "chore"
         },
         {
             "section": "🧰 Maintenance",

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,5 @@ jobs:
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   release-type: node
-                  package-name: '@doist/reactist'
                   config-file: .github/release-please-config.json
                   manifest-file: .github/release-please-manifest.json

--- a/README.md
+++ b/README.md
@@ -211,10 +211,16 @@ This project uses [release-please](https://github.com/googleapis/release-please)
 
     - `feat:` for new features (minor version bump)
     - `fix:` for bug fixes (patch version bump)
-    - `feat!:` or `fix!:` for breaking changes (major version bump)
+    - `style:` for code style changes
+    - `perf:` for performance improvements
+    - `refactor:` for refactoring code
+    - `test:` for adding/updating tests
+    - `build:` for build/dependency changes
     - `docs:` for documentation changes
-    - `chore:` for maintenance tasks
     - `ci:` for CI changes
+    - `revert:` for reverting previous commits
+    - `feat!:` or `fix!:` for breaking changes (major version bump)
+    - `chore:` for maintenance tasks (NOTE: these are not included in the changelog)
 
 2. When commits are pushed to `main`:
 


### PR DESCRIPTION
## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

Change dependabot commit prefix to `build(deps)` and exclude `chore` from releases. We need one excluded type for various changes, but mostly for release commits that are something like `chore(release)`, if we consider `chore` in releases and changelog, new commit releases will also be included in the upcoming release.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Updated docs (storybooks, readme)

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
