### PR TITLE
fix(Tabs): Add resize observer for dynamic tab selection adjustments

### DIFF
--- a/scripts/jestSetup.ts
+++ b/scripts/jestSetup.ts
@@ -2,3 +2,15 @@ import { toHaveNoViolations } from 'jest-axe'
 import '@testing-library/jest-dom'
 
 expect.extend(toHaveNoViolations)
+
+/* Stub out ResizeObserver */
+if (!window.ResizeObserver) {
+    class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    }
+
+    window.ResizeObserver = ResizeObserver
+    global.ResizeObserver = ResizeObserver
+}

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -223,21 +223,35 @@ function TabList({
 
     React.useEffect(
         function observeTabListWidthChange() {
-            const tabList = new ResizeObserver(([entry]) => {
+            let animationFrameId: number | null = null
+
+            const tabListObserver = new ResizeObserver(([entry]) => {
                 const width = entry?.contentRect.width
 
                 if (width && tabListPrevWidthRef.current !== width) {
                     tabListPrevWidthRef.current = width
-                    updateSelectedTabPosition()
+
+                    if (animationFrameId !== null) {
+                        cancelAnimationFrame(animationFrameId)
+                    }
+
+                    animationFrameId = requestAnimationFrame(() => {
+                        updateSelectedTabPosition()
+                        animationFrameId = null
+                    })
                 }
             })
 
             if (tabListRef.current) {
-                tabList.observe(tabListRef.current)
+                tabListObserver.observe(tabListRef.current)
             }
 
             return function cleanupResizeObserver() {
-                tabList.disconnect()
+                if (animationFrameId) {
+                    cancelAnimationFrame(animationFrameId)
+                }
+
+                tabListObserver.disconnect()
             }
         },
         [updateSelectedTabPosition],


### PR DESCRIPTION
## Short description

This PR replaces our viewport‐only resize listener with a `ResizeObserver` on the tabs container itself, ensuring the selected tab is always correctly positioned whenever its parent’s width changes. In particular, it fixes an edge case where removing an inline element (for example, a status badge or "unread" count) from a tab causes the container to shrink without firing a window `resize` event, leaving the selected tab indicator out of sync.

**What’s changed:**

- **Replace** the `window.addEventListener('resize', …)` logic for updating the selected tab with a `ResizeObserver` attached to the tabs list container.
- **On resize** of the container or **on manual tab change**, run the same recalculation & repositioning logic for the active tab.

This makes the tabs component resilient to any changes in its own dimensions—whether coming from viewport resizes, dynamic inline element changes, font changes, or other content shifts—so the active tab indicator stays perfectly in sync.

---

_@frankieyan Assigned you directly since you reviewed the original PR where the viewport resize was introduced, and I want your thoughts on this alternative solution that should be more robust._