### PR TITLE
fix(TextField): adjust character count threshold to zero

### DIFF
--- a/src/base-field/base-field.tsx
+++ b/src/base-field/base-field.tsx
@@ -10,6 +10,7 @@ import { Spinner } from '../spinner'
 import { Column, Columns } from '../columns'
 
 // Define the remaining characters before the character count turns red
+// See: https://twist.com/a/1585/ch/765851/t/6664583/c/93631846 for latest spec
 const MAX_LENGTH_THRESHOLD = 0
 
 type FieldTone = 'neutral' | 'success' | 'error' | 'loading'

--- a/src/base-field/base-field.tsx
+++ b/src/base-field/base-field.tsx
@@ -9,7 +9,8 @@ import type { WithEnhancedClassName } from '../utils/common-types'
 import { Spinner } from '../spinner'
 import { Column, Columns } from '../columns'
 
-const MAX_LENGTH_THRESHOLD = 10
+// Define the remaining characters before the character count turns red
+const MAX_LENGTH_THRESHOLD = 0
 
 type FieldTone = 'neutral' | 'success' | 'error' | 'loading'
 


### PR DESCRIPTION
## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

As per new specification ([ref](https://twist.com/a/1585/ch/765851/t/6664583/c/93631846)), this PR changes character count threshold to determine when to set error tone to text field component.

### Demo
**Before:**
![CleanShot 2025-01-28 at 12 52 35@2x](https://github.com/user-attachments/assets/0ffdab52-80fa-4590-a394-2e9c3705358c)

**After:**
![CleanShot 2025-01-28 at 12 52 04@2x](https://github.com/user-attachments/assets/b674fdd9-8635-48ca-89c1-68c9c4c4e698)

![CleanShot 2025-01-28 at 12 51 33@2x](https://github.com/user-attachments/assets/85eca644-da4a-4343-b9c6-3a2eac733b3d)

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
