### PR TITLE
fix: Enable banner with an Image to use container full width

### DIFF
--- a/src/banner/banner.module.css
+++ b/src/banner/banner.module.css
@@ -22,7 +22,7 @@
     overflow: hidden;
     min-height: 64px;
 }
-.banner:has(.image) {
+.banner:not(.fullWidth):has(.image) {
     width: min-content;
     container-type: normal;
 }

--- a/src/banner/banner.stories.mdx
+++ b/src/banner/banner.stories.mdx
@@ -218,6 +218,12 @@ export function BannerImageExamples({ theme }) {
                     inlineLinks={[{ label: 'Learn more', href: '#' }]}
                     onClose={() => ({})}
                 />
+                <Banner
+                    type="neutral"
+                    description="Here’s the banner with image that fit the whole container width"
+                    image={<PromoImage />}
+                    width="full"
+                />
             </Stack>
         </Stack>
     )

--- a/src/banner/banner.stories.mdx
+++ b/src/banner/banner.stories.mdx
@@ -220,7 +220,7 @@ export function BannerImageExamples({ theme }) {
                 />
                 <Banner
                     type="neutral"
-                    description="Here’s the banner with image that fit the whole container width"
+                    description="Here’s the banner with image that fit the whole container width."
                     image={<PromoImage />}
                     width="full"
                 />

--- a/src/banner/banner.tsx
+++ b/src/banner/banner.tsx
@@ -65,6 +65,7 @@ type BaseBanner = {
     description: Exclude<React.ReactNode, null | undefined | boolean>
     action?: Action
     inlineLinks?: InlineLink[]
+    width?: 'full' | 'auto'
 } & CloseButton
 
 /**
@@ -103,6 +104,7 @@ const Banner = React.forwardRef<HTMLDivElement, BannerProps>(function Banner(
         inlineLinks,
         closeLabel,
         onClose,
+        width = 'auto',
         ...props
     }: BannerProps,
     ref,
@@ -134,7 +136,8 @@ const Banner = React.forwardRef<HTMLDivElement, BannerProps>(function Banner(
             aria-live="polite"
             tabIndex={0}
             borderRadius="full"
-            className={styles.banner}
+            className={[styles.banner, width === 'full' ? styles.fullWidth : null]}
+            width={width}
         >
             {image ? <Box className={styles.image}>{image}</Box> : null}
 


### PR DESCRIPTION
## Short description

For the purpose [of adding a QR code banner](https://app.todoist.com/app/task/web-triggered-sidebar-card-with-qr-code-6cWMwvjqRrf3WcM7) to the app, we'd like the banner with the image to use the full width of its container. This is currently not possible, because the banners with images get automatically narrowed to the image's width.

<img width="1516" height="1706" alt="CleanShot 2025-08-06 at 12 04 59@2x" src="https://github.com/user-attachments/assets/44877971-ef13-4fc5-953a-b8998a56a402" />

This PR enables the user to choose if the banner with an image should be narrowed (default behaviour) or if it should stretch to the full width.

<img width="1350" height="1124" alt="CleanShot 2025-08-06 at 12 06 49@2x" src="https://github.com/user-attachments/assets/e8d1fb7e-55db-40ad-b6d7-52c8e63a097b" />

## Reference
- Required for https://app.todoist.com/app/task/web-triggered-sidebar-card-with-qr-code-6cWMwvjqRrf3WcM7


