### PR TITLE
ci: enhance release workflow with automatic deployment triggers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
     push:
         tags:
             - 'v*'
+    workflow_dispatch:
 
 permissions:
     # Enable the use of OIDC for npm provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
     push:
         tags:
             - 'v*'
+    # triggered by `release-please.yml`
     workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
     release-please:
         runs-on: ubuntu-latest
+        outputs:
+            release_created: ${{ steps.release.outputs.release_created }}
         steps:
             - uses: googleapis/release-please-action@v4
               id: release
@@ -20,3 +22,24 @@ jobs:
                   target-branch: main
                   config-file: .github/release-please-config.json
                   manifest-file: .github/release-please-manifest.json
+
+            - name: Trigger deployment workflows
+              if: ${{ steps.release.outputs.release_created }}
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      // Trigger deploy-storybook workflow
+                      await github.rest.actions.createWorkflowDispatch({
+                          owner: context.repo.owner,
+                          repo: context.repo.name,
+                          workflow_id: 'deploy-storybook.yml',
+                          ref: 'main'
+                      });
+
+                      // Trigger publish workflow
+                      await github.rest.actions.createWorkflowDispatch({
+                          owner: context.repo.owner,
+                          repo: context.repo.name,
+                          workflow_id: 'publish.yml',
+                          ref: 'main'
+                      });


### PR DESCRIPTION
## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

When using release-please with GITHUB_TOKEN, the tag creation doesn't trigger subsequent workflows due to GitHub's security limitations. This PR implements a workaround by:

1. Adding `workflow_dispatch` trigger to the `publish` workflow
2. Extending release-please workflow to programmatically trigger dependent workflows (`publish` and `deploy-storybook`) after a successful release

This makes use of Github's script action: https://github.com/actions/github-script

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
