### PR TITLE
fix: Smaller loader in `<Button>` component

### DIFF
--- a/src/button/button.stories.mdx
+++ b/src/button/button.stories.mdx
@@ -26,14 +26,21 @@ export function Icon() {
     )
 }
 
-export function LoadingButton(props) {
+export function LoadingButton({ disabledWhenLoading = false, ...props }) {
     const [loading, setLoading] = useState(false)
     useEffect(() => {
         if (!loading) return undefined
         const timeout = setTimeout(() => setLoading(false), 3000)
         return () => clearTimeout(timeout)
     }, [loading])
-    return <Button {...props} loading={loading} onClick={() => setLoading(true)} />
+    return (
+        <Button
+            {...props}
+            loading={loading}
+            disabled={disabledWhenLoading ? loading : props.disabled}
+            onClick={() => setLoading(true)}
+        />
+    )
 }
 
 # Button
@@ -66,6 +73,28 @@ export function LoadingButton(props) {
                     </Box>
                     <Box>
                         <LoadingButton variant="quaternary">Quaternary</LoadingButton>
+                    </Box>
+                </Inline>
+                <Inline space="large">
+                    <Box>
+                        <LoadingButton variant="primary" disabledWhenLoading>
+                            Primary
+                        </LoadingButton>
+                    </Box>
+                    <Box>
+                        <LoadingButton variant="secondary" disabledWhenLoading>
+                            Secondary
+                        </LoadingButton>
+                    </Box>
+                    <Box>
+                        <LoadingButton variant="tertiary" disabledWhenLoading>
+                            Tertiary
+                        </LoadingButton>
+                    </Box>
+                    <Box>
+                        <LoadingButton variant="quaternary" disabledWhenLoading>
+                            Quaternary
+                        </LoadingButton>
                     </Box>
                 </Inline>
                 <Inline space="large">
@@ -111,6 +140,28 @@ export function LoadingButton(props) {
                     </Box>
                     <Box>
                         <LoadingButton variant="quaternary" tone="destructive">
+                            Quaternary
+                        </LoadingButton>
+                    </Box>
+                </Inline>
+                <Inline space="large">
+                    <Box>
+                        <LoadingButton variant="primary" tone="destructive" disabledWhenLoading>
+                            Primary
+                        </LoadingButton>
+                    </Box>
+                    <Box>
+                        <LoadingButton variant="secondary" tone="destructive" disabledWhenLoading>
+                            Secondary
+                        </LoadingButton>
+                    </Box>
+                    <Box>
+                        <LoadingButton variant="tertiary" tone="destructive" disabledWhenLoading>
+                            Tertiary
+                        </LoadingButton>
+                    </Box>
+                    <Box>
+                        <LoadingButton variant="quaternary" tone="destructive" disabledWhenLoading>
                             Quaternary
                         </LoadingButton>
                     </Box>

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -177,7 +177,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
             <>
                 {startIcon ? (
                     <Box display="flex" className={styles.startIcon} aria-hidden>
-                        {loading && !endIcon ? <Spinner /> : startIcon}
+                        {loading && !endIcon ? <Spinner size={18} /> : startIcon}
                     </Box>
                 ) : null}
 

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -177,7 +177,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
             <>
                 {startIcon ? (
                     <Box display="flex" className={styles.startIcon} aria-hidden>
-                        {loading && !endIcon ? <Spinner size={18} /> : startIcon}
+                        {loading && !endIcon ? <Spinner /> : startIcon}
                     </Box>
                 ) : null}
 
@@ -195,7 +195,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
 
                 {endIcon || (loading && !startIcon) ? (
                     <Box display="flex" className={styles.endIcon} aria-hidden>
-                        {loading ? <Spinner size={18} /> : endIcon}
+                        {loading ? <Spinner /> : endIcon}
                     </Box>
                 ) : null}
             </>
@@ -264,7 +264,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(function
                 disabled ? styles.disabled : null,
             ])}
         >
-            {(loading && <Spinner size={18} />) || icon}
+            {(loading && <Spinner />) || icon}
         </Role.button>
     )
 

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -195,7 +195,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
 
                 {endIcon || (loading && !startIcon) ? (
                     <Box display="flex" className={styles.endIcon} aria-hidden>
-                        {loading ? <Spinner /> : endIcon}
+                        {loading ? <Spinner size={18} /> : endIcon}
                     </Box>
                 ) : null}
             </>
@@ -264,7 +264,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(function
                 disabled ? styles.disabled : null,
             ])}
         >
-            {(loading && <Spinner />) || icon}
+            {(loading && <Spinner size={18} />) || icon}
         </Role.button>
     )
 

--- a/src/spinner/spinner.tsx
+++ b/src/spinner/spinner.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import styles from './spinner.module.css'
 
-function Spinner({ size = 24 }: { size?: number }) {
+function Spinner({ size = 18 }: { size?: number }) {
     return (
         <svg
             aria-hidden


### PR DESCRIPTION
## Short description

This PR reduces the size of the loader icon that gets displayed inside a `<Button>` component, when the `loading` prop is true. More specifically, the loader size was `24px` prior to this PR. This PR changes it to `18px`.

## Reference

- [Todoist task](https://app.todoist.com/app/task/web-add-appropriately-sized-loader-spinner-to-upload-photo-flow-6cpWVf4jmRRpqFW7)
- Requested [in Figma here](https://www.figma.com/design/z4zytHrQew1cySsuoVVckt?node-id=1884-226828&m=dev#1411492158)
- Discover the need for this fix while implementing https://github.com/Doist/todoist-web/pull/14237
- Enables https://github.com/Doist/todoist-web/pull/14639

## Demo 

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>

https://github.com/user-attachments/assets/00f7b102-362e-44bf-8fa1-6f4887fa9e6a

</td><td>

https://github.com/user-attachments/assets/e4fae595-3f7c-4d84-8e3f-24a2de955091

</td></tr>
</tbody>
</table>