### PR TITLE
feat(TextField): add support for customizable character count position

### DIFF
--- a/src/base-field/base-field.tsx
+++ b/src/base-field/base-field.tsx
@@ -94,6 +94,7 @@ type ChildrenRenderProps = {
     'aria-describedby'?: string
     'aria-invalid'?: true
     onChange?: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+    characterCountElement?: React.ReactNode | null
 }
 
 type HtmlInputProps<T extends HTMLElement> = React.DetailedHTMLProps<
@@ -118,7 +119,7 @@ type BaseFieldVariantProps = {
     variant?: BaseFieldVariant
 }
 
-type BaseFieldProps = WithEnhancedClassName &
+export type BaseFieldProps = WithEnhancedClassName &
     Pick<HtmlInputProps<HTMLInputElement>, 'id' | 'hidden' | 'maxLength' | 'aria-describedby'> & {
         /**
          * The main label for this field element.
@@ -202,6 +203,14 @@ type BaseFieldProps = WithEnhancedClassName &
          * the public props of such components.
          */
         children: (props: ChildrenRenderProps) => React.ReactNode
+
+        /**
+         * The position of the character count element.
+         * It can be shown below the field or inline with the field.
+         *
+         * @default 'below'
+         */
+        characterCountPosition?: 'below' | 'inline' | 'hidden'
     }
 
 type FieldComponentProps<T extends HTMLElement> = Omit<
@@ -210,6 +219,9 @@ type FieldComponentProps<T extends HTMLElement> = Omit<
 > &
     Omit<HtmlInputProps<T>, 'className' | 'style'>
 
+/**
+ * BaseField is a base component that provides a consistent structure for form fields.
+ */
 function BaseField({
     variant = 'default',
     label,
@@ -224,6 +236,7 @@ function BaseField({
     hidden,
     'aria-describedby': originalAriaDescribedBy,
     id: originalId,
+    characterCountPosition = 'below',
 }: BaseFieldProps & BaseFieldVariantProps & WithEnhancedClassName) {
     const id = useId(originalId)
     const messageId = useId()
@@ -234,6 +247,16 @@ function BaseField({
     const [characterCountTone, setCharacterCountTone] = React.useState<FieldTone>(inputLength.tone)
 
     const ariaDescribedBy = originalAriaDescribedBy ?? (message ? messageId : null)
+
+    /**
+     * Renders the character count element.
+     * If the characterCountPosition value is 'hidden', it returns null.
+     */
+    function renderCharacterCount() {
+        return characterCountPosition !== 'hidden' ? (
+            <FieldCharacterCount tone={characterCountTone}>{characterCount}</FieldCharacterCount>
+        ) : null
+    }
 
     const childrenProps: ChildrenRenderProps = {
         id,
@@ -253,6 +276,8 @@ function BaseField({
             setCharacterCount(inputLength.count)
             setCharacterCountTone(inputLength.tone)
         },
+        // If the character count is inline, we pass it as a prop to the children element so it can be rendered inline
+        characterCountElement: characterCountPosition === 'inline' ? renderCharacterCount() : null,
     }
 
     React.useEffect(
@@ -306,6 +331,7 @@ function BaseField({
                 ) : null}
                 {children(childrenProps)}
             </Box>
+
             {message || characterCount ? (
                 <Columns align="right" space="small" maxWidth={maxWidth}>
                     {message ? (
@@ -315,12 +341,11 @@ function BaseField({
                             </FieldMessage>
                         </Column>
                     ) : null}
-                    {characterCount ? (
-                        <Column width="content">
-                            <FieldCharacterCount tone={characterCountTone}>
-                                {characterCount}
-                            </FieldCharacterCount>
-                        </Column>
+
+                    {/* If the character count is below the field, we render it, if it's inline,
+                        we pass it as a prop to the children element so it can be rendered inline */}
+                    {characterCountPosition === 'below' ? (
+                        <Column width="content">{renderCharacterCount()}</Column>
                     ) : null}
                 </Columns>
             ) : null}

--- a/src/select-field/select-field.tsx
+++ b/src/select-field/select-field.tsx
@@ -3,7 +3,9 @@ import { BaseField, BaseFieldVariantProps, FieldComponentProps } from '../base-f
 import { Box } from '../box'
 import styles from './select-field.module.css'
 
-interface SelectFieldProps extends FieldComponentProps<HTMLSelectElement>, BaseFieldVariantProps {}
+interface SelectFieldProps
+    extends Omit<FieldComponentProps<HTMLSelectElement>, 'maxLength' | 'characterCountPosition'>,
+        BaseFieldVariantProps {}
 
 const SelectField = React.forwardRef<HTMLSelectElement, SelectFieldProps>(function SelectField(
     {

--- a/src/text-field/text-field.module.css
+++ b/src/text-field/text-field.module.css
@@ -74,6 +74,10 @@
     padding: var(--tmp-vertical-padding) var(--reactist-spacing-small);
 }
 
+.slot {
+    align-items: center;
+}
+
 .slot button {
     --reactist-btn-height: 24px !important;
 }

--- a/src/text-field/text-field.stories.mdx
+++ b/src/text-field/text-field.stories.mdx
@@ -337,6 +337,7 @@ export function WithMaxLengthExample() {
             maxLength={30}
             value={value}
             onChange={(event) => setValue(event.currentTarget.value)}
+            maxWidth="small"
         />
     )
 }
@@ -344,5 +345,52 @@ export function WithMaxLengthExample() {
 <Canvas withToolbar>
     <Story name="Max Length">
         <WithMaxLengthExample />
+    </Story>
+</Canvas>
+
+## Character count position
+
+The `characterCountPosition` prop is used to position the character count element. It can be shown <strong>below</strong> the field, <strong>inline</strong> with the field or <strong>hidden</strong>.
+
+export function WithCharacterCountPositionExample() {
+    return (
+        <TextField
+            label="Company name"
+            maxLength={30}
+            characterCountPosition="inline"
+            maxWidth="small"
+        />
+    )
+}
+
+export function WithCharacterCountPositionBelowExample() {
+    return (
+        <TextField
+            label="Company name"
+            maxLength={30}
+            characterCountPosition="below"
+            maxWidth="small"
+        />
+    )
+}
+
+export function WithCharacterCountPositionHiddenExample() {
+    return (
+        <TextField
+            label="Company name"
+            maxLength={30}
+            characterCountPosition="hidden"
+            maxWidth="small"
+        />
+    )
+}
+
+<Canvas withToolbar>
+    <Story name="Character count position">
+        <Stack space="xxlarge" dividers="secondary">
+            <WithCharacterCountPositionExample />
+            <WithCharacterCountPositionBelowExample />
+            <WithCharacterCountPositionHiddenExample />
+        </Stack>
     </Story>
 </Canvas>

--- a/src/text-field/text-field.test.tsx
+++ b/src/text-field/text-field.test.tsx
@@ -246,4 +246,39 @@ describe('TextField', () => {
             expect(results).toHaveNoViolations()
         })
     })
+
+    describe('character count', () => {
+        it('renders the character count element when characterCountPosition is "below"', () => {
+            render(
+                <TextField
+                    label="Whatʼs your name?"
+                    maxLength={30}
+                    characterCountPosition="below"
+                />,
+            )
+            expect(screen.getByText(/0\/30/)).toBeInTheDocument()
+        })
+
+        it('renders the character count element when characterCountPosition is "inline"', () => {
+            render(
+                <TextField
+                    label="Whatʼs your name?"
+                    maxLength={30}
+                    characterCountPosition="inline"
+                />,
+            )
+            expect(screen.getByText(/0\/30/)).toBeInTheDocument()
+        })
+
+        it('does not render the character count element when characterCountPosition is "hidden"', () => {
+            render(
+                <TextField
+                    label="Whatʼs your name?"
+                    maxLength={30}
+                    characterCountPosition="hidden"
+                />,
+            )
+            expect(screen.queryByText(/0\/30/)).not.toBeInTheDocument()
+        })
+    })
 })

--- a/src/text-field/text-field.tsx
+++ b/src/text-field/text-field.tsx
@@ -2,14 +2,15 @@ import * as React from 'react'
 import { BaseField, BaseFieldVariantProps } from '../base-field'
 import { Box } from '../box'
 import styles from './text-field.module.css'
-import type { FieldComponentProps } from '../base-field'
+import type { BaseFieldProps, FieldComponentProps } from '../base-field'
 import { useMergeRefs } from 'use-callback-ref'
 
 type TextFieldType = 'email' | 'search' | 'tel' | 'text' | 'url'
 
 interface TextFieldProps
     extends Omit<FieldComponentProps<HTMLInputElement>, 'type'>,
-        BaseFieldVariantProps {
+        BaseFieldVariantProps,
+        Pick<BaseFieldProps, 'characterCountPosition'> {
     type?: TextFieldType
     startSlot?: React.ReactElement | string | number
     endSlot?: React.ReactElement | string | number
@@ -38,6 +39,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
         startSlot,
         endSlot,
         onChange: originalOnChange,
+        characterCountPosition = 'below',
         ...props
     },
     ref,
@@ -63,8 +65,9 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
             maxLength={maxLength}
             hidden={hidden}
             aria-describedby={ariaDescribedBy}
+            characterCountPosition={characterCountPosition}
         >
-            {({ onChange, ...extraProps }) => (
+            {({ onChange, characterCountElement, ...extraProps }) => (
                 <Box
                     display="flex"
                     alignItems="center"
@@ -97,13 +100,14 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
                             onChange?.(event)
                         }}
                     />
-                    {endSlot ? (
+                    {endSlot || characterCountElement ? (
                         <Box
                             className={styles.slot}
                             display="flex"
                             marginRight={variant === 'bordered' ? '-xsmall' : 'xsmall'}
                             marginLeft={variant === 'bordered' ? 'xsmall' : '-xsmall'}
                         >
+                            {characterCountElement}
                             {endSlot}
                         </Box>
                     ) : null}


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

This PR introduces a new feature to customize the character count position in text fields. Major changes include:
- Added a new `characterCountPosition` prop to `BaseField` component with three options (two of them new):
  - `'below'` (default) - shows the counter below the field
  - `'inline'` - displays the counter inline with the field content
  - `'hidden'` - hides the character counter completely
- Updated `TextField` component to support the new character count positioning feature
- Added new stories and examples in the documentation
- Added test coverage for the new feature

![CleanShot 2025-01-28 at 22 04 10@2x](https://github.com/user-attachments/assets/6007223e-694c-46de-acd3-e4305abe3922)

### References
- Twist thread: https://twist.com/a/1585/ch/765851/t/6664583/

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
