### PR TITLE
fix: Toasts can be auto-dismissed when concurrent mode is enabled

### DIFF
--- a/src/toast/use-toasts.tsx
+++ b/src/toast/use-toasts.tsx
@@ -67,18 +67,7 @@ const InternalToast = React.forwardRef<HTMLDivElement, InternalToastProps>(funct
     },
     ref,
 ) {
-    const [timeoutRunning, setTimeoutRunning] = React.useState(Boolean(autoDismissDelay))
     const timeoutRef = React.useRef<number | undefined>()
-
-    const startTimeout = React.useCallback(function startTimeout() {
-        setTimeoutRunning(true)
-    }, [])
-
-    const stopTimeout = React.useCallback(function stopTimeout() {
-        setTimeoutRunning(false)
-        clearTimeout(timeoutRef.current)
-        timeoutRef.current = undefined
-    }, [])
 
     const removeToast = React.useCallback(
         function removeToast() {
@@ -88,13 +77,27 @@ const InternalToast = React.forwardRef<HTMLDivElement, InternalToastProps>(funct
         [onDismiss, onRemoveToast, toastId],
     )
 
+    const startTimeout = React.useCallback(
+        function startTimeout() {
+            if (!autoDismissDelay) return
+            timeoutRef.current = window.setTimeout(removeToast, autoDismissDelay * 1000)
+        },
+        [autoDismissDelay, removeToast],
+    )
+
+    const stopTimeout = React.useCallback(function stopTimeout() {
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = undefined
+    }, [])
+
     React.useEffect(
         function setupAutoDismiss() {
-            if (!timeoutRunning || !autoDismissDelay) return
-            timeoutRef.current = window.setTimeout(removeToast, autoDismissDelay * 1000)
+            stopTimeout()
+            startTimeout()
+
             return stopTimeout
         },
-        [autoDismissDelay, removeToast, stopTimeout, timeoutRunning],
+        [startTimeout, stopTimeout],
     )
 
     /**


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

This updates the `Toast` component so that its auto dismiss effect is compatible with new `<StrictMode>` behaviours in dev mode. As we can no longer assume effects are just run once, this removes the `timeoutRunning` state, reducing the reliance on the `setupAutoDismiss` effect and instead allow `startTimeout` to set the timeout directly.

### Test plan

* Run storybook and navigate to http://localhost:6006/?path=/docs/design-system-toast--notification-toasts-story. 
* [ ] Verify that toasts are dismissed after 10s
* [ ] Verify that hovering your mouse over the toasts prevents it from auto dismissing, and moving the cursor off restarts the timeout
* [ ] Optional: we can't test Reactist's storybook in React 18 without upgrading Storybook, so we can follow the instructions on using yelc to run this within Todoist, specifically [this branch](https://github.com/Doist/todoist-web/pull/13388) where we boot React with `createRoot`

## Reference

https://react.dev/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [ ] Added tests for bugs / new features
-   [ ] Updated docs (storybooks, readme)
-   [ ] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
