### PR TITLE
chore: Ensure that undefined gets passed correctly from Storybook for a couple of recently introduced `TextField` props

### DIFF
--- a/src/text-field/text-field.stories.mdx
+++ b/src/text-field/text-field.stories.mdx
@@ -130,6 +130,16 @@ export function InteractivePropsStory({
                 control: { type: 'boolean' },
                 defaultValue: false,
             },
+            characterCountPosition: {
+                options: [undefined, 'hidden', 'inline', 'below'],
+                control: { type: 'inline-radio' },
+                defaultValue: undefined,
+            },
+            endSlotPosition: {
+                options: [undefined, 'bottom', 'fullHeight'],
+                control: { type: 'inline-radio' },
+                defaultValue: undefined,
+            },
         }}
     >
         {InteractivePropsStory.bind({})}


### PR DESCRIPTION
Originally reported [here](https://github.com/Doist/reactist/pull/899#issuecomment-2718197426)

## Short description

Apparently props that are non-explicitly defined in Storybook get passed as "undefined" (string) when the undefined option gets chosen.

This PR ensures that if we pick the undefined option in Storybook, this gets actually passed as the value undefined and not as the string "undefined".

For the time being the best option I found was to explicitly define these props in Storybook.

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>

![image](https://github.com/user-attachments/assets/d44a67dd-85e7-4ef7-aac8-5a9a5be0bfb5)


</td><td>

![Screenshot 2025-03-12 at 16 53 24](https://github.com/user-attachments/assets/71da2e99-6428-4336-a539-f29b07573437)


</td></tr>
</tbody>
</table>

## PR Checklist

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI