### PR TITLE
ci: add permissions to dispatch workflows in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
     contents: write
     pull-requests: write
+    actions: write
 
 jobs:
     release-please:
@@ -30,10 +31,6 @@ jobs:
                   script: |
                       const repo = context.repo.repo;
                       const owner = context.repo.owner;
-
-                      // Debug logging
-                      console.log(`Owner: ${owner}`);
-                      console.log(`Repo: ${repo}`);
 
                       async function triggerWorkflow(workflow_id) {
                         console.log(`Triggering workflow: ${workflow_id}`);


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Closes #...

## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

Add `release-please` workflow permission to trigger other workflows ([ref](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token)). Also, remove debug logs

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
