### PR TITLE
fix: Update `BaseField` styling to match the form field spec

### DIFF
--- a/src/base-field/base-field.module.css
+++ b/src/base-field/base-field.module.css
@@ -1,9 +1,13 @@
 :root {
-    --reactist-field-label-padding-bottom: var(--reactist-spacing-small);
+    --reactist-field-label-padding-bottom: 6px;
     --reactist-field-label-line-height: inherit;
 }
 .container {
     font-family: var(--reactist-font-family);
+}
+
+.container label {
+    letter-spacing: -0.15px;
 }
 
 .container label,
@@ -32,6 +36,10 @@
     cursor: default;
 }
 
+.container.bordered:hover {
+    border-color: var(--reactist-inputs-hover) !important;
+}
+
 .container.bordered:focus-within {
     border-color: var(--reactist-inputs-focus) !important;
 }
@@ -54,6 +62,16 @@
 
 .container:not(.bordered) .auxiliaryLabel {
     font-size: var(--reactist-font-size-body);
+}
+
+.container input,
+.container textarea,
+.container select {
+    font-size: var(--reactist-font-size-body);
+    font-style: normal;
+    font-weight: var(--reactist-font-weight-regular);
+    line-height: calc(var(--reactist-font-size-body) + 7px);
+    letter-spacing: -0.15px;
 }
 
 .auxiliaryLabel {

--- a/src/select-field/select-field.module.css
+++ b/src/select-field/select-field.module.css
@@ -44,8 +44,6 @@
     background: none;
     border-radius: var(--reactist-border-radius-small);
     border: 1px solid var(--reactist-inputs-idle);
-    font-size: var(--reactist-font-size-body);
-    line-height: calc(var(--reactist-font-size-body) + 4px);
     margin: 0;
 }
 
@@ -55,6 +53,10 @@
 
 .selectWrapper:not(.bordered) option {
     background-color: var(--reactist-bg-aside);
+}
+
+.selectWrapper:not(.bordered) select:hover {
+    border-color: var(--reactist-inputs-hover);
 }
 
 .selectWrapper:not(.bordered) select:focus {

--- a/src/styles/design-tokens.css
+++ b/src/styles/design-tokens.css
@@ -56,6 +56,7 @@
     --reactist-divider-tertiary: #edf2f3;
 
     /* input border colors */
+    --reactist-inputs-hover: var(--reactist-divider-primary);
     --reactist-inputs-focus: var(--reactist-divider-primary);
     --reactist-inputs-idle: var(--reactist-divider-secondary);
     --reactist-inputs-alert: rgb(209, 69, 59);

--- a/src/text-area/text-area.module.css
+++ b/src/text-area/text-area.module.css
@@ -24,7 +24,6 @@ See https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
     border: none;
     padding: 0;
     box-sizing: border-box;
-    font: inherit;
     width: 100%;
     resize: vertical;
     overflow-wrap: anywhere; /* to stop unnecessary horizontal expansion of text-area when `autoExpand` is enabled.*/
@@ -49,6 +48,11 @@ See https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
 .textAreaContainer:not(.bordered) textarea,
 .textAreaContainer.bordered {
     border: 1px solid var(--reactist-inputs-idle);
+}
+
+.textAreaContainer:not(.bordered) textarea:hover,
+.textAreaContainer.bordered:hover {
+    border-color: var(--reactist-inputs-hover);
 }
 
 .textAreaContainer:not(.bordered) textarea:focus,

--- a/src/text-field/text-field.module.css
+++ b/src/text-field/text-field.module.css
@@ -29,6 +29,10 @@
     height: var(--reactist-input-wrapper-height);
 }
 
+.inputWrapper:not(.bordered):hover {
+    border-color: var(--reactist-inputs-hover);
+}
+
 .inputWrapper:not(.bordered):focus-within {
     border-color: var(--reactist-inputs-focus);
 }
@@ -65,8 +69,6 @@
             ) / 2
     );
 
-    font-size: var(--reactist-font-size-body);
-    line-height: calc(var(--reactist-font-size-body) + 4px);
     margin: 0;
 }
 


### PR DESCRIPTION
## Short description

This PR updates the `BaseField` component styling to match the form field spec:

- https://www.figma.com/design/5gTX7MuUxhCIvL6WK87JVA/24Q3-Foundation?node-id=1947-125676&m=dev

## PR Checklist

-   [x] Reviewed and approved Chromatic visual regression tests in CI