### PR TITLE
feat(TextLink): Add color and underline styling options

### DIFF
--- a/src/text-link/text-link.module.css
+++ b/src/text-link/text-link.module.css
@@ -9,8 +9,6 @@
     font-size: inherit;
     font-weight: inherit;
     font-family: inherit;
-    text-decoration: var(--reactist-text-link-idle-decoration);
-    color: var(--reactist-text-link-idle-tint);
     cursor: pointer;
 }
 
@@ -38,4 +36,22 @@
     vertical-align: -0.125em;
     fill: currentColor;
     padding: 0 6px;
+}
+
+/* Color variants */
+.default {
+    color: var(--reactist-text-link-idle-tint);
+}
+
+.inherit {
+    color: inherit;
+}
+
+/* Underline variants */
+.underline {
+    text-decoration: underline;
+}
+
+.no-underline {
+    text-decoration: none;
 }

--- a/src/text-link/text-link.module.css
+++ b/src/text-link/text-link.module.css
@@ -12,21 +12,6 @@
     cursor: pointer;
 }
 
-.container > * {
-    text-decoration: var(--reactist-text-link-idle-decoration);
-    color: var(--reactist-text-link-idle-tint);
-}
-
-/**
- * We need to target the child elements to ensure that styles are
- * applied to the text independently of the DOM elements hierarchy.
- */
-.container:hover,
-.container:hover > * {
-    text-decoration: var(--reactist-text-link-hover-decoration);
-    color: var(--reactist-text-link-hover-tint);
-}
-
 .container svg {
     display: inline-block;
     width: 1em;
@@ -39,19 +24,43 @@
 }
 
 /* Color variants */
-.default {
+.default,
+.default * {
     color: var(--reactist-text-link-idle-tint);
 }
 
-.inherit {
+.default:hover,
+.default:hover * {
+    color: var(--reactist-text-link-hover-tint);
+}
+
+.inherit,
+.inherit * {
     color: inherit;
 }
 
-/* Underline variants */
-.underline {
-    text-decoration: underline;
+.inherit:hover,
+.inherit:hover * {
+    color: var(--reactist-text-link-hover-tint);
 }
 
-.no-underline {
+/* Underline variants */
+.underline,
+.underline * {
+    text-decoration: var(--reactist-text-link-idle-decoration);
+}
+
+.underline:hover,
+.underline:hover * {
+    text-decoration: var(--reactist-text-link-hover-decoration);
+}
+
+.no-underline,
+.no-underline * {
     text-decoration: none;
+}
+
+.no-underline:hover,
+.no-underline:hover * {
+    text-decoration: var(--reactist-text-link-hover-decoration);
 }

--- a/src/text-link/text-link.stories.mdx
+++ b/src/text-link/text-link.stories.mdx
@@ -47,13 +47,7 @@ A component used to create text-based hyperlinks.
 When using nested elements inside a `TextLink`, hover styles are properly applied to all children.
 
 <Canvas>
-    <Story
-        name="Nested elements"
-        parameters={{
-            docs: { source: { type: 'code' } },
-            chromatic: { disableSnapshot: false },
-        }}
-    >
+    <Story name="Nested elements">
         <Stack space="medium" align="start">
             <TextLink href="https://www.doist.com/">
                 <span>Link with nested span</span>
@@ -70,6 +64,25 @@ When using nested elements inside a `TextLink`, hover styles are properly applie
                     link
                 </a>{' '}
                 section
+            </TextLink>
+        </Stack>
+    </Story>
+</Canvas>
+
+## Style
+
+The `color` prop can be used to change the color of the link. The default color sets the link to color defined in `--reactist-text-link-idle-tint` and hover to `--reactist-text-link-hover-tint`. The `color` prop allows to change it to `inherit`.
+
+The `underline` prop can be used to change the underline style of the link. The default is `true`.
+
+<Canvas>
+    <Story name="Colors">
+        <Stack space="medium" align="start">
+            <TextLink href="https://www.doist.com/" color="inherit">
+                inherit color
+            </TextLink>
+            <TextLink href="https://www.doist.com/" underline={false}>
+                no underline
             </TextLink>
         </Stack>
     </Story>

--- a/src/text-link/text-link.stories.mdx
+++ b/src/text-link/text-link.stories.mdx
@@ -18,7 +18,7 @@ A component used to create text-based hyperlinks.
     <Story
         name="Main demo"
         parameters={{
-            docs: { source: { type: 'code' } },
+            chromatic: { disableSnapshot: false },
         }}
     >
         <Stack space="medium" align="start">
@@ -47,7 +47,12 @@ A component used to create text-based hyperlinks.
 When using nested elements inside a `TextLink`, hover styles are properly applied to all children.
 
 <Canvas>
-    <Story name="Nested elements">
+    <Story
+        name="Nested elements"
+        parameters={{
+            chromatic: { disableSnapshot: false },
+        }}
+    >
         <Stack space="medium" align="start">
             <TextLink href="https://www.doist.com/">
                 <span>Link with nested span</span>
@@ -76,7 +81,12 @@ The `color` prop can be used to change the color of the link. The default color 
 The `underline` prop can be used to change the underline style of the link. The default is `true`.
 
 <Canvas>
-    <Story name="Colors">
+    <Story
+        name="Colors"
+        parameters={{
+            chromatic: { disableSnapshot: false },
+        }}
+    >
         <Stack space="medium" align="start">
             <TextLink href="https://www.doist.com/" color="inherit">
                 inherit color

--- a/src/text-link/text-link.test.tsx
+++ b/src/text-link/text-link.test.tsx
@@ -62,4 +62,56 @@ describe('TextLink', () => {
         // Verify it still has the default container class
         expect(link).toHaveClass('container')
     })
+
+    it('applies default color class when no color prop is provided', () => {
+        render(<TextLink href="#">Default color</TextLink>)
+
+        const link = screen.getByText('Default color')
+        expect(link).toHaveClass('default')
+    })
+
+    it('applies inherit color class when color prop is set to inherit', () => {
+        render(
+            <TextLink href="#" color="inherit">
+                Inherit color
+            </TextLink>,
+        )
+
+        const link = screen.getByText('Inherit color')
+        expect(link).toHaveClass('inherit')
+    })
+
+    it('applies underline class by default', () => {
+        render(<TextLink href="#">Underlined link</TextLink>)
+
+        const link = screen.getByText('Underlined link')
+        expect(link).toHaveClass('underline')
+    })
+
+    it('applies no-underline class when underline prop is false', () => {
+        render(
+            <TextLink href="#" underline={false}>
+                No underline
+            </TextLink>,
+        )
+
+        const link = screen.getByText('No underline')
+        expect(link).toHaveClass('no-underline')
+    })
+
+    it('combines multiple classes correctly', () => {
+        render(
+            <TextLink
+                href="#"
+                color="inherit"
+                underline={false}
+                exceptionallySetClassName="custom-class"
+            >
+                Combined classes
+            </TextLink>,
+        )
+
+        const link = screen.getByText('Combined classes')
+        expect(link).toHaveClass('container', 'inherit', 'no-underline', 'custom-class')
+    })
 })

--- a/src/text-link/text-link.tsx
+++ b/src/text-link/text-link.tsx
@@ -4,10 +4,22 @@ import { polymorphicComponent } from '../utils/polymorphism'
 import styles from './text-link.module.css'
 import type { OpenInNewTab } from '../utils/common-types'
 
-type TextLinkProps = OpenInNewTab
+type TextLinkColors = 'default' | 'inherit'
+
+type TextLinkProps = OpenInNewTab & {
+    color?: TextLinkColors
+    underline?: boolean
+}
 
 const TextLink = polymorphicComponent<'a', TextLinkProps>(function TextLink(
-    { as = 'a', openInNewTab = false, exceptionallySetClassName, ...props },
+    {
+        as = 'a',
+        openInNewTab = false,
+        exceptionallySetClassName,
+        color = 'default',
+        underline = true,
+        ...props
+    },
     ref,
 ) {
     return (
@@ -15,7 +27,12 @@ const TextLink = polymorphicComponent<'a', TextLinkProps>(function TextLink(
             {...props}
             as={as}
             display="inline"
-            className={[exceptionallySetClassName, styles.container]}
+            className={[
+                exceptionallySetClassName,
+                styles.container,
+                styles[color],
+                underline ? styles.underline : styles['no-underline'],
+            ]}
             ref={ref}
             target={openInNewTab ? '_blank' : undefined}
             rel={openInNewTab ? 'noopener noreferrer' : undefined}


### PR DESCRIPTION
## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

- Introduce color prop with 'default' and 'inherit' variants
- Add underline prop to control text-decoration
- Extend stories and tests to cover new styling options

![CleanShot 2025-02-18 at 20 28 26@2x](https://github.com/user-attachments/assets/78a902db-9818-4044-bd0a-674e344fb576)

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
