### PR TITLE
feat(Tabs)!: Add support for additional customization settings

### DIFF
--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -2,14 +2,20 @@
     --reactist-tab-themed-background: var(--reactist-bg-default);
     --reactist-tab-themed-foreground: #006f85;
     --reactist-tab-themed-unselected: #006f85;
+    --reactist-tab-themed-hover: #006f85;
+    --reactist-tab-themed-disabled: #006f85;
     --reactist-tab-themed-track: rgb(242, 246, 247);
     --reactist-tab-themed-border: var(--reactist-divider-secondary);
+    --reactist-tab-themed-shadow: none;
 
     --reactist-tab-neutral-background: var(--reactist-bg-default);
     --reactist-tab-neutral-foreground: var(--reactist-content-primary);
     --reactist-tab-neutral-unselected: var(--reactist-content-tertiary);
+    --reactist-tab-neutral-hover: var(--reactist-content-tertiary);
+    --reactist-tab-neutral-disabled: var(--reactist-content-tertiary);
     --reactist-tab-neutral-track: var(--reactist-framework-fill-selected);
     --reactist-tab-neutral-border: var(--reactist-divider-primary);
+    --reactist-tab-neutral-shadow: none;
 
     --reactist-tab-track-border-width: 2px;
     --reactist-tab-border-radius: 20px;
@@ -59,6 +65,18 @@
     background-color: var(--reactist-tab-neutral-background);
     color: var(--reactist-tab-neutral-foreground);
     border-color: var(--reactist-tab-neutral-border);
+    box-shadow: var(--reactist-tab-neutral-shadow);
+}
+
+.tab[aria-selected='false']:hover,
+.tab-neutral[aria-selected='false']:hover {
+    color: var(--reactist-tab-neutral-hover);
+}
+
+.tab[aria-disabled='true'],
+.tab-neutral[aria-disabled='true'] {
+    color: var(--reactist-tab-neutral-disabled);
+    cursor: not-allowed;
 }
 
 .tab-themed {
@@ -69,6 +87,16 @@
     background-color: var(--reactist-tab-themed-background);
     color: var(--reactist-tab-themed-foreground);
     border-color: var(--reactist-tab-themed-border);
+    box-shadow: var(--reactist-tab-themed-shadow);
+}
+
+.tab-themed[aria-selected='false']:hover {
+    color: var(--reactist-tab-themed-hover);
+}
+
+.tab-themed[aria-disabled='true'] {
+    color: var(--reactist-tab-themed-disabled);
+    cursor: not-allowed;
 }
 
 .track,

--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -18,6 +18,7 @@
     --reactist-tab-neutral-shadow: none;
 
     --reactist-tab-track-border-width: 2px;
+    --reactist-tab-selected-transition: none;
     --reactist-tab-border-radius: 20px;
     --reactist-tab-border-width: 1px;
     --reactist-tab-padding-x: var(--reactist-spacing-medium);
@@ -37,7 +38,6 @@
     z-index: 1;
     text-decoration: none;
     border: var(--reactist-tab-border-width) solid transparent;
-    border-radius: var(--reactist-tab-border-radius);
 }
 
 .fullTabList .tab {
@@ -55,6 +55,16 @@
     border-style: solid;
 }
 
+.selected {
+    position: absolute;
+    z-index: 0;
+    top: 0;
+    height: 100%;
+    border: var(--reactist-tab-border-width) solid transparent;
+    border-radius: var(--reactist-tab-border-radius);
+    transition: var(--reactist-tab-selected-transition);
+}
+
 /*
  * Variant options
  */
@@ -66,10 +76,7 @@
 
 .tab[aria-selected='true'],
 .tab-neutral[aria-selected='true'] {
-    background-color: var(--reactist-tab-neutral-background);
     color: var(--reactist-tab-neutral-foreground);
-    border-color: var(--reactist-tab-neutral-border);
-    box-shadow: var(--reactist-tab-neutral-shadow);
 }
 
 .tab[aria-selected='false']:hover,
@@ -88,10 +95,7 @@
 }
 
 .tab-themed[aria-selected='true'] {
-    background-color: var(--reactist-tab-themed-background);
     color: var(--reactist-tab-themed-foreground);
-    border-color: var(--reactist-tab-themed-border);
-    box-shadow: var(--reactist-tab-themed-shadow);
 }
 
 .tab-themed[aria-selected='false']:hover {
@@ -112,4 +116,16 @@
 .track-themed {
     background: var(--reactist-tab-themed-track);
     border-color: var(--reactist-tab-themed-track);
+}
+
+.selected,
+.selected-neutral {
+    background-color: var(--reactist-tab-neutral-background);
+    border-color: var(--reactist-tab-neutral-border);
+}
+
+.selected-themed {
+    background-color: var(--reactist-tab-themed-background);
+    border-color: var(--reactist-tab-themed-border);
+    box-shadow: var(--reactist-tab-themed-shadow);
 }

--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -1,18 +1,24 @@
 :root {
-    --reactist-tab-themed-background: var(--reactist-bg-default);
-    --reactist-tab-themed-foreground: #006f85;
-    --reactist-tab-themed-unselected: #006f85;
-    --reactist-tab-themed-hover: #006f85;
-    --reactist-tab-themed-disabled: #006f85;
+    --reactist-tab-themed-selected-tint: #006f85;
+    --reactist-tab-themed-selected-fill: var(--reactist-bg-default);
+    --reactist-tab-themed-unselected-tint: #006f85;
+    --reactist-tab-themed-unselected-fill: transparent;
+    --reactist-tab-themed-hover-tint: #006f85;
+    --reactist-tab-themed-hover-fill: transparent;
+    --reactist-tab-themed-disabled-tint: #006f85;
+    --reactist-tab-themed-disabled-fill: transparent;
     --reactist-tab-themed-track: rgb(242, 246, 247);
     --reactist-tab-themed-border: var(--reactist-divider-secondary);
     --reactist-tab-themed-shadow: none;
 
-    --reactist-tab-neutral-background: var(--reactist-bg-default);
-    --reactist-tab-neutral-foreground: var(--reactist-content-primary);
-    --reactist-tab-neutral-unselected: var(--reactist-content-tertiary);
-    --reactist-tab-neutral-hover: var(--reactist-content-tertiary);
-    --reactist-tab-neutral-disabled: var(--reactist-content-tertiary);
+    --reactist-tab-neutral-selected-tint: var(--reactist-content-primary);
+    --reactist-tab-neutral-selected-fill: var(--reactist-bg-default);
+    --reactist-tab-neutral-unselected-tint: var(--reactist-content-tertiary);
+    --reactist-tab-neutral-unselected-fill: transparent;
+    --reactist-tab-neutral-hover-tint: var(--reactist-content-tertiary);
+    --reactist-tab-neutral-hover-fill: transparent;
+    --reactist-tab-neutral-disabled-tint: var(--reactist-content-tertiary);
+    --reactist-tab-neutral-disabled-fill: transparent;
     --reactist-tab-neutral-track: var(--reactist-framework-fill-selected);
     --reactist-tab-neutral-border: var(--reactist-divider-primary);
     --reactist-tab-neutral-shadow: none;
@@ -72,39 +78,45 @@
 
 .tab,
 .tab-neutral {
-    color: var(--reactist-tab-neutral-unselected);
+    background-color: var(--reactist-tab-neutral-unselected-fill);
+    color: var(--reactist-tab-neutral-unselected-tint);
 }
 
 .tab[aria-selected='true'],
 .tab-neutral[aria-selected='true'] {
-    color: var(--reactist-tab-neutral-foreground);
+    color: var(--reactist-tab-neutral-selected-tint);
 }
 
 .tab[aria-selected='false']:hover,
 .tab-neutral[aria-selected='false']:hover {
-    color: var(--reactist-tab-neutral-hover);
+    background-color: var(--reactist-tab-neutral-hover-fill);
+    color: var(--reactist-tab-neutral-hover-tint);
 }
 
 .tab[aria-disabled='true'],
 .tab-neutral[aria-disabled='true'] {
-    color: var(--reactist-tab-neutral-disabled);
+    background-color: var(--reactist-tab-neutral-disabled-fill);
+    color: var(--reactist-tab-neutral-disabled-tint);
     cursor: not-allowed;
 }
 
 .tab-themed {
-    color: var(--reactist-tab-themed-unselected);
+    background-color: var(--reactist-tab-themed-unselected-fill);
+    color: var(--reactist-tab-themed-unselected-tint);
 }
 
 .tab-themed[aria-selected='true'] {
-    color: var(--reactist-tab-themed-foreground);
+    color: var(--reactist-tab-themed-selected-tint);
 }
 
 .tab-themed[aria-selected='false']:hover {
-    color: var(--reactist-tab-themed-hover);
+    background-color: var(--reactist-tab-themed-hover-fill);
+    color: var(--reactist-tab-themed-hover-tint);
 }
 
 .tab-themed[aria-disabled='true'] {
-    color: var(--reactist-tab-themed-disabled);
+    background-color: var(--reactist-tab-themed-disabled-fill);
+    color: var(--reactist-tab-themed-disabled-tint);
     cursor: not-allowed;
 }
 
@@ -121,13 +133,13 @@
 
 .selected,
 .selected-neutral {
-    background-color: var(--reactist-tab-neutral-background);
+    background-color: var(--reactist-tab-neutral-selected-fill);
     border-color: var(--reactist-tab-neutral-border);
     box-shadow: var(--reactist-tab-neutral-shadow);
 }
 
 .selected-themed {
-    background-color: var(--reactist-tab-themed-background);
+    background-color: var(--reactist-tab-themed-selected-fill);
     border-color: var(--reactist-tab-themed-border);
     box-shadow: var(--reactist-tab-themed-shadow);
 }

--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -40,6 +40,10 @@
     border-radius: var(--reactist-tab-border-radius);
 }
 
+.fullTabList .tab {
+    flex: 1;
+}
+
 .track {
     position: absolute;
     top: calc(-1 * var(--reactist-tab-track-border-width));

--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -117,7 +117,6 @@
 .tab-themed[aria-disabled='true'] {
     background-color: var(--reactist-tab-themed-disabled-fill);
     color: var(--reactist-tab-themed-disabled-tint);
-    cursor: not-allowed;
 }
 
 .track,

--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -38,6 +38,7 @@
     z-index: 1;
     text-decoration: none;
     border: var(--reactist-tab-border-width) solid transparent;
+    border-radius: var(--reactist-tab-border-radius);
 }
 
 .fullTabList .tab {
@@ -122,6 +123,7 @@
 .selected-neutral {
     background-color: var(--reactist-tab-neutral-background);
     border-color: var(--reactist-tab-neutral-border);
+    box-shadow: var(--reactist-tab-neutral-shadow);
 }
 
 .selected-themed {

--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -23,6 +23,7 @@
     --reactist-tab-neutral-border: var(--reactist-divider-primary);
     --reactist-tab-neutral-shadow: none;
 
+    --reactist-tab-track-border-radius: 20px;
     --reactist-tab-track-border-width: 2px;
     --reactist-tab-selected-transition: none;
     --reactist-tab-border-radius: 20px;
@@ -57,7 +58,7 @@
     right: calc(-1 * var(--reactist-tab-track-border-width));
     bottom: calc(-1 * var(--reactist-tab-track-border-width));
     left: calc(-1 * var(--reactist-tab-track-border-width));
-    border-radius: var(--reactist-tab-border-radius);
+    border-radius: var(--reactist-tab-track-border-radius);
     border-width: var(--reactist-tab-track-border-width);
     border-style: solid;
 }

--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -130,17 +130,23 @@ The following CSS custom properties are available so that the tabs' colors can b
 --reactist-tab-neutral-background
 --reactist-tab-neutral-foreground
 --reactist-tab-neutral-unselected
+--reactist-tab-neutral-hover
+--reactist-tab-neutral-disabled
 --reactist-tab-neutral-track
 --reactist-tab-neutral-border
 
 --reactist-tab-themed-background
 --reactist-tab-themed-foreground
 --reactist-tab-themed-unselected
+--reactist-tab-themed-hover
+--reactist-tab-themed-disabled
 --reactist-tab-themed-track
 --reactist-tab-themed-border
 ```
 
-Their size can also be customized with:
+## Sizes
+
+The following CSS custom properties are available so that the tabs' sizes can be customized:
 
 ```
 --reactist-tab-track-border-width
@@ -149,6 +155,16 @@ Their size can also be customized with:
 --reactist-tab-padding-x
 --reactist-tab-padding-y
 --reactist-tab-line-height
+```
+
+## Other
+
+The following CSS custom properties are also available to customize other tabs' styles:
+
+```
+--reactist-tab-neutral-shadow
+
+--reactist-tab-themed-shadow
 ```
 
 ## Stories

--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -184,6 +184,35 @@ The following CSS custom properties are also available to customize other tabs' 
     </Story>
 </Canvas>
 
+### Full container width tabs
+
+<Canvas withToolbar>
+    <Story parameters={{ docs: { source: { type: 'code' } } }} name="Full container width tabs">
+        <Tabs>
+            <TabList aria-label="Full width tabs example" width="full">
+                <Tab id="tab1">Tab 1</Tab>
+                <Tab id="tab2">Tab 2</Tab>
+                <Tab id="tab3">Tab 3</Tab>
+            </TabList>
+            <TabPanel id="tab1">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 1</Text>
+                </Box>
+            </TabPanel>
+            <TabPanel id="tab2">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 2</Text>
+                </Box>
+            </TabPanel>
+            <TabPanel id="tab3">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 3</Text>
+                </Box>
+            </TabPanel>
+        </Tabs>
+    </Story>
+</Canvas>
+
 ### Using the `<TabAwareSlot>` component
 
 <Canvas withToolbar>

--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -155,6 +155,7 @@ The following CSS custom properties are available so that the tabs' colors can b
 The following CSS custom properties are available so that the tabs' sizes can be customized:
 
 ```
+--reactist-tab-track-border-radius
 --reactist-tab-track-border-width
 --reactist-tab-border-radius
 --reactist-tab-border-width

--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -127,19 +127,25 @@ export const Template = ({
 The following CSS custom properties are available so that the tabs' colors can be customized:
 
 ```
---reactist-tab-neutral-background
---reactist-tab-neutral-foreground
---reactist-tab-neutral-unselected
---reactist-tab-neutral-hover
---reactist-tab-neutral-disabled
+--reactist-tab-neutral-selected-tint
+--reactist-tab-neutral-selected-fill
+--reactist-tab-neutral-unselected-tint
+--reactist-tab-neutral-unselected-fill
+--reactist-tab-neutral-hover-tint
+--reactist-tab-neutral-hover-fill
+--reactist-tab-neutral-disabled-tint
+--reactist-tab-neutral-disabled-fill
 --reactist-tab-neutral-track
 --reactist-tab-neutral-border
 
---reactist-tab-themed-background
---reactist-tab-themed-foreground
---reactist-tab-themed-unselected
---reactist-tab-themed-hover
---reactist-tab-themed-disabled
+--reactist-tab-themed-selected-tint
+--reactist-tab-themed-selected-fill
+--reactist-tab-themed-unselected-tint
+--reactist-tab-themed-unselected-fill
+--reactist-tab-themed-hover-tint
+--reactist-tab-themed-hover-fill
+--reactist-tab-themed-disabled-tint
+--reactist-tab-themed-disabled-fill
 --reactist-tab-themed-track
 --reactist-tab-themed-border
 ```
@@ -165,6 +171,8 @@ The following CSS custom properties are also available to customize other tabs' 
 --reactist-tab-neutral-shadow
 
 --reactist-tab-themed-shadow
+
+--reactist-tab-selected-transition
 ```
 
 ## Stories

--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -242,6 +242,44 @@ The following CSS custom properties are also available to customize other tabs' 
     </Story>
 </Canvas>
 
+### Selected tab with slide animation
+
+<Canvas withToolbar>
+    <Story
+        parameters={{ docs: { source: { type: 'code' } } }}
+        name="Selected tab with slide animation"
+        style={{ border: '1px solid red' }}
+    >
+        <Tabs>
+            <style>
+                {
+                    '.transition { --reactist-tab-selected-transition: left 0.3s ease, width 0.3s ease; }'
+                }
+            </style>
+            <TabList aria-label="Full width tabs example" exceptionallySetClassName="transition">
+                <Tab id="tab1">Tab 1</Tab>
+                <Tab id="tab2">Tab 2</Tab>
+                <Tab id="tab3">Tab 3</Tab>
+            </TabList>
+            <TabPanel id="tab1">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 1</Text>
+                </Box>
+            </TabPanel>
+            <TabPanel id="tab2">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 2</Text>
+                </Box>
+            </TabPanel>
+            <TabPanel id="tab3">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 3</Text>
+                </Box>
+            </TabPanel>
+        </Tabs>
+    </Story>
+</Canvas>
+
 ### Using the `<TabAwareSlot>` component
 
 <Canvas withToolbar>

--- a/src/tabs/tabs.stories.mdx
+++ b/src/tabs/tabs.stories.mdx
@@ -213,6 +213,35 @@ The following CSS custom properties are also available to customize other tabs' 
     </Story>
 </Canvas>
 
+### Tabs aligned to the center
+
+<Canvas withToolbar>
+    <Story parameters={{ docs: { source: { type: 'code' } } }} name="Tabs aligned to the center">
+        <Tabs>
+            <TabList aria-label="Full width tabs example" align="center">
+                <Tab id="tab1">Tab 1</Tab>
+                <Tab id="tab2">Tab 2</Tab>
+                <Tab id="tab3">Tab 3</Tab>
+            </TabList>
+            <TabPanel id="tab1">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 1</Text>
+                </Box>
+            </TabPanel>
+            <TabPanel id="tab2">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 2</Text>
+                </Box>
+            </TabPanel>
+            <TabPanel id="tab3">
+                <Box paddingX="small" paddingY="xlarge">
+                    <Text>Content of tab 3</Text>
+                </Box>
+            </TabPanel>
+        </Tabs>
+    </Story>
+</Canvas>
+
 ### Using the `<TabAwareSlot>` component
 
 <Canvas withToolbar>

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -149,12 +149,27 @@ type TabListProps = (
      * Controls the spacing between tabs
      */
     space?: Space
+
+    /**
+     * The width of the tab list.
+     *
+     * - `'maxContent'`: Each tab will be as wide as its content.
+     * - `'full'`: Each tab will be as wide as the tab list.
+     *
+     * @default 'maxContent'
+     */
+    width?: 'maxContent' | 'full'
 }
 
 /**
  * A component used to group `<Tab>` elements together.
  */
-function TabList({ children, space, ...props }: TabListProps): React.ReactElement | null {
+function TabList({
+    children,
+    space,
+    width = 'maxContent',
+    ...props
+}: TabListProps): React.ReactElement | null {
     const tabContextValue = React.useContext(TabsContext)
 
     if (!tabContextValue) {
@@ -169,11 +184,18 @@ function TabList({ children, space, ...props }: TabListProps): React.ReactElemen
         <div>
             <BaseTabList
                 store={tabStore}
-                render={<Box position="relative" width="maxContent" />}
+                render={<Box position="relative" width={width} />}
                 {...props}
             >
                 <Box className={[styles.track, styles[`track-${variant}`]]} />
-                <Inline space={space}>{children}</Inline>
+                <Inline
+                    space={space}
+                    exceptionallySetClassName={classNames(
+                        width === 'full' ? styles.fullTabList : null,
+                    )}
+                >
+                    {children}
+                </Inline>
             </BaseTabList>
         </div>
     )

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -168,7 +168,7 @@ type TabListProps = (
      * @default 'start'
      */
     align?: ResponsiveProp<'start' | 'center' | 'end'>
-}
+} & ObfuscatedClassName
 
 /**
  * A component used to group `<Tab>` elements together.
@@ -178,6 +178,7 @@ function TabList({
     space,
     width = 'maxContent',
     align = 'start',
+    exceptionallySetClassName,
     ...props
 }: TabListProps): React.ReactElement | null {
     const tabContextValue = React.useContext(TabsContext)
@@ -233,7 +234,9 @@ function TabList({
         >
             <BaseTabList
                 store={tabStore}
-                render={<Box position="relative" width={width} />}
+                render={
+                    <Box position="relative" width={width} className={exceptionallySetClassName} />
+                }
                 ref={tabListRef}
                 {...props}
             >

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -86,13 +86,18 @@ interface TabProps
      * The tab's identifier. This must match its corresponding `<TabPanel>`'s id
      */
     id: string
+
+    /**
+     * Defines wether or not the tab is disabled.
+     */
+    disabled?: boolean
 }
 
 /**
  * Represents the individual tab elements within the group. Each `<Tab>` must have a corresponding `<TabPanel>` component.
  */
 const Tab = React.forwardRef<HTMLButtonElement, TabProps>(function Tab(
-    { children, id, exceptionallySetClassName, render, onClick },
+    { children, id, disabled, exceptionallySetClassName, render, onClick },
     ref,
 ): React.ReactElement | null {
     const tabContextValue = React.useContext(TabsContext)
@@ -105,6 +110,7 @@ const Tab = React.forwardRef<HTMLButtonElement, TabProps>(function Tab(
         <BaseTab
             id={id}
             ref={ref}
+            disabled={disabled}
             store={tabStore}
             render={render}
             className={className}

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -189,23 +189,32 @@ function TabList({
     const selectedId = tabContextValue?.tabStore.useState('selectedId')
 
     React.useLayoutEffect(() => {
-        if (!selectedId || !tabListRef.current) {
-            return
+        function updateSelectedTabStyle() {
+            if (!selectedId || !tabListRef.current) {
+                return
+            }
+
+            const tabs = tabListRef.current.querySelectorAll('[role="tab"]')
+
+            const selectedTab = Array.from(tabs).find(
+                (tab) => tab.getAttribute('id') === selectedId,
+            ) as HTMLElement | undefined
+
+            if (selectedTab) {
+                setSelectedTabElement(selectedTab)
+                setSelectedTabStyle({
+                    left: `${selectedTab.offsetLeft}px`,
+                    width: `${selectedTab.offsetWidth}px`,
+                })
+            }
         }
 
-        const tabs = tabListRef.current.querySelectorAll('[role="tab"]')
+        updateSelectedTabStyle()
 
-        const selectedTab = Array.from(tabs).find(
-            (tab) => tab.getAttribute('id') === selectedId,
-        ) as HTMLElement | undefined
+        window.addEventListener('resize', updateSelectedTabStyle)
 
-        if (selectedTab) {
-            setSelectedTabElement(selectedTab)
-
-            setSelectedTabStyle({
-                left: `${selectedTab.offsetLeft}px`,
-                width: `${selectedTab.offsetWidth}px`,
-            })
+        return function cleanupEventListener() {
+            window.removeEventListener('resize', updateSelectedTabStyle)
         }
     }, [selectedId])
 

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -9,12 +9,13 @@ import {
     TabPanelProps as BaseTabPanelProps,
     TabStore,
 } from '@ariakit/react'
+import { Box } from '../box'
 import { Inline } from '../inline'
+
 import type { ObfuscatedClassName, Space } from '../utils/common-types'
+import type { ResponsiveProp } from '../utils/responsive-props'
 
 import styles from './tabs.module.css'
-import { Box } from '../box'
-import { ResponsiveProp } from '../utils/responsive-props'
 
 type TabsContextValue = Required<Pick<TabsProps, 'variant'>> & {
     tabStore: TabStore

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -9,11 +9,10 @@ import {
     TabPanelProps as BaseTabPanelProps,
     TabStore,
 } from '@ariakit/react'
-import { Box } from '../box'
+import { Box, BoxJustifyContent } from '../box'
 import { Inline } from '../inline'
 
 import type { ObfuscatedClassName, Space } from '../utils/common-types'
-import type { ResponsiveProp } from '../utils/responsive-props'
 
 import styles from './tabs.module.css'
 
@@ -167,7 +166,7 @@ type TabListProps = (
      *
      * @default 'start'
      */
-    align?: ResponsiveProp<'start' | 'center' | 'end'>
+    align?: 'start' | 'center' | 'end'
 } & ObfuscatedClassName
 
 /**
@@ -216,21 +215,19 @@ function TabList({
 
     const { tabStore, variant } = tabContextValue
 
+    const justifyContentAlignMap: Record<typeof align, BoxJustifyContent> = {
+        start: 'flexStart',
+        end: 'flexEnd',
+        center: 'center',
+    }
+
     return (
         // This extra <Box> not only provides alignment for the tabs, but also prevents <Inline>'s
         // negative margins from collapsing when used in a flex container which will render the
         // track with the wrong height
         <Box
             display="flex"
-            justifyContent={
-                width === 'full'
-                    ? 'center'
-                    : align === 'start'
-                    ? 'flexStart'
-                    : align === 'end'
-                    ? 'flexEnd'
-                    : 'center'
-            }
+            justifyContent={width === 'full' ? 'center' : justifyContentAlignMap[align]}
         >
             <BaseTabList
                 store={tabStore}

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -181,6 +181,33 @@ function TabList({
 }: TabListProps): React.ReactElement | null {
     const tabContextValue = React.useContext(TabsContext)
 
+    const [selectedTabElement, setSelectedTabElement] = React.useState<HTMLElement | null>(null)
+    const [selectedTabStyle, setSelectedTabStyle] = React.useState<React.CSSProperties>({})
+    const tabListRef = React.useRef<HTMLDivElement>(null)
+
+    const selectedId = tabContextValue?.tabStore.useState('selectedId')
+
+    React.useLayoutEffect(() => {
+        if (!selectedId || !tabListRef.current) {
+            return
+        }
+
+        const tabs = tabListRef.current.querySelectorAll('[role="tab"]')
+
+        const selectedTab = Array.from(tabs).find(
+            (tab) => tab.getAttribute('id') === selectedId,
+        ) as HTMLElement | undefined
+
+        if (selectedTab) {
+            setSelectedTabElement(selectedTab)
+
+            setSelectedTabStyle({
+                left: `${selectedTab.offsetLeft}px`,
+                width: `${selectedTab.offsetWidth}px`,
+            })
+        }
+    }, [selectedId])
+
     if (!tabContextValue) {
         return null
     }
@@ -206,9 +233,16 @@ function TabList({
             <BaseTabList
                 store={tabStore}
                 render={<Box position="relative" width={width} />}
+                ref={tabListRef}
                 {...props}
             >
                 <Box className={[styles.track, styles[`track-${variant}`]]} />
+                {selectedTabElement ? (
+                    <Box
+                        className={[styles.selected, styles[`selected-${variant}`]]}
+                        style={selectedTabStyle}
+                    />
+                ) : null}
                 <Inline
                     space={space}
                     exceptionallySetClassName={classNames(

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -14,6 +14,7 @@ import type { ObfuscatedClassName, Space } from '../utils/common-types'
 
 import styles from './tabs.module.css'
 import { Box } from '../box'
+import { ResponsiveProp } from '../utils/responsive-props'
 
 type TabsContextValue = Required<Pick<TabsProps, 'variant'>> & {
     tabStore: TabStore
@@ -159,6 +160,13 @@ type TabListProps = (
      * @default 'maxContent'
      */
     width?: 'maxContent' | 'full'
+
+    /**
+     * How to align the tabs within the tab list.
+     *
+     * @default 'start'
+     */
+    align?: ResponsiveProp<'start' | 'center' | 'end'>
 }
 
 /**
@@ -168,6 +176,7 @@ function TabList({
     children,
     space,
     width = 'maxContent',
+    align = 'start',
     ...props
 }: TabListProps): React.ReactElement | null {
     const tabContextValue = React.useContext(TabsContext)
@@ -179,9 +188,21 @@ function TabList({
     const { tabStore, variant } = tabContextValue
 
     return (
-        // The extra <div> prevents <Inline>'s negative margins from collapsing when used in a flex container
-        // which will render the track with the wrong height
-        <div>
+        // This extra <Box> not only provides alignment for the tabs, but also prevents <Inline>'s
+        // negative margins from collapsing when used in a flex container which will render the
+        // track with the wrong height
+        <Box
+            display="flex"
+            justifyContent={
+                width === 'full'
+                    ? 'center'
+                    : align === 'start'
+                    ? 'flexStart'
+                    : align === 'end'
+                    ? 'flexEnd'
+                    : 'center'
+            }
+        >
             <BaseTabList
                 store={tabStore}
                 render={<Box position="relative" width={width} />}
@@ -197,7 +218,7 @@ function TabList({
                     {children}
                 </Inline>
             </BaseTabList>
-        </div>
+        </Box>
     )
 }
 


### PR DESCRIPTION
## Short description

This PR adds support for the following customization settings for the `Tabs` component:

- CSS variables for hover and disabled states for the `Tab` component
    - `--reactist-tab-themed-hover` / `--reactist-tab-neutral-hover`
    - `--reactist-tab-themed-disabled` / `--reactist-tab-themed-disabled`
    - A tab can be individually disabled with the `disabled` prop
- CSS variable for a box shadow for the selected tab
    - `--reactist-tab-neutral-shadow` / `--reactist-tab-themed-shadow`
- Full width for the `TabList` component
    - The `width` prop can be `full` or `maxContent` (default)
- Tab alignment for the `TabList` component
    - The `align` prop can be `start` (default), `center`, or `end`
- CSS variable for a transition for the selected tab
    - `--reactist-tab-selected-transition`
- `exceptionallySetClassName` prop added to the `TabList` component
    - Allows to override the `--reactist-tab-border-radius` variable used in the "track" element

All these changes are necessary to help customize the `Tabs` component to help with the upcoming style updates, and they come with sensible defaults that match the current style and behaviour. This avoids breaking changes, and helps with a smoother transition. I've also added a few example stories to demonstrate some of the most relevant new settings.

## PR Checklist

-   [x] Updated docs (storybooks, readme)
-   [x] Reviewed and approved Chromatic visual regression tests in CI