### PR TITLE
Add support for customizing the tab font size and weight

### DIFF
--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -30,6 +30,8 @@
     --reactist-tab-border-width: 1px;
     --reactist-tab-padding-x: var(--reactist-spacing-medium);
     --reactist-tab-padding-y: var(--reactist-spacing-small);
+    --reactist-tab-font-size: var(--reactist-font-size-body);
+    --reactist-tab-font-weight: var(--reactist-font-weight-medium);
     --reactist-tab-line-height: 21px;
 }
 
@@ -39,8 +41,8 @@
     border: none;
     background: none;
     cursor: pointer;
-    font-size: var(--reactist-font-size-body);
-    font-weight: var(--reactist-font-weight-medium);
+    font-size: var(--reactist-tab-font-size);
+    font-weight: var(--reactist-tab-font-weight);
     line-height: var(--reactist-tab-line-height);
     z-index: 1;
     text-decoration: none;

--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -90,17 +90,17 @@
     color: var(--reactist-tab-neutral-selected-tint);
 }
 
-.tab[aria-selected='false']:hover,
-.tab-neutral[aria-selected='false']:hover {
-    background-color: var(--reactist-tab-neutral-hover-fill);
-    color: var(--reactist-tab-neutral-hover-tint);
-}
-
 .tab[aria-disabled='true'],
 .tab-neutral[aria-disabled='true'] {
     background-color: var(--reactist-tab-neutral-disabled-fill);
     color: var(--reactist-tab-neutral-disabled-tint);
     cursor: not-allowed;
+}
+
+.tab[aria-selected='false']:not([aria-disabled='true']):hover,
+.tab-neutral[aria-selected='false']:not([aria-disabled='true']):hover {
+    background-color: var(--reactist-tab-neutral-hover-fill);
+    color: var(--reactist-tab-neutral-hover-tint);
 }
 
 .tab-themed {
@@ -112,14 +112,14 @@
     color: var(--reactist-tab-themed-selected-tint);
 }
 
-.tab-themed[aria-selected='false']:hover {
-    background-color: var(--reactist-tab-themed-hover-fill);
-    color: var(--reactist-tab-themed-hover-tint);
-}
-
 .tab-themed[aria-disabled='true'] {
     background-color: var(--reactist-tab-themed-disabled-fill);
     color: var(--reactist-tab-themed-disabled-tint);
+}
+
+.tab-themed[aria-selected='false']:not([aria-disabled='true']):hover {
+    background-color: var(--reactist-tab-themed-hover-fill);
+    color: var(--reactist-tab-themed-hover-tint);
 }
 
 .track,


### PR DESCRIPTION
## Short description

Builds on top of https://github.com/Doist/reactist/pull/903 to:

- Adds missing CSS properties to customize the tabs' font size and weight
- Fixes an issue where the hover styling was applied to disabled tags

## PR Checklist

-   [ ] Reviewed and approved Chromatic visual regression tests in CI