### PR TITLE
fix: Prevent a controlled TextArea from expanding when autoExpand is false

### DIFF
--- a/src/text-area/text-area.stories.mdx
+++ b/src/text-area/text-area.stories.mdx
@@ -22,10 +22,17 @@ export function preventDefault(event) {
     event.preventDefault()
 }
 
-export function InteractivePropsStory({ label, auxiliaryLabel, ...props }) {
+export function InteractivePropsStory({
+    label,
+    auxiliaryLabel,
+    value,
+    controlled: _controlled,
+    ...props
+}) {
     return (
         <TextArea
             {...props}
+            value={value}
             label={label}
             auxiliaryLabel={
                 auxiliaryLabel ? (
@@ -49,7 +56,15 @@ export function InteractivePropsStory({ label, auxiliaryLabel, ...props }) {
                 control: { type: 'text' },
                 defaultValue: 'User bio',
             },
-            value: { table: { disable: true } },
+            controlled: {
+                control: { type: 'boolean' },
+                defaultValue: false,
+            },
+            value: {
+                if: { arg: 'controlled', truthy: true },
+                control: { type: 'text' },
+                defaultValue: '',
+            },
             tone: {
                 options: ['neutral', 'success', 'error', 'loading'],
                 control: { type: 'inline-radio' },

--- a/src/text-area/text-area.test.tsx
+++ b/src/text-area/text-area.test.tsx
@@ -248,6 +248,27 @@ describe('TextArea', () => {
         expect(screen.getByTestId('value')).toHaveTextContent('I love to travel around the world')
     })
 
+    it('sets a data-replicated-value attribute on a controlled field when autoExpand is true', () => {
+        render(
+            <TextArea
+                value="I am a Frontend Developer"
+                label="Tell us a bit about you"
+                autoExpand
+            />,
+        )
+        const textareaElement = screen.getByRole('textbox', { name: 'Tell us a bit about you' })
+        expect(textareaElement.parentElement).toHaveAttribute(
+            'data-replicated-value',
+            'I am a Frontend Developer',
+        )
+    })
+
+    it('does NOT set a data-replicated-value attribute on an uncontrolled field when autoExpand is false', () => {
+        render(<TextArea value="I am a Frontend Developer" label="Tell us a bit about you" />)
+        const textareaElement = screen.getByRole('textbox', { name: 'Tell us a bit about you' })
+        expect(textareaElement.parentElement).not.toHaveAttribute('data-replicated-value')
+    })
+
     describe('a11y', () => {
         it('renders with no a11y violations', async () => {
             const { container } = render(

--- a/src/text-area/text-area.tsx
+++ b/src/text-area/text-area.tsx
@@ -166,7 +166,7 @@ function useAutoExpand({
 
     React.useEffect(
         function setupAutoExpandWhenControlled() {
-            if (!isControlled) {
+            if (!isControlled || !autoExpand) {
                 return
             }
 
@@ -175,7 +175,7 @@ function useAutoExpand({
                 containerElement.dataset.replicatedValue = value
             }
         },
-        [value, containerRef, isControlled],
+        [value, containerRef, isControlled, autoExpand],
     )
 }
 


### PR DESCRIPTION
## Short description

When a controlled `TextArea` has the `autoExpand` prop omitted or set to false, it would still expand based on the content as the `setupAutoExpandWhenControlled` effect was missing a check for the prop.

|Before|After|
|-|-|
|<img width="442" height="269" alt="image" src="https://github.com/user-attachments/assets/5321a206-5ee3-4f6e-a011-60bd553aeb78" />|<img width="444" height="158" alt="image" src="https://github.com/user-attachments/assets/0f4c15cf-fce0-4a88-a37b-da5276a23e7d" />|

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

-   [x] Added tests for bugs / new features
-   [x] Updated docs (storybooks, readme)
-   [x] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
