### PR TITLE
ci: allow publish workflow to run from workflow_dispatch event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ permissions:
 
 jobs:
     publish:
-        # Only run if release-please created a release
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        # Allow both tag pushes and workflow_dispatch events
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
         runs-on: ubuntu-latest
         # Based on historical data
         timeout-minutes: 60


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Closes #...

## Short description

We were preventing publish workflow from running if not from tag ref. We're now allowing also it to run when triggered from ' workflow_dispatch' event, as we're using it in `release-please` workflow.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
