### PR TITLE
fix: Enable banner with an Image to use container full width (with CSS vars)

### DIFF
--- a/src/banner/banner.module.css
+++ b/src/banner/banner.module.css
@@ -62,6 +62,12 @@
     display: block;
 }
 
+/* The close button is invisible in this resolution, so we're hiding the container to prevent flex-gap from making extra space */
+.icon:empty,
+.icon:has(.closeButton:only-child) {
+    display: none;
+}
+
 .icon .closeButton {
     display: none;
 }
@@ -85,6 +91,9 @@
         width: 100%;
         align-items: center;
         justify-content: space-between;
+    }
+    .icon:has(.closeButton:only-child) {
+        display: flex;
     }
     .icon .closeButton {
         display: flex;

--- a/src/banner/banner.module.css
+++ b/src/banner/banner.module.css
@@ -11,6 +11,8 @@
     --reactist-banner-secondary-copy-font-size: 12px;
     --reactist-banner-secondary-copy-line-height: 20px;
     --reactist-banner-secondary-copy-color: #666666;
+
+    --reactist-banner-min-width: 0;
 }
 
 .banner {
@@ -21,6 +23,7 @@
     border: 1px solid var(--reactist-banner-border-color);
     overflow: hidden;
     min-height: 64px;
+    min-width: var(--reactist-banner-min-width);
 }
 .banner:has(.image) {
     width: min-content;

--- a/src/banner/banner.stories.mdx
+++ b/src/banner/banner.stories.mdx
@@ -218,6 +218,13 @@ export function BannerImageExamples({ theme }) {
                     inlineLinks={[{ label: 'Learn more', href: '#' }]}
                     onClose={() => ({})}
                 />
+                <div style={{ '--reactist-banner-min-width': '100%' }}>
+                    <Banner
+                        type="neutral"
+                        description="Here’s the banner with image that fit the whole container width."
+                        image={<PromoImage />}
+                    />
+                </div>
             </Stack>
         </Stack>
     )


### PR DESCRIPTION
## Short description

For the purpose [of adding a QR code banner](https://app.todoist.com/app/task/web-triggered-sidebar-card-with-qr-code-6cWMwvjqRrf3WcM7) to the app, we'd like the banner with the image to use the full width of its container. This is currently not possible, because the banners with images get automatically narrowed to the image's width.

<img width="1516" height="1706" alt="CleanShot 2025-08-06 at 12 04 59@2x" src="https://github.com/user-attachments/assets/44877971-ef13-4fc5-953a-b8998a56a402" />

This PR enables the user to choose if the banner with an image should be narrowed (default behaviour) or if it should stretch to the full width.

<img width="1350" height="1124" alt="CleanShot 2025-08-06 at 12 06 49@2x" src="https://github.com/user-attachments/assets/e8d1fb7e-55db-40ad-b6d7-52c8e63a097b" />

## Implementation

This solution leverages CSS vars to set the banner's min-width. 

## Reference
- Required for https://app.todoist.com/app/task/web-triggered-sidebar-card-with-qr-code-6cWMwvjqRrf3WcM7


