### PR TITLE
ci: migrate to latest release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
     release-please:
         runs-on: ubuntu-latest
         steps:
-            - uses: google-github-actions/release-please-action@v4
+            - uses: googleapis/release-please-action@v4
               id: release
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

`google-github-actions/release-please-action@v4` is deprecated, as seen in https://github.com/google-github-actions/release-please-action/tree/v4/. This PR migrate to recommended and latest repository https://github.com/googleapis/release-please-action/tree/v4/

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
