### PR TITLE
ci: deploy storybook only when publishing package

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,57 +1,58 @@
 name: Deploy Storybook to Pages
 
 on:
-  push:
-    branches: ["main"]
-  workflow_dispatch:
+    push:
+        tags:
+            - 'v*'
+    workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+    contents: read
+    pages: write
+    id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+    group: 'pages'
+    cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    # Single deploy job since we're just deploying
+    deploy:
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
 
-      - name: Read Node.js version from '.nvmrc'
-        id: nvmrc
-        run: |
-          echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+            - name: Read Node.js version from '.nvmrc'
+              id: nvmrc
+              run: |
+                  echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
-        with:
-            node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
+            - name: Setup Node.js
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
 
-      - name: Install dependencies
-        run: npm ci
+            - name: Install dependencies
+              run: npm ci
 
-      - name: Build storybook
-        run: npm run build:storybook
+            - name: Build storybook
+              run: npm run build:storybook
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
+            - name: Setup Pages
+              uses: actions/configure-pages@v3
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: './docs'
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v1
+              with:
+                  path: './docs'
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

With the introduction of release PRs workflow (https://github.com/Doist/reactist/pull/863), we only want to deploy latest changes to Storybook when publishing new release.
