### PR TITLE
fix(base-field): Don't unnecessarily render container below BaseField children

### DIFF
--- a/src/base-field/base-field.tsx
+++ b/src/base-field/base-field.tsx
@@ -268,14 +268,12 @@ function BaseField({
 
     const ariaDescribedBy = originalAriaDescribedBy ?? (message ? messageId : null)
 
-    /**
-     * Renders the character count element.
-     * If the characterCountPosition value is 'hidden', it returns null.
-     */
+    const renderCharacterCountBelow = characterCountPosition === 'below' && characterCount !== null
+    const renderCharacterCountInline =
+        characterCountPosition === 'inline' && characterCount !== null
+
     function renderCharacterCount() {
-        return characterCountPosition !== 'hidden' ? (
-            <FieldCharacterCount tone={characterCountTone}>{characterCount}</FieldCharacterCount>
-        ) : null
+        return <FieldCharacterCount tone={characterCountTone}>{characterCount}</FieldCharacterCount>
     }
 
     const childrenProps: ChildrenRenderProps = {
@@ -297,7 +295,7 @@ function BaseField({
             setCharacterCountTone(inputLength.tone)
         },
         // If the character count is inline, we pass it as a prop to the children element so it can be rendered inline
-        characterCountElement: characterCountPosition === 'inline' ? renderCharacterCount() : null,
+        characterCountElement: renderCharacterCountInline ? renderCharacterCount() : null,
     }
 
     React.useEffect(
@@ -360,7 +358,7 @@ function BaseField({
                 {endSlot && endSlotPosition === 'fullHeight' ? endSlot : null}
             </Box>
 
-            {message || characterCount ? (
+            {message || renderCharacterCountBelow ? (
                 <Columns align="right" space="small" maxWidth={maxWidth}>
                     {message ? (
                         <Column width="auto">


### PR DESCRIPTION
## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

Previously, a small gap would be rendered under `<BaseField>`'s children when a `maxLength` was provided. This happened because we'd always render a container for the character count under the field, even when `characterCountPosition` was `inline`. Now, we only render the container when needed (i.e. when there's a `message` or `characterCountPosition === 'below'`).

Show PR for tiny bug fix.

## 📸 Demo

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>

<img width="454" alt="image" src="https://github.com/user-attachments/assets/6c0cbb48-16c0-48d3-b285-ecb9a6ff899b" />

</td><td>

<img width="454" alt="image" src="https://github.com/user-attachments/assets/1f980e12-b104-45fc-b2e9-3589a49ff405" />

</td></tr>
</tbody>
</table>

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
