### PR TITLE
feat: Expose closeToast in useToasts hook action object

### DIFF
--- a/src/toast/static-toast.tsx
+++ b/src/toast/static-toast.tsx
@@ -11,6 +11,7 @@ import styles from './toast.module.css'
 type ToastActionObject = {
     label: string
     onClick: () => void
+    closeToast?: boolean
 }
 
 type StaticToastProps = {

--- a/src/toast/toast.stories.tsx
+++ b/src/toast/toast.stories.tsx
@@ -88,10 +88,26 @@ export function NotificationToastsStory() {
                         >
                             Show toast with action
                         </Button>
+                        <Button
+                            variant="primary"
+                            onClick={() => {
+                                const actionLabel = getRandom(actions)
+                                showToast({
+                                    message: `${count.current++}: ${getRandom(message)}`,
+                                    action: {
+                                        label: actionLabel,
+                                        onClick: storybookAction(actionLabel),
+                                    },
+                                    showStickyToast: true,
+                                })
+                            }}
+                        >
+                            Show sticky toast
+                        </Button>
                     </Inline>
                 </Box>
                 <SwitchField
-                    label="Show sticky toast?"
+                    label="Show sticky toast without hook?"
                     checked={showSticky}
                     onChange={(event) => setShowSticky(event.target.checked)}
                     message={

--- a/src/toast/toast.stories.tsx
+++ b/src/toast/toast.stories.tsx
@@ -97,17 +97,17 @@ export function NotificationToastsStory() {
                                     action: {
                                         label: actionLabel,
                                         onClick: storybookAction(actionLabel),
+                                        closeToast: false,
                                     },
-                                    showStickyToast: true,
                                 })
                             }}
                         >
-                            Show sticky toast
+                            Show toast without closing on action
                         </Button>
                     </Inline>
                 </Box>
                 <SwitchField
-                    label="Show sticky toast without hook?"
+                    label="Show sticky toast?"
                     checked={showSticky}
                     onChange={(event) => setShowSticky(event.target.checked)}
                     message={

--- a/src/toast/toast.test.tsx
+++ b/src/toast/toast.test.tsx
@@ -124,12 +124,11 @@ describe('useToast', () => {
         expect(within(screen.getByRole('alert')).getByTestId('test-icon')).toBeInTheDocument()
     })
 
-    it('allows to keep the toast after the action is performed if showStickyToast is true', () => {
+    it('allows to keep the toast after the action is performed if closeToast is false', () => {
         const actionFn = jest.fn()
         const { showToast } = renderTestCase()
         showToast({
-            action: { label: 'A sticky toast action', onClick: actionFn },
-            showStickyToast: true,
+            action: { label: 'A sticky toast action', onClick: actionFn, closeToast: false },
         })
         expect(actionFn).not.toHaveBeenCalled()
         userEvent.click(
@@ -139,7 +138,7 @@ describe('useToast', () => {
         )
         expect(actionFn).toHaveBeenCalledTimes(1)
 
-        // showStickyToast has kept it in view
+        // closeToast has kept it in view
         expect(screen.getByRole('alert')).toBeInTheDocument()
     })
 

--- a/src/toast/toast.test.tsx
+++ b/src/toast/toast.test.tsx
@@ -124,22 +124,45 @@ describe('useToast', () => {
         expect(within(screen.getByRole('alert')).getByTestId('test-icon')).toBeInTheDocument()
     })
 
-    it('allows to keep the toast after the action is performed if closeToast is false', () => {
-        const actionFn = jest.fn()
-        const { showToast } = renderTestCase()
-        showToast({
-            action: { label: 'A sticky toast action', onClick: actionFn, closeToast: false },
-        })
-        expect(actionFn).not.toHaveBeenCalled()
-        userEvent.click(
-            within(screen.getByRole('alert')).getByRole('button', {
-                name: 'A sticky toast action',
-            }),
-        )
-        expect(actionFn).toHaveBeenCalledTimes(1)
+    describe('if `closeToast` is false', () => {
+        it('keeps the toast visible after the action button is clicked', () => {
+            const actionFn = jest.fn()
+            const { showToast } = renderTestCase()
+            showToast({
+                action: { label: 'A sticky toast action', onClick: actionFn, closeToast: false },
+            })
+            expect(actionFn).not.toHaveBeenCalled()
+            userEvent.click(
+                within(screen.getByRole('alert')).getByRole('button', {
+                    name: 'A sticky toast action',
+                }),
+            )
+            expect(actionFn).toHaveBeenCalledTimes(1)
 
-        // closeToast has kept it in view
-        expect(screen.getByRole('alert')).toBeInTheDocument()
+            // closeToast has kept it in view
+            expect(screen.getByRole('alert')).toBeInTheDocument()
+        })
+    })
+
+    describe('if `closeToast` is true', () => {
+        it('removes the toast from view after the action button is clicked', async () => {
+            const actionFn = jest.fn()
+            const { showToast } = renderTestCase()
+            showToast({
+                action: { label: 'A sticky toast action', onClick: actionFn },
+            })
+            expect(actionFn).not.toHaveBeenCalled()
+            userEvent.click(
+                within(screen.getByRole('alert')).getByRole('button', {
+                    name: 'A sticky toast action',
+                }),
+            )
+            expect(actionFn).toHaveBeenCalledTimes(1)
+
+            await waitFor(() => {
+                expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+            })
+        })
     })
 
     describe('Dismiss button', () => {

--- a/src/toast/toast.test.tsx
+++ b/src/toast/toast.test.tsx
@@ -124,6 +124,25 @@ describe('useToast', () => {
         expect(within(screen.getByRole('alert')).getByTestId('test-icon')).toBeInTheDocument()
     })
 
+    it('allows to keep the toast after the action is performed if showStickyToast is true', () => {
+        const actionFn = jest.fn()
+        const { showToast } = renderTestCase()
+        showToast({
+            action: { label: 'A sticky toast action', onClick: actionFn },
+            showStickyToast: true,
+        })
+        expect(actionFn).not.toHaveBeenCalled()
+        userEvent.click(
+            within(screen.getByRole('alert')).getByRole('button', {
+                name: 'A sticky toast action',
+            }),
+        )
+        expect(actionFn).toHaveBeenCalledTimes(1)
+
+        // showStickyToast has kept it in view
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+
     describe('Dismiss button', () => {
         it('is rendered with a default label', () => {
             const { showToast } = renderTestCase()

--- a/src/toast/use-toasts.tsx
+++ b/src/toast/use-toasts.tsx
@@ -39,17 +39,6 @@ type ToastProps = StaticToastProps & {
      * dismiss the toast by calling the function returned by `showToast`.
      */
     showDismissButton?: boolean
-
-    /**
-     * Whether to keep the toast after the action is performed.
-     *
-     * Set this value to true if, in your particular case, it doesn't make sense for the confirm action to call
-     * onDismiss right after. If set to true, it is your responsibility to then close the toast after performing
-     * the confirm action.
-     *
-     * @default false
-     */
-    showStickyToast?: boolean
 }
 
 //
@@ -75,7 +64,6 @@ const InternalToast = React.forwardRef<HTMLDivElement, InternalToastProps>(funct
         toastId,
         onDismiss,
         onRemoveToast,
-        showStickyToast = false,
     },
     ref,
 ) {
@@ -121,6 +109,7 @@ const InternalToast = React.forwardRef<HTMLDivElement, InternalToastProps>(funct
 
         return {
             ...action,
+            closeToast: action.closeToast ?? true,
             onClick: function handleActionClick() {
                 if (!action) {
                     return
@@ -128,12 +117,12 @@ const InternalToast = React.forwardRef<HTMLDivElement, InternalToastProps>(funct
 
                 action.onClick()
 
-                if (!showStickyToast) {
+                if (action.closeToast ?? true) {
                     removeToast()
                 }
             },
         }
-    }, [action, removeToast, showStickyToast])
+    }, [action, removeToast])
 
     return (
         <StaticToast

--- a/src/toast/use-toasts.tsx
+++ b/src/toast/use-toasts.tsx
@@ -39,6 +39,17 @@ type ToastProps = StaticToastProps & {
      * dismiss the toast by calling the function returned by `showToast`.
      */
     showDismissButton?: boolean
+
+    /**
+     * Whether to keep the toast after the action is performed.
+     *
+     * Set this value to true if, in your particular case, it doesn't make sense for the confirm action to call
+     * onDismiss right after. If set to true, it is your responsibility to then close the toast after performing
+     * the confirm action.
+     *
+     * @default false
+     */
+    showStickyToast?: boolean
 }
 
 //
@@ -64,6 +75,7 @@ const InternalToast = React.forwardRef<HTMLDivElement, InternalToastProps>(funct
         toastId,
         onDismiss,
         onRemoveToast,
+        showStickyToast = false,
     },
     ref,
 ) {
@@ -115,10 +127,13 @@ const InternalToast = React.forwardRef<HTMLDivElement, InternalToastProps>(funct
                 }
 
                 action.onClick()
-                removeToast()
+
+                if (!showStickyToast) {
+                    removeToast()
+                }
             },
         }
-    }, [action, removeToast])
+    }, [action, removeToast, showStickyToast])
 
     return (
         <StaticToast


### PR DESCRIPTION
## Short description

Adds a new prop to the `useToasts` hook: `showStickyToast`. This works exactly as seen in Storybook when checking the sticky toast checkbox [here](https://doist.github.io/reactist/?path=/docs/design-system-toast--notification-toasts-story). Except that state is managed locally in the story. 

We're exposing via the hook to give consumers a chance to choose whether the action calls `onDismiss` (which aside from closing the toast, would also call any logic consumers are passing into `onDismiss`, which may be undesirable).

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
