### PR TITLE
ci: bump deploy-pages action to v4

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -11,6 +11,7 @@ permissions:
     contents: read
     pages: write
     id-token: write
+    actions: read
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -55,4 +56,4 @@ jobs:
 
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v2
+              uses: actions/deploy-pages@v4


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Closes #...

## Short description

After bumping `upload-pages-artifact` to v3 (https://github.com/Doist/reactist/pull/885), we need to bump also the deploy action.

Also added read permissions to actions as it's required: https://github.com/actions/deploy-pages/releases/tag/v4.0.0

> This version requires the permission actions: read in the workflows which use it.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
