### PR TITLE
ci: update Storybook deployment action to v4

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -49,7 +49,7 @@ jobs:
               uses: actions/configure-pages@v3
 
             - name: Upload artifact
-              uses: actions/upload-pages-artifact@v1
+              uses: actions/upload-pages-artifact@v4
               with:
                   path: './docs'
 


### PR DESCRIPTION
## Short description

Bump `upload-pages-artifact` version from v1 to v4 as per deprecation notice:

![CleanShot 2025-02-05 at 13 04 52@2x](https://github.com/user-attachments/assets/8f07c715-455f-4f19-a946-1218a7667e82)

- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
