### PR TITLE
fix(Box): Inherit `font-size` to prevent unintended typography overrides

### DIFF
--- a/src/box/box.module.css
+++ b/src/box/box.module.css
@@ -3,7 +3,7 @@
     border: 0;
     margin: 0;
     padding: 0;
-    font-size: var(--reactist-font-size-body);
+    font-size: inherit;
     font-family: inherit;
     vertical-align: baseline;
     background-color: transparent;


### PR DESCRIPTION
## Short description

This PR removes the default `font-size` from the `Box` component to avoid unintentionally overriding the font-size of its children. Components like `Stack`, which use `Box` internally, can inherit typography from their parent. Forcing a specific font-size in `Box` causes issues when nesting text elements, leading to inconsistent styles and the need for manual overrides like `font-size: inherit`. Removing this makes `Box` a more flexible layout utility and avoids unnecessary overrides.

### 🔗 Reference

- https://twist.com/a/1585/ch/190200/t/7035042/

## PR Checklist

-   [ ] Reviewed and approved Chromatic visual regression tests in CI
