### PR TITLE
fix: fix text area auto-expand when controlled

### DIFF
--- a/src/text-area/text-area.stories.mdx
+++ b/src/text-area/text-area.stories.mdx
@@ -185,12 +185,14 @@ Note that these variables are shared with other components such as `Textfield`, 
 export function AutoExpandStory(props) {
     const [value, setValue] = React.useState('')
     return (
-        <Box maxWidth="small">
+        <Stack space="large" dividers="secondary" maxWidth="medium">
             <TextArea
-                label="Type something"
+                label="Text area with auto-expand"
+                auxiliaryLabel="(controlled)"
                 autoExpand
                 value={value}
                 onChange={(event) => setValue(event.target.value)}
+                message="Write as much or as little as you want. The input area will auto-expand to fit what you've typed."
                 rows={1}
                 onKeyDown={(event) => {
                     if (event.key === 'Enter') {
@@ -199,7 +201,12 @@ export function AutoExpandStory(props) {
                     }
                 }}
             />
-        </Box>
+            <Text size="caption" tone="secondary">
+                If you press Enter, the input will be cleared. This allows you to test that
+                auto-expand works when the input is cleared programmatically, shrinking the textarea
+                to the new expected height.
+            </Text>
+        </Stack>
     )
 }
 
@@ -255,26 +262,12 @@ export function AutoExpandStory(props) {
 export function AutoExpandWithInitialValueStory(props) {
     const initialValue =
         'This is some text that takes up multiple lines. It should cause the textarea to render initially as large as needed to fit this text, even if its initial rows are not enough.'
-    const [value, setValue] = React.useState(initialValue)
     return (
         <Stack space="xxlarge" dividers="secondary" maxWidth="medium">
             <TextArea
                 {...props}
-                label="What do you want to accomplish?"
-                auxiliaryLabel={
-                    <Text tone="secondary" size="caption">
-                        {value.length}
-                    </Text>
-                }
-                message="Write as much or as little as you want. The input area will auto-expand to fit what you've typed."
-                value={value}
-                onChange={(event) => setValue(event.target.value)}
-                rows={1}
-                autoExpand
-            />
-            <TextArea
-                {...props}
-                label="What do you want to accomplish?"
+                label="Text area with auto-expand and initial value"
+                auxiliaryLabel="(uncontrolled)"
                 message="Write as much or as little as you want. The input area will auto-expand to fit what you've typed."
                 defaultValue={initialValue}
                 rows={1}

--- a/src/text-area/text-area.stories.mdx
+++ b/src/text-area/text-area.stories.mdx
@@ -187,6 +187,7 @@ export function AutoExpandStory(props) {
     return (
         <Stack space="large" dividers="secondary" maxWidth="medium">
             <TextArea
+                {...props}
                 label="Text area with auto-expand"
                 auxiliaryLabel="(controlled)"
                 autoExpand

--- a/src/text-area/text-area.stories.mdx
+++ b/src/text-area/text-area.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable, Description } from '@storybook/addon-docs'
 
+import { Box } from '../box'
 import { Stack } from '../stack'
 import { Text } from '../text'
 import { TextArea } from './'
@@ -182,21 +183,23 @@ Note that these variables are shared with other components such as `Textfield`, 
 </Canvas>
 
 export function AutoExpandStory(props) {
+    const [value, setValue] = React.useState('')
     return (
-        <Stack space="xxlarge" dividers="secondary" maxWidth="medium">
+        <Box maxWidth="small">
             <TextArea
-                {...props}
-                label="What do you want to accomplish?"
-                message="Write as much or as little as you want. The input area will auto-expand to fit what you've typed."
+                label="Type something"
                 autoExpand
+                value={value}
+                onChange={(event) => setValue(event.target.value)}
+                rows={1}
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                        event.preventDefault()
+                        setValue('') // Clear the input programmatically
+                    }
+                }}
             />
-            <TextArea
-                {...props}
-                label="What do you want to accomplish?"
-                message="This one will not auto-expand."
-                autoExpand={false}
-            />
-        </Stack>
+        </Box>
     )
 }
 

--- a/src/text-area/text-area.tsx
+++ b/src/text-area/text-area.tsx
@@ -62,38 +62,12 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(function T
     const internalRef = React.useRef<HTMLTextAreaElement>(null)
     const combinedRef = useMergeRefs([ref, internalRef])
 
+    useAutoExpand({ autoExpand, containerRef, internalRef })
+
     const textAreaClassName = classNames([
         autoExpand ? styles.disableResize : null,
         disableResize ? styles.disableResize : null,
     ])
-
-    React.useEffect(
-        function setupAutoExpand() {
-            const containerElement = containerRef.current
-
-            function handleAutoExpand(value: string) {
-                if (containerElement) {
-                    containerElement.dataset.replicatedValue = value
-                }
-            }
-
-            function handleInput(event: Event) {
-                handleAutoExpand((event.currentTarget as HTMLTextAreaElement).value)
-            }
-
-            const textAreaElement = internalRef.current
-            if (!textAreaElement || !autoExpand) {
-                return undefined
-            }
-
-            // Apply change initially, in case the text area has a non-empty initial value
-            handleAutoExpand(textAreaElement.value)
-
-            textAreaElement.addEventListener('input', handleInput)
-            return () => textAreaElement.removeEventListener('input', handleInput)
-        },
-        [autoExpand],
-    )
 
     return (
         <BaseField
@@ -138,6 +112,44 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(function T
         </BaseField>
     )
 })
+
+function useAutoExpand({
+    autoExpand,
+    containerRef,
+    internalRef,
+}: {
+    autoExpand: boolean
+    containerRef: React.RefObject<HTMLDivElement>
+    internalRef: React.RefObject<HTMLTextAreaElement>
+}) {
+    React.useEffect(
+        function setupAutoExpand() {
+            const containerElement = containerRef.current
+
+            function handleAutoExpand(value: string) {
+                if (containerElement) {
+                    containerElement.dataset.replicatedValue = value
+                }
+            }
+
+            function handleInput(event: Event) {
+                handleAutoExpand((event.currentTarget as HTMLTextAreaElement).value)
+            }
+
+            const textAreaElement = internalRef.current
+            if (!textAreaElement || !autoExpand) {
+                return undefined
+            }
+
+            // Apply change initially, in case the text area has a non-empty initial value
+            handleAutoExpand(textAreaElement.value)
+
+            textAreaElement.addEventListener('input', handleInput)
+            return () => textAreaElement.removeEventListener('input', handleInput)
+        },
+        [autoExpand, containerRef, internalRef],
+    )
+}
 
 export { TextArea }
 export type { TextAreaProps }


### PR DESCRIPTION
## Short description

Fixes #911 

The main issue is that our current auto-expand implementation is more suitable for when the component is uncontrolled. When the component is controlled, it is better to use the `value` changes as the signal to run the effect.

This PR now changes the auto-expand to set up two different `useEffect` calls:

1. one that runs only when the component is uncontrolled (it uses the `oninput` event to update the auto-expand size)
2. one that runs only when the component is controlled (it has the `value` as dependency in the effect, to update the auto-expand size)

## PR Checklist

-   [ ] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI
