### PR TITLE
feat: add shadcn component registry build system

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,4 +1,4 @@
-name: Deploy Storybook to Pages
+name: Deploy Storybook and Registry to Pages
 
 on:
     push:
@@ -49,6 +49,12 @@ jobs:
 
             - name: Build storybook
               run: npm run build:storybook
+
+            - name: Build registry
+              run: npm run build:registry
+
+            - name: Copy registry into storybook output
+              run: cp -r public/r docs/r
 
             - name: Setup Pages
               uses: actions/configure-pages@v3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,3 +44,5 @@ jobs:
             - run: npm run type-check
             - run: npm test
             - run: npm run build
+            - run: npm run build:registry
+            - run: npm run test:registry

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage/
 stats.html
 public/
 registry/
+registry.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ lib/
 coverage/
 .vscode/
 stats.html
+public/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 .vscode/
 stats.html
 public/
+registry/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ If you prefer to include static files grab the [minified build from the dist fol
 <link rel="stylesheet" type="text/css" href="./node_modules/@doist/reactist/styles/reactist.css" />
 ```
 
-# Registry (shadcn/ui)
+# Registry (shadcn/ui) — experimental
+
+> **Note:** The shadcn registry is experimental and may change without notice.
 
 Reactist is also available as a [shadcn/ui registry](https://ui.shadcn.com/docs/registry), distributing component source files (TypeScript + CSS Modules) directly into your project.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,34 @@ If you prefer to include static files grab the [minified build from the dist fol
 <link rel="stylesheet" type="text/css" href="./node_modules/@doist/reactist/styles/reactist.css" />
 ```
 
+# Registry (shadcn/ui)
+
+Reactist is also available as a [shadcn/ui registry](https://ui.shadcn.com/docs/registry), distributing component source files (TypeScript + CSS Modules) directly into your project.
+
+```sh
+npx shadcn add https://doist.github.io/reactist/r
+```
+
+## Setup
+
+Your bundler must support CSS Modules (Vite, Next.js, and webpack do by default). Add a path alias so registry imports resolve correctly:
+
+```json
+{
+    "compilerOptions": {
+        "paths": {
+            "@reactist/*": ["./src/components/reactist/*"]
+        }
+    }
+}
+```
+
+## Mixing npm and registry
+
+Do not import the same component from both `@doist/reactist` (npm) and the registry. Each source applies its own CSS Module scoping, so duplicate components will have conflicting styles.
+
+Different components from different sources (e.g., Button from npm, Box from registry) work fine — CSS Modules scope independently. Migrate one component at a time.
+
 # Changelog
 
 You can find our changelog [here](./CHANGELOG.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,7 @@
                 "rollup": "2.79.2",
                 "rollup-plugin-styles": "4.0.0",
                 "rollup-plugin-visualizer": "6.0.5",
+                "shadcn": "3.8.3",
                 "style-loader": "^0.23.1",
                 "svg-url-loader": "^6.0.0",
                 "ts-loader": "^8.0.2",
@@ -136,6 +137,28 @@
             "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@antfu/ni": {
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-25.0.0.tgz",
+            "integrity": "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansis": "^4.0.0",
+                "fzf": "^0.5.2",
+                "package-manager-detector": "^1.3.0",
+                "tinyexec": "^1.0.1"
+            },
+            "bin": {
+                "na": "bin/na.mjs",
+                "nci": "bin/nci.mjs",
+                "ni": "bin/ni.mjs",
+                "nlx": "bin/nlx.mjs",
+                "nr": "bin/nr.mjs",
+                "nun": "bin/nun.mjs",
+                "nup": "bin/nup.mjs"
+            }
         },
         "node_modules/@ariakit/core": {
             "version": "0.4.16",
@@ -2813,6 +2836,94 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@dotenvx/dotenvx": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.52.0.tgz",
+            "integrity": "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "commander": "^11.1.0",
+                "dotenv": "^17.2.1",
+                "eciesjs": "^0.4.10",
+                "execa": "^5.1.1",
+                "fdir": "^6.2.0",
+                "ignore": "^5.3.0",
+                "object-treeify": "1.1.33",
+                "picomatch": "^4.0.2",
+                "which": "^4.0.0"
+            },
+            "bin": {
+                "dotenvx": "src/cli/dotenvx.js"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/@dotenvx/dotenvx/node_modules/commander": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@dotenvx/dotenvx/node_modules/dotenv": {
+            "version": "17.2.4",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.4.tgz",
+            "integrity": "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/@dotenvx/dotenvx/node_modules/isexe": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.2.tgz",
+            "integrity": "sha512-mIcis6w+JiQf3P7t7mg/35GKB4T1FQsBOtMIvuKw4YErj5RjtbhcTd5/I30fmkmGMwvI0WlzSNN+27K0QCMkAw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@dotenvx/dotenvx/node_modules/which": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+            "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^3.1.1"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@ecies/ciphers": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.5.tgz",
+            "integrity": "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "bun": ">=1",
+                "deno": ">=2",
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@noble/ciphers": "^1.0.0"
+            }
+        },
         "node_modules/@emotion/cache": {
             "version": "10.0.29",
             "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -3078,6 +3189,19 @@
                 "styled-components": "^5.2.1"
             }
         },
+        "node_modules/@hono/node-server": {
+            "version": "1.19.9",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+            "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.14.1"
+            },
+            "peerDependencies": {
+                "hono": "^4"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.13.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -3115,6 +3239,114 @@
             "deprecated": "Use @eslint/object-schema instead",
             "dev": true,
             "license": "BSD-3-Clause"
+        },
+        "node_modules/@inquirer/ansi": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+            "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/confirm": {
+            "version": "5.1.21",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+            "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^10.3.2",
+                "@inquirer/type": "^3.0.10"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/core": {
+            "version": "10.3.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+            "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/ansi": "^1.0.2",
+                "@inquirer/figures": "^1.0.15",
+                "@inquirer/type": "^3.0.10",
+                "cli-width": "^4.1.0",
+                "mute-stream": "^2.0.0",
+                "signal-exit": "^4.1.0",
+                "wrap-ansi": "^6.2.0",
+                "yoctocolors-cjs": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/cli-width": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+            "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/mute-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+            "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/@inquirer/external-editor": {
             "version": "1.0.2",
@@ -3155,6 +3387,34 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/@inquirer/figures": {
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+            "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/type": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+            "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@isaacs/balanced-match": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -3165,10 +3425,11 @@
             }
         },
         "node_modules/@isaacs/brace-expansion": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+            "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@isaacs/balanced-match": "^4.0.1"
             },
@@ -4475,6 +4736,404 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/@modelcontextprotocol/sdk": {
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+            "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@hono/node-server": "^1.19.9",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
+                "content-type": "^1.0.5",
+                "cors": "^2.8.5",
+                "cross-spawn": "^7.0.5",
+                "eventsource": "^3.0.2",
+                "eventsource-parser": "^3.0.0",
+                "express": "^5.2.1",
+                "express-rate-limit": "^8.2.1",
+                "hono": "^4.11.4",
+                "jose": "^6.1.3",
+                "json-schema-typed": "^8.0.2",
+                "pkce-challenge": "^5.0.0",
+                "raw-body": "^3.0.0",
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@cfworker/json-schema": "^4.1.1",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "@cfworker/json-schema": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^1.0.5",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.0",
+                "iconv-lite": "^0.7.0",
+                "on-finished": "^2.4.1",
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+            "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -4496,6 +5155,24 @@
             "dev": true,
             "license": "BSD"
         },
+        "node_modules/@mswjs/interceptors": {
+            "version": "0.41.0",
+            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.0.tgz",
+            "integrity": "sha512-edAo9bW53BLYeSK+UPRr2Iz1Fj9DeGMjytvVM0HXRoo750ElWUgPsZPAOTQa12EUiwgDErH2PsFNTLvk1jBxjQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@open-draft/deferred-promise": "^2.2.0",
+                "@open-draft/logger": "^0.3.0",
+                "@open-draft/until": "^2.0.0",
+                "is-node-process": "^1.2.0",
+                "outvariant": "^1.4.3",
+                "strict-event-emitter": "^0.5.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@nicolo-ribaudo/chokidar-2": {
             "version": "2.1.8-no-fsevents.3",
             "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -4503,6 +5180,48 @@
             "dev": true,
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/@noble/ciphers": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+            "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/curves": {
+            "version": "1.9.7",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.8.0"
+            },
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -4580,6 +5299,31 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/@open-draft/deferred-promise": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+            "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@open-draft/logger": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+            "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-node-process": "^1.2.0",
+                "outvariant": "^1.4.0"
+            }
+        },
+        "node_modules/@open-draft/until": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+            "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@pkgr/core": {
             "version": "0.2.9",
@@ -4754,12 +5498,32 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/@sec-ant/readable-stream": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.24.51",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
             "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@sindresorhus/merge-streams": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/@sinonjs/commons": {
             "version": "1.8.6",
@@ -9800,6 +10564,41 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/@ts-morph/common": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
+            "integrity": "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-glob": "^3.3.3",
+                "minimatch": "^10.0.1",
+                "path-browserify": "^1.0.1"
+            }
+        },
+        "node_modules/@ts-morph/common/node_modules/minimatch": {
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+            "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@ts-morph/common/node_modules/path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/aria-query": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -10269,6 +11068,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/statuses": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+            "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/tapable": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
@@ -10317,6 +11123,13 @@
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
             "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/validate-npm-package-name": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
+            "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/webpack": {
@@ -11381,6 +12194,16 @@
             },
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/ansis": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
+            "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/anymatch": {
@@ -13227,6 +14050,22 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -14169,6 +15008,13 @@
                 "node": ">=4"
             }
         },
+        "node_modules/code-block-writer": {
+            "version": "13.0.3",
+            "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+            "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/collapse-white-space": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
@@ -14654,6 +15500,24 @@
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/cors": {
+            "version": "2.8.6",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+            "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "object-assign": "^4",
+                "vary": "^1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
         },
         "node_modules/cosmiconfig": {
             "version": "7.1.0",
@@ -15549,6 +16413,16 @@
             "dev": true,
             "license": "BSD-2-Clause"
         },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/data-urls": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -15750,6 +16624,23 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/default-browser": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/default-browser-id": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-1.0.4.tgz",
@@ -15767,6 +16658,19 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/default-browser/node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/defaults": {
@@ -16009,6 +16913,16 @@
             },
             "engines": {
                 "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/diff": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+            "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
             }
         },
         "node_modules/diff-sequences": {
@@ -16319,6 +17233,24 @@
                 "safe-buffer": "~5.1.0"
             }
         },
+        "node_modules/eciesjs": {
+            "version": "0.4.17",
+            "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.17.tgz",
+            "integrity": "sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@ecies/ciphers": "^0.2.5",
+                "@noble/ciphers": "^1.3.0",
+                "@noble/curves": "^1.9.7",
+                "@noble/hashes": "^1.8.0"
+            },
+            "engines": {
+                "bun": ">=1",
+                "deno": ">=2",
+                "node": ">=16"
+            }
+        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -16469,6 +17401,16 @@
             "license": "BSD-2-Clause",
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/enzyme": {
@@ -17501,6 +18443,29 @@
                 "node": ">=0.8.x"
             }
         },
+        "node_modules/eventsource": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+            "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eventsource-parser": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/eventsource-parser": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+            "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/evp_bytestokey": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -17790,6 +18755,25 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/express-rate-limit": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+            "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "10.0.1"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
+            }
+        },
         "node_modules/express/node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -18027,6 +19011,30 @@
                 "picomatch": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
             }
         },
         "node_modules/fetch-retry": {
@@ -18655,6 +19663,19 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/forwarded": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -18897,6 +19918,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/fuzzysort": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
+            "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fzf": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fzf/-/fzf-0.5.2.tgz",
+            "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
         "node_modules/gauge": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
@@ -18949,6 +19984,19 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/get-east-asian-width": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+            "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -18972,6 +20020,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-own-enumerable-keys": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
+            "integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-own-enumerable-property-symbols": {
@@ -19256,6 +20317,16 @@
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/graphql": {
+            "version": "16.12.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+            "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+            }
         },
         "node_modules/handlebars": {
             "version": "4.7.8",
@@ -19652,6 +20723,13 @@
                 "tslib": "^2.0.3"
             }
         },
+        "node_modules/headers-polyfill": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+            "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/hermes-estree": {
             "version": "0.25.1",
             "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -19718,6 +20796,16 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/hono": {
+            "version": "4.11.7",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+            "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.9.0"
             }
         },
         "node_modules/hosted-git-info": {
@@ -20542,6 +21630,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/ip-address": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+            "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -21031,6 +22129,54 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/is-in-ssh": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+            "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container/node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-interactive": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -21076,6 +22222,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/is-node-process": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+            "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-number": {
             "version": "7.0.0",
@@ -21170,6 +22323,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -24131,6 +25291,16 @@
                 "@types/yargs-parser": "*"
             }
         },
+        "node_modules/jose": {
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+            "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
         "node_modules/js-string-escape": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -24291,6 +25461,13 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -25720,6 +26897,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/min-document": {
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -26040,6 +27230,111 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
+        "node_modules/msw": {
+            "version": "2.12.8",
+            "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.8.tgz",
+            "integrity": "sha512-KOriJUhjefCO+liF7Ie1KlSXcBAQEzuLhPZ4EKuEUSEmAR4YhuuzT9YuGxTipjqDrg6eWQ6oMoGVhvEnqukFGg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/confirm": "^5.0.0",
+                "@mswjs/interceptors": "^0.41.0",
+                "@open-draft/deferred-promise": "^2.2.0",
+                "@types/statuses": "^2.0.6",
+                "cookie": "^1.0.2",
+                "graphql": "^16.12.0",
+                "headers-polyfill": "^4.0.2",
+                "is-node-process": "^1.2.0",
+                "outvariant": "^1.4.3",
+                "path-to-regexp": "^6.3.0",
+                "picocolors": "^1.1.1",
+                "rettime": "^0.10.1",
+                "statuses": "^2.0.2",
+                "strict-event-emitter": "^0.5.1",
+                "tough-cookie": "^6.0.0",
+                "type-fest": "^5.2.0",
+                "until-async": "^3.0.2",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "msw": "cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mswjs"
+            },
+            "peerDependencies": {
+                "typescript": ">= 4.8.x"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/msw/node_modules/cookie": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/msw/node_modules/path-to-regexp": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/msw/node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/msw/node_modules/tough-cookie": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+            "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/msw/node_modules/type-fest": {
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.3.tgz",
+            "integrity": "sha512-AXSAQJu79WGc79/3e9/CR77I/KQgeY1AhNvcShIH4PTcGYyC4xv6H4R4AUOwkPS5799KlVDAu8zExeCrkGquiA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "dependencies": {
+                "tagged-tag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/mute-stream": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -26203,6 +27498,27 @@
             },
             "engines": {
                 "node": ">= 0.10.5"
+            }
+        },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "deprecated": "Use your platform's native DOMException instead",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.5.0"
             }
         },
         "node_modules/node-fetch": {
@@ -26653,6 +27969,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/object-treeify": {
+            "version": "1.1.33",
+            "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
+            "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/object-visit": {
@@ -28056,6 +29382,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/outvariant": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+            "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/own-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -28231,6 +29564,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/package-manager-detector": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+            "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -28378,6 +29718,19 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse-ms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+            "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -28850,6 +30203,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/pkce-challenge": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+            "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.20.0"
             }
         },
         "node_modules/pkg-dir": {
@@ -29698,6 +31061,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/powershell-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+            "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -29794,6 +31170,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/pretty-ms": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+            "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parse-ms": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/process": {
@@ -30019,9 +31411,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.14.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -31047,6 +32439,36 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/recast": {
+            "version": "0.23.11",
+            "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+            "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ast-types": "^0.16.1",
+                "esprima": "~4.0.0",
+                "source-map": "~0.6.1",
+                "tiny-invariant": "^1.3.3",
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/recast/node_modules/ast-types": {
+            "version": "0.16.1",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+            "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/rechoir": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -31709,6 +33131,13 @@
                 "node": ">=0.12"
             }
         },
+        "node_modules/rettime": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
+            "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/reusify": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -32086,6 +33515,34 @@
                 "node": ">= 12"
             }
         },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/router/node_modules/path-to-regexp": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/rst-selector-parser": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -32106,6 +33563,19 @@
             "license": "MIT",
             "engines": {
                 "node": "6.* || >= 7.*"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/run-async": {
@@ -32902,6 +34372,668 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/shadcn": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-3.8.3.tgz",
+            "integrity": "sha512-4cq123nBeWJWWhMT2wG7ddoix5jIfPBvybjbS+xwc9gtQbhmi5X6RY8FjR1OhUSN4TYqV2O5dmJ9cl0/eBHIfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@antfu/ni": "^25.0.0",
+                "@babel/core": "^7.28.0",
+                "@babel/parser": "^7.28.0",
+                "@babel/plugin-transform-typescript": "^7.28.0",
+                "@babel/preset-typescript": "^7.27.1",
+                "@dotenvx/dotenvx": "^1.48.4",
+                "@modelcontextprotocol/sdk": "^1.17.2",
+                "@types/validate-npm-package-name": "^4.0.2",
+                "browserslist": "^4.26.2",
+                "commander": "^14.0.0",
+                "cosmiconfig": "^9.0.0",
+                "dedent": "^1.6.0",
+                "deepmerge": "^4.3.1",
+                "diff": "^8.0.2",
+                "execa": "^9.6.0",
+                "fast-glob": "^3.3.3",
+                "fs-extra": "^11.3.1",
+                "fuzzysort": "^3.1.0",
+                "https-proxy-agent": "^7.0.6",
+                "kleur": "^4.1.5",
+                "msw": "^2.10.4",
+                "node-fetch": "^3.3.2",
+                "open": "^11.0.0",
+                "ora": "^8.2.0",
+                "postcss": "^8.5.6",
+                "postcss-selector-parser": "^7.1.0",
+                "prompts": "^2.4.2",
+                "recast": "^0.23.11",
+                "stringify-object": "^5.0.0",
+                "tailwind-merge": "^3.0.1",
+                "ts-morph": "^26.0.0",
+                "tsconfig-paths": "^4.2.0",
+                "validate-npm-package-name": "^7.0.1",
+                "zod": "^3.24.1",
+                "zod-to-json-schema": "^3.24.6"
+            },
+            "bin": {
+                "shadcn": "dist/index.js"
+            }
+        },
+        "node_modules/shadcn/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/shadcn/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/shadcn/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/shadcn/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/shadcn/node_modules/cli-cursor": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/shadcn/node_modules/cosmiconfig": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "env-paths": "^2.2.1",
+                "import-fresh": "^3.3.0",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/shadcn/node_modules/dedent": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
+            "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "babel-plugin-macros": "^3.1.0"
+            },
+            "peerDependenciesMeta": {
+                "babel-plugin-macros": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/shadcn/node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/shadcn/node_modules/execa": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.0",
+                "human-signals": "^8.0.1",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.2.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/shadcn/node_modules/figures": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+            "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-unicode-supported": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/fs-extra": {
+            "version": "11.3.3",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+            "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
+        "node_modules/shadcn/node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/shadcn/node_modules/human-signals": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/shadcn/node_modules/is-obj": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
+            "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/is-regexp": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+            "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/is-unicode-supported": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/shadcn/node_modules/kleur": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+            "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/shadcn/node_modules/log-symbols": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+            "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.3.0",
+                "is-unicode-supported": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/log-symbols/node_modules/is-unicode-supported": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
+        },
+        "node_modules/shadcn/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/onetime": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-function": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/open": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+            "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "default-browser": "^5.4.0",
+                "define-lazy-prop": "^3.0.0",
+                "is-in-ssh": "^1.0.0",
+                "is-inside-container": "^1.0.0",
+                "powershell-utils": "^0.1.0",
+                "wsl-utils": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/ora": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+            "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.3.0",
+                "cli-cursor": "^5.0.0",
+                "cli-spinners": "^2.9.2",
+                "is-interactive": "^2.0.0",
+                "is-unicode-supported": "^2.0.0",
+                "log-symbols": "^6.0.0",
+                "stdin-discarder": "^0.2.2",
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/postcss-selector-parser": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/shadcn/node_modules/restore-cursor": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/shadcn/node_modules/stdin-discarder": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+            "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/stringify-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
+            "integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "get-own-enumerable-keys": "^1.0.0",
+                "is-obj": "^3.0.0",
+                "is-regexp": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/yeoman/stringify-object?sponsor=1"
+            }
+        },
+        "node_modules/shadcn/node_modules/strip-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/shadcn/node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/shadcn/node_modules/strip-final-newline": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/shadcn/node_modules/tsconfig-paths": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+            "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json5": "^2.2.2",
+                "minimist": "^1.2.6",
+                "strip-bom": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/shadcn/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
         "node_modules/shallow-clone": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -33677,6 +35809,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/strict-event-emitter": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+            "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/strict-uri-encode": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -34338,6 +36477,30 @@
                 "url": "https://opencollective.com/synckit"
             }
         },
+        "node_modules/tagged-tag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+            "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/tailwind-merge": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+            "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/dcastil"
+            }
+        },
         "node_modules/tapable": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -34741,6 +36904,23 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+            "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/title-case": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
@@ -34750,6 +36930,26 @@
             "dependencies": {
                 "tslib": "^2.0.3"
             }
+        },
+        "node_modules/tldts": {
+            "version": "7.0.22",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.22.tgz",
+            "integrity": "sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.0.22"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.0.22",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
+            "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tmp": {
             "version": "0.0.33",
@@ -35003,6 +37203,17 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/ts-morph": {
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-26.0.0.tgz",
+            "integrity": "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@ts-morph/common": "~0.27.0",
+                "code-block-writer": "^13.0.3"
             }
         },
         "node_modules/ts-pnp": {
@@ -35365,6 +37576,19 @@
                 "node": ">=4"
             }
         },
+        "node_modules/unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/unified": {
             "version": "9.2.0",
             "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.0.tgz",
@@ -35655,6 +37879,16 @@
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/until-async": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+            "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/kettanaito"
+            }
         },
         "node_modules/untildify": {
             "version": "2.1.0",
@@ -35998,6 +38232,16 @@
             "dependencies": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/validate-npm-package-name": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/vary": {
@@ -36484,6 +38728,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/webidl-conversions": {
@@ -37529,6 +39783,39 @@
                 }
             }
         },
+        "node_modules/wsl-utils": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+            "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0",
+                "powershell-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wsl-utils/node_modules/is-wsl": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/x-default-browser": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/x-default-browser/-/x-default-browser-0.4.0.tgz",
@@ -37646,15 +39933,50 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/yoctocolors": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+            "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yoctocolors-cjs": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+            "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/zod": {
             "version": "4.1.12",
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
             "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-to-json-schema": {
+            "version": "3.25.1",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+            "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+            "dev": true,
+            "license": "ISC",
+            "peerDependencies": {
+                "zod": "^3.25 || ^4"
             }
         },
         "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "poststart:yalc": "yalc installations clean",
         "start:yalc:success": "./scripts/organize-styles.sh && yalc push --sig",
         "build": "scripts/build.sh",
+        "build:registry": "node scripts/build-registry.mjs && shadcn build -o ./public/r",
         "build:storybook": "build-storybook -o docs",
         "clean": "rimraf es lib styles dist",
         "test": "jest --passWithNoTests",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "build:storybook": "build-storybook -o docs",
         "clean": "rimraf es lib styles dist",
         "test": "jest --passWithNoTests",
+        "test:registry": "node --test scripts/__tests__/build-registry.test.mjs",
         "test:watch": "npm run test -- --watch",
         "test:coverage": "npm run test -- --coverage",
         "type-check": "tsc --noEmit -p ./tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
         "rollup": "2.79.2",
         "rollup-plugin-styles": "4.0.0",
         "rollup-plugin-visualizer": "6.0.5",
+        "shadcn": "3.8.3",
         "style-loader": "^0.23.1",
         "svg-url-loader": "^6.0.0",
         "ts-loader": "^8.0.2",

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,0 @@
-{
-    "$schema": "https://ui.shadcn.com/schema/registry.json",
-    "name": "reactist",
-    "homepage": "https://github.com/Doist/reactist",
-    "items": []
-}

--- a/registry.json
+++ b/registry.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://ui.shadcn.com/schema/registry.json",
+    "name": "reactist",
+    "homepage": "https://github.com/Doist/reactist",
+    "items": []
+}

--- a/scripts/__tests__/build-registry.test.mjs
+++ b/scripts/__tests__/build-registry.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * Snapshot tests for the registry build output.
+ *
+ * Validates that import/export rewriting in registry files hasn't regressed,
+ * and that registry.json structure (deps, file paths) is stable.
+ *
+ * Run: npm run test:registry
+ * Update snapshots: npm run test:registry -- --test-update-snapshots
+ */
+
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, before, test } from 'node:test'
+
+const ROOT = path.resolve(import.meta.dirname, '../..')
+const REGISTRY_DIR = path.join(ROOT, 'registry')
+
+before(() => {
+    execSync('node scripts/build-registry.mjs', { cwd: ROOT, stdio: 'pipe' })
+})
+
+/** Recursively collect all files matching a predicate */
+function walk(dir, predicate) {
+    const results = []
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name)
+        if (entry.isDirectory()) {
+            results.push(...walk(full, predicate))
+        } else if (predicate(entry.name)) {
+            results.push(full)
+        }
+    }
+    return results.sort()
+}
+
+describe('registry build', () => {
+    test('import/export lines match snapshot', (t) => {
+        const tsFiles = walk(REGISTRY_DIR, (name) => /\.(ts|tsx)$/.test(name))
+        const imports = {}
+
+        for (const file of tsFiles) {
+            const content = fs.readFileSync(file, 'utf-8')
+            const lines = content
+                .split('\n')
+                .filter((l) => /^\s*(import|export)\s/.test(l))
+            const rel = path.relative(ROOT, file)
+            if (lines.length > 0) {
+                imports[rel] = lines
+            }
+        }
+
+        t.assert.snapshot(imports)
+    })
+
+    test('registry.json structure matches snapshot', (t) => {
+        const registryJson = JSON.parse(
+            fs.readFileSync(path.join(ROOT, 'registry.json'), 'utf-8'),
+        )
+
+        // Snapshot the structural parts (names, deps, file targets) — not full paths
+        // which could differ per machine
+        const structure = registryJson.items.map((item) => ({
+            name: item.name,
+            type: item.type,
+            dependencies: item.dependencies,
+            registryDependencies: item.registryDependencies,
+            fileTargets: item.files.map((f) => f.target),
+        }))
+
+        t.assert.snapshot(structure)
+    })
+})

--- a/scripts/__tests__/build-registry.test.mjs.snapshot
+++ b/scripts/__tests__/build-registry.test.mjs.snapshot
@@ -1,0 +1,1110 @@
+exports[`registry build > import/export lines match snapshot 1`] = `
+{
+  "registry/lib/common-helpers/common-helpers.ts": [
+    "import * as React from 'react'",
+    "export function generateElementId(prefix: string): string {",
+    "export function useId(providedId?: string): string {"
+  ],
+  "registry/lib/common-types/common-types.ts": [
+    "import type classNames from 'classnames'",
+    "import type { HTMLAttributes } from 'react'",
+    "export type Space = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'",
+    "export type SpaceWithNegatives =",
+    "export type Tone = 'normal' | 'secondary' | 'danger' | 'positive'",
+    "export type AlertTone = 'info' | 'positive' | 'caution' | 'critical'",
+    "export type DividerWeight = 'primary' | 'secondary' | 'tertiary' | 'none'",
+    "export type WithEnhancedClassName<T = unknown> = T extends HTMLElement",
+    "export interface OpenInNewTab {",
+    "export type ObfuscatedClassName = {"
+  ],
+  "registry/lib/polymorphism/polymorphism.ts": [
+    "import * as React from 'react'",
+    "import type { ObfuscatedClassName } from '@reactist/lib/common-types'",
+    "export type { PolymorphicComponent }",
+    "export { polymorphicComponent }"
+  ],
+  "registry/lib/responsive-props/responsive-props.ts": [
+    "export type { ResponsiveBreakpoints, ResponsiveProp }",
+    "export { getClassNames, mapResponsiveProp }"
+  ],
+  "registry/ui/avatar/avatar.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { getClassNames } from '@reactist/lib/responsive-props'",
+    "import { emailToIndex, getInitials } from './utils'",
+    "import styles from './avatar.module.css'",
+    "import type { ObfuscatedClassName } from '@reactist/lib/common-types'",
+    "import type { ResponsiveProp } from '@reactist/lib/responsive-props'",
+    "export { Avatar }"
+  ],
+  "registry/ui/avatar/index.ts": [
+    "export * from './avatar'"
+  ],
+  "registry/ui/avatar/utils.ts": [
+    "export { emailToIndex, getInitials }"
+  ],
+  "registry/ui/badge/badge.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import styles from './badge.module.css'",
+    "export { Badge }",
+    "export type { BadgeProps }"
+  ],
+  "registry/ui/badge/index.ts": [
+    "export { Badge } from './badge'"
+  ],
+  "registry/ui/banner/banner.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { Button, IconButton } from '@reactist/ui/button'",
+    "import { BannerIcon } from '@reactist/ui/icons/banner-icon'",
+    "import { CloseIcon } from '@reactist/ui/icons/close-icon'",
+    "import { TextLink } from '@reactist/ui/text-link'",
+    "import { useId } from '@reactist/lib/common-helpers'",
+    "import styles from './banner.module.css'",
+    "import type { ButtonProps } from '@reactist/ui/button'",
+    "export type BannerType = 'neutral' | SystemBannerType",
+    "export type SystemBannerType = 'info' | 'upgrade' | 'experiment' | 'warning' | 'error' | 'success'",
+    "export { Banner }",
+    "export type { BannerProps }"
+  ],
+  "registry/ui/banner/index.ts": [
+    "export type { BannerProps } from './banner'",
+    "export { Banner } from './banner'"
+  ],
+  "registry/ui/base-field/base-field.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { Column, Columns } from '@reactist/ui/columns'",
+    "import { Spinner } from '@reactist/ui/spinner'",
+    "import { Stack } from '@reactist/ui/stack'",
+    "import { Text } from '@reactist/ui/text'",
+    "import { useId } from '@reactist/lib/common-helpers'",
+    "import styles from './base-field.module.css'",
+    "import type { BoxProps } from '@reactist/ui/box'",
+    "import type { WithEnhancedClassName } from '@reactist/lib/common-types'",
+    "export type BaseFieldProps = WithEnhancedClassName &",
+    "export { BaseField, FieldMessage }",
+    "export type { BaseFieldVariant, BaseFieldVariantProps, FieldComponentProps }"
+  ],
+  "registry/ui/base-field/index.ts": [
+    "export * from './base-field'"
+  ],
+  "registry/ui/box/box.tsx": [
+    "import * as React from 'react'",
+    "import classNames from 'classnames'",
+    "import { polymorphicComponent } from '@reactist/lib/polymorphism'",
+    "import { getClassNames } from '@reactist/lib/responsive-props'",
+    "import styles from './box.module.css'",
+    "import gapStyles from './gap.module.css'",
+    "import marginStyles from './margin.module.css'",
+    "import paddingStyles from './padding.module.css'",
+    "import widthStyles from './width.module.css'",
+    "import type {",
+    "import type { ResponsiveProp } from '@reactist/lib/responsive-props'",
+    "export type {",
+    "export { Box, getBoxClassNames }"
+  ],
+  "registry/ui/box/index.ts": [
+    "export * from './box'"
+  ],
+  "registry/ui/button/button.tsx": [
+    "import * as React from 'react'",
+    "import { Role } from '@ariakit/react'",
+    "import classNames from 'classnames'",
+    "import { Box, getBoxClassNames } from '@reactist/ui/box'",
+    "import { Spinner } from '@reactist/ui/spinner'",
+    "import { Tooltip } from '@reactist/ui/tooltip'",
+    "import styles from './button.module.css'",
+    "import type { RoleProps } from '@ariakit/react'",
+    "import type { TooltipProps } from '@reactist/ui/tooltip'",
+    "import type { ObfuscatedClassName } from '@reactist/lib/common-types'",
+    "export type { ButtonProps, ButtonTone, ButtonVariant, IconButtonProps }",
+    "export { Button, IconButton }"
+  ],
+  "registry/ui/button/index.ts": [
+    "export * from './button'"
+  ],
+  "registry/ui/checkbox-field/checkbox-field.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { Text } from '@reactist/ui/text'",
+    "import { CheckboxIcon } from './checkbox-icon'",
+    "import { useForkRef } from './use-fork-ref'",
+    "import styles from './checkbox-field.module.css'",
+    "export { CheckboxField }",
+    "export type { CheckboxFieldProps }"
+  ],
+  "registry/ui/checkbox-field/checkbox-icon.tsx": [
+    "import * as React from 'react'",
+    "export { CheckboxIcon }"
+  ],
+  "registry/ui/checkbox-field/index.ts": [
+    "export * from './checkbox-field'"
+  ],
+  "registry/ui/checkbox-field/use-fork-ref.ts": [
+    "import { useMemo } from 'react'",
+    "export { useForkRef }"
+  ],
+  "registry/ui/columns/columns.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { polymorphicComponent } from '@reactist/lib/polymorphism'",
+    "import { getClassNames, mapResponsiveProp } from '@reactist/lib/responsive-props'",
+    "import styles from './columns.module.css'",
+    "import type { ReusableBoxProps } from '@reactist/ui/box'",
+    "import type { Space } from '@reactist/lib/common-types'",
+    "import type { ResponsiveBreakpoints, ResponsiveProp } from '@reactist/lib/responsive-props'",
+    "export type {",
+    "export { Column, Columns }"
+  ],
+  "registry/ui/columns/index.ts": [
+    "export * from './columns'"
+  ],
+  "registry/ui/divider/divider.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { getClassNames } from '@reactist/lib/responsive-props'",
+    "import styles from './divider.module.css'",
+    "import type { DividerWeight } from '@reactist/lib/common-types'",
+    "export type { DividerProps, DividerWeight }",
+    "export { Divider }"
+  ],
+  "registry/ui/divider/index.ts": [
+    "export * from './divider'"
+  ],
+  "registry/ui/heading/heading.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { getClassNames } from '@reactist/lib/responsive-props'",
+    "import styles from './heading.module.css'",
+    "import type { BoxProps } from '@reactist/ui/box'",
+    "import type { ObfuscatedClassName, Tone } from '@reactist/lib/common-types'",
+    "export type { HeadingLevel, HeadingProps }",
+    "export { Heading }"
+  ],
+  "registry/ui/heading/index.ts": [
+    "export * from './heading'"
+  ],
+  "registry/ui/hidden-visually/hidden-visually.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { polymorphicComponent } from '@reactist/lib/polymorphism'",
+    "import styles from './hidden-visually.module.css'",
+    "export { HiddenVisually }"
+  ],
+  "registry/ui/hidden-visually/index.ts": [
+    "export * from './hidden-visually'"
+  ],
+  "registry/ui/hidden/hidden.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { polymorphicComponent } from '@reactist/lib/polymorphism'",
+    "import styles from './hidden.module.css'",
+    "import type { ResponsiveBreakpoints } from '@reactist/lib/responsive-props'",
+    "export { Hidden }",
+    "export type { HiddenProps }"
+  ],
+  "registry/ui/hidden/index.ts": [
+    "export * from './hidden'"
+  ],
+  "registry/ui/icons/alert-icon/alert-icon.tsx": [
+    "import * as React from 'react'",
+    "import type { AlertTone } from '@reactist/lib/common-types'",
+    "export { AlertIcon }"
+  ],
+  "registry/ui/icons/banner-icon/banner-icon.tsx": [
+    "import * as React from 'react'",
+    "import styles from './banner-icon.module.css'",
+    "import type { SystemBannerType } from '@reactist/ui/banner/banner'",
+    "export { BannerIcon }"
+  ],
+  "registry/ui/icons/close-icon/close-icon.tsx": [
+    "import * as React from 'react'",
+    "export { CloseIcon }"
+  ],
+  "registry/ui/icons/password-icons/password-hidden-icon.tsx": [
+    "import * as React from 'react'",
+    "export { PasswordHiddenIcon }"
+  ],
+  "registry/ui/icons/password-icons/password-visible-icon.tsx": [
+    "import * as React from 'react'",
+    "export { PasswordVisibleIcon }"
+  ],
+  "registry/ui/inline/index.ts": [
+    "export * from './inline'"
+  ],
+  "registry/ui/inline/inline.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { polymorphicComponent } from '@reactist/lib/polymorphism'",
+    "import { mapResponsiveProp } from '@reactist/lib/responsive-props'",
+    "import type { ReusableBoxProps } from '@reactist/ui/box'",
+    "import type { Space } from '@reactist/lib/common-types'",
+    "import type { ResponsiveProp } from '@reactist/lib/responsive-props'",
+    "export type { InlineAlign, InlineProps }",
+    "export { Inline }"
+  ],
+  "registry/ui/loading/index.ts": [
+    "export * from './loading'"
+  ],
+  "registry/ui/loading/loading.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { Spinner } from '@reactist/ui/spinner'",
+    "import type { ObfuscatedClassName } from '@reactist/lib/common-types'",
+    "export { Loading }",
+    "export type { LoadingProps }"
+  ],
+  "registry/ui/menu/index.ts": [
+    "export type { MenuGroupProps, MenuItemProps } from './menu'",
+    "export {"
+  ],
+  "registry/ui/menu/menu.tsx": [
+    "import './menu.less'",
+    "import * as React from 'react'",
+    "import {",
+    "import classNames from 'classnames'",
+    "import type {",
+    "import type { ObfuscatedClassName } from '@reactist/lib/common-types'",
+    "export { ContextMenuTrigger, Menu, MenuButton, MenuGroup, MenuItem, MenuList, SubMenu }",
+    "export type { MenuButtonProps, MenuGroupProps, MenuItemProps, MenuListProps }"
+  ],
+  "registry/ui/modal/index.ts": [
+    "export * from './modal'"
+  ],
+  "registry/ui/modal/modal.tsx": [
+    "import * as React from 'react'",
+    "import { forwardRef } from 'react'",
+    "import FocusLock from 'react-focus-lock'",
+    "import { Dialog, Portal, useDialogStore } from '@ariakit/react'",
+    "import { hideOthers } from 'aria-hidden'",
+    "import classNames from 'classnames'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { IconButton } from '@reactist/ui/button'",
+    "import { Column, Columns } from '@reactist/ui/columns'",
+    "import { Divider } from '@reactist/ui/divider'",
+    "import { CloseIcon } from '@reactist/ui/icons/close-icon'",
+    "import { Inline } from '@reactist/ui/inline'",
+    "import styles from './modal.module.css'",
+    "import type { DialogOptions, PortalOptions } from '@ariakit/react'",
+    "import type { IconButtonProps } from '@reactist/ui/button'",
+    "import type { DividerProps } from '@reactist/ui/divider'",
+    "import type { ObfuscatedClassName } from '@reactist/lib/common-types'",
+    "export interface ModalProps extends DivProps, ObfuscatedClassName {",
+    "export function Modal({",
+    "export interface ModalCloseButtonProps",
+    "export function ModalCloseButton(props: ModalCloseButtonProps) {",
+    "export interface ModalHeaderProps extends DivProps, ObfuscatedClassName {",
+    "export function ModalHeader({",
+    "export interface ModalBodyProps extends DivProps, ObfuscatedClassName {",
+    "export const ModalBody = forwardRef<HTMLDivElement, ModalBodyProps>(function ModalBody(",
+    "export interface ModalFooterProps extends DivProps, ObfuscatedClassName {",
+    "export function ModalFooter({",
+    "export type ModalActionsProps = ModalFooterProps",
+    "export function ModalActions({ children, ...props }: ModalActionsProps) {"
+  ],
+  "registry/ui/notice/index.ts": [
+    "export * from './notice'"
+  ],
+  "registry/ui/notice/notice.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { Column, Columns } from '@reactist/ui/columns'",
+    "import { AlertIcon } from '@reactist/ui/icons/alert-icon'",
+    "import { getClassNames } from '@reactist/lib/responsive-props'",
+    "import styles from './notice.module.css'",
+    "import type { AlertTone } from '@reactist/lib/common-types'",
+    "export { Notice }",
+    "export type { NoticeProps }"
+  ],
+  "registry/ui/password-field/index.ts": [
+    "export * from './password-field'"
+  ],
+  "registry/ui/password-field/password-field.tsx": [
+    "import * as React from 'react'",
+    "import { IconButton } from '@reactist/ui/button'",
+    "import { PasswordHiddenIcon } from '@reactist/ui/icons/password-hidden-icon'",
+    "import { PasswordVisibleIcon } from '@reactist/ui/icons/password-visible-icon'",
+    "import { TextField } from '@reactist/ui/text-field'",
+    "import type { BaseFieldVariantProps } from '@reactist/ui/base-field'",
+    "import type { TextFieldProps } from '@reactist/ui/text-field'",
+    "export { PasswordField }",
+    "export type { PasswordFieldProps }"
+  ],
+  "registry/ui/prose/index.ts": [
+    "export type { ProseProps } from './prose'",
+    "export { Prose } from './prose'"
+  ],
+  "registry/ui/prose/prose.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import styles from './prose.module.css'",
+    "import type { ObfuscatedClassName } from '@reactist/lib/common-types'",
+    "export { Prose }",
+    "export type { ProseProps }"
+  ],
+  "registry/ui/select-field/index.ts": [
+    "export * from './select-field'"
+  ],
+  "registry/ui/select-field/select-field.tsx": [
+    "import * as React from 'react'",
+    "import { BaseField } from '@reactist/ui/base-field'",
+    "import { Box } from '@reactist/ui/box'",
+    "import styles from './select-field.module.css'",
+    "import type { BaseFieldVariantProps, FieldComponentProps } from '@reactist/ui/base-field'",
+    "export { SelectField }",
+    "export type { SelectFieldProps }"
+  ],
+  "registry/ui/spinner/index.ts": [
+    "export * from './spinner'"
+  ],
+  "registry/ui/spinner/spinner.tsx": [
+    "import * as React from 'react'",
+    "import styles from './spinner.module.css'",
+    "export { Spinner }"
+  ],
+  "registry/ui/stack/index.ts": [
+    "export * from './stack'"
+  ],
+  "registry/ui/stack/stack.tsx": [
+    "import * as React from 'react'",
+    "import flattenChildren from 'react-keyed-flatten-children'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { Divider } from '@reactist/ui/divider'",
+    "import { polymorphicComponent } from '@reactist/lib/polymorphism'",
+    "import { mapResponsiveProp } from '@reactist/lib/responsive-props'",
+    "import type { BoxProps, ReusableBoxProps } from '@reactist/ui/box'",
+    "import type { DividerWeight, Space } from '@reactist/lib/common-types'",
+    "import type { ResponsiveProp } from '@reactist/lib/responsive-props'",
+    "export type { StackProps }",
+    "export { Stack }"
+  ],
+  "registry/ui/switch-field/index.ts": [
+    "export * from './switch-field'"
+  ],
+  "registry/ui/switch-field/switch-field.tsx": [
+    "import * as React from 'react'",
+    "import { FieldMessage } from '@reactist/ui/base-field'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { HiddenVisually } from '@reactist/ui/hidden-visually'",
+    "import { Stack } from '@reactist/ui/stack'",
+    "import { Text } from '@reactist/ui/text'",
+    "import { useId } from '@reactist/lib/common-helpers'",
+    "import styles from './switch-field.module.css'",
+    "import type { FieldComponentProps } from '@reactist/ui/base-field'",
+    "export { SwitchField }",
+    "export type { SwitchFieldProps }"
+  ],
+  "registry/ui/tabs/index.ts": [
+    "export * from './tabs'"
+  ],
+  "registry/ui/tabs/tabs.tsx": [
+    "import * as React from 'react'",
+    "import {",
+    "import classNames from 'classnames'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { Inline } from '@reactist/ui/inline'",
+    "import styles from './tabs.module.css'",
+    "import type {",
+    "import type { BoxJustifyContent } from '@reactist/ui/box'",
+    "import type { ObfuscatedClassName, Space } from '@reactist/lib/common-types'",
+    "export { Tab, TabAwareSlot, TabList, TabPanel, Tabs }"
+  ],
+  "registry/ui/text-area/index.ts": [
+    "export * from './text-area'"
+  ],
+  "registry/ui/text-area/text-area.tsx": [
+    "import * as React from 'react'",
+    "import classNames from 'classnames'",
+    "import { useMergeRefs } from 'use-callback-ref'",
+    "import { BaseField } from '@reactist/ui/base-field'",
+    "import { Box } from '@reactist/ui/box'",
+    "import styles from './text-area.module.css'",
+    "import type { BaseFieldVariantProps, FieldComponentProps } from '@reactist/ui/base-field'",
+    "export { TextArea }",
+    "export type { TextAreaProps }"
+  ],
+  "registry/ui/text-field/index.ts": [
+    "export * from './text-field'"
+  ],
+  "registry/ui/text-field/text-field.tsx": [
+    "import * as React from 'react'",
+    "import { useMergeRefs } from 'use-callback-ref'",
+    "import { BaseField } from '@reactist/ui/base-field'",
+    "import { Box } from '@reactist/ui/box'",
+    "import styles from './text-field.module.css'",
+    "import type { BaseFieldProps, BaseFieldVariantProps, FieldComponentProps } from '@reactist/ui/base-field'",
+    "export { TextField }",
+    "export type { TextFieldProps, TextFieldType }"
+  ],
+  "registry/ui/text-link/index.ts": [
+    "export * from './text-link'"
+  ],
+  "registry/ui/text-link/text-link.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { polymorphicComponent } from '@reactist/lib/polymorphism'",
+    "import styles from './text-link.module.css'",
+    "import type { OpenInNewTab } from '@reactist/lib/common-types'",
+    "export { TextLink }",
+    "export type { TextLinkProps }"
+  ],
+  "registry/ui/text/index.ts": [
+    "export * from './text'"
+  ],
+  "registry/ui/text/text.tsx": [
+    "import * as React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { polymorphicComponent } from '@reactist/lib/polymorphism'",
+    "import { getClassNames } from '@reactist/lib/responsive-props'",
+    "import styles from './text.module.css'",
+    "import type { BoxProps } from '@reactist/ui/box'",
+    "import type { Tone } from '@reactist/lib/common-types'",
+    "export type { TextProps }",
+    "export { Text }"
+  ],
+  "registry/ui/toast/index.ts": [
+    "export type { StaticToastProps } from './static-toast'",
+    "export { StaticToast } from './static-toast'",
+    "export type { ToastProps, ToastsProviderProps } from './use-toasts'",
+    "export { Toast, ToastsProvider, useToasts } from './use-toasts'"
+  ],
+  "registry/ui/toast/static-toast.tsx": [
+    "import React from 'react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { Button, IconButton } from '@reactist/ui/button'",
+    "import { CloseIcon } from '@reactist/ui/icons/close-icon'",
+    "import { Stack } from '@reactist/ui/stack'",
+    "import { Text } from '@reactist/ui/text'",
+    "import styles from './toast.module.css'",
+    "export { isActionObject, StaticToast }",
+    "export type { StaticToastProps }"
+  ],
+  "registry/ui/toast/toast-animation.ts": [
+    "import { useCallback, useLayoutEffect, useMemo } from 'react'",
+    "export { ANIMATION_TIMEOUT, useToastsAnimation }"
+  ],
+  "registry/ui/toast/use-toasts.tsx": [
+    "import React from 'react'",
+    "import { Portal } from '@ariakit/react'",
+    "import { Box } from '@reactist/ui/box'",
+    "import { Stack } from '@reactist/ui/stack'",
+    "import { generateElementId } from '@reactist/lib/common-helpers'",
+    "import { isActionObject, StaticToast } from './static-toast'",
+    "import { useToastsAnimation } from './toast-animation'",
+    "import styles from './toast.module.css'",
+    "import type { Space } from '@reactist/lib/common-types'",
+    "import type { StaticToastProps } from './static-toast'",
+    "export { Toast, ToastsProvider, useToasts }",
+    "export type { ToastProps, ToastsProviderProps }"
+  ],
+  "registry/ui/tooltip/index.ts": [
+    "export type { TooltipProps } from './tooltip'",
+    "export { Tooltip, TooltipProvider } from './tooltip'"
+  ],
+  "registry/ui/tooltip/tooltip.tsx": [
+    "import * as React from 'react'",
+    "import {",
+    "import { Box } from '@reactist/ui/box'",
+    "import styles from './tooltip.module.css'",
+    "import type { TooltipStore, TooltipStoreState } from '@ariakit/react'",
+    "import type { ObfuscatedClassName } from '@reactist/lib/common-types'",
+    "export type { TooltipProps }",
+    "export { Tooltip, TooltipProvider }"
+  ]
+}
+`;
+
+exports[`registry build > registry.json structure matches snapshot 1`] = `
+[
+  {
+    "name": "design-tokens",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [],
+    "fileTargets": [
+      "src/components/reactist/styles/design-tokens/design-tokens.css"
+    ]
+  },
+  {
+    "name": "common-types",
+    "type": "registry:file",
+    "dependencies": [
+      "classnames@^2.2.5"
+    ],
+    "registryDependencies": [],
+    "fileTargets": [
+      "src/components/reactist/lib/common-types/common-types.ts"
+    ]
+  },
+  {
+    "name": "common-helpers",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [],
+    "fileTargets": [
+      "src/components/reactist/lib/common-helpers/common-helpers.ts"
+    ]
+  },
+  {
+    "name": "responsive-props",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [],
+    "fileTargets": [
+      "src/components/reactist/lib/responsive-props/responsive-props.ts"
+    ]
+  },
+  {
+    "name": "polymorphism",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/lib/polymorphism/polymorphism.ts"
+    ]
+  },
+  {
+    "name": "spinner",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "design-tokens"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/spinner/index.ts",
+      "src/components/reactist/ui/spinner/spinner.tsx",
+      "src/components/reactist/ui/spinner/spinner.module.css"
+    ]
+  },
+  {
+    "name": "close-icon",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [],
+    "fileTargets": [
+      "src/components/reactist/ui/icons/close-icon/close-icon.tsx"
+    ]
+  },
+  {
+    "name": "alert-icon",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/icons/alert-icon/alert-icon.tsx"
+    ]
+  },
+  {
+    "name": "password-icons",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [],
+    "fileTargets": [
+      "src/components/reactist/ui/icons/password-icons/password-hidden-icon.tsx",
+      "src/components/reactist/ui/icons/password-icons/password-visible-icon.tsx"
+    ]
+  },
+  {
+    "name": "box",
+    "type": "registry:file",
+    "dependencies": [
+      "classnames@^2.2.5"
+    ],
+    "registryDependencies": [
+      "polymorphism",
+      "responsive-props",
+      "common-types",
+      "design-tokens"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/box/index.ts",
+      "src/components/reactist/ui/box/box.tsx",
+      "src/components/reactist/ui/box/box.module.css",
+      "src/components/reactist/ui/box/gap.module.css",
+      "src/components/reactist/ui/box/margin.module.css",
+      "src/components/reactist/ui/box/padding.module.css",
+      "src/components/reactist/ui/box/width.module.css"
+    ]
+  },
+  {
+    "name": "hidden-visually",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "polymorphism"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/hidden-visually/index.ts",
+      "src/components/reactist/ui/hidden-visually/hidden-visually.tsx",
+      "src/components/reactist/ui/hidden-visually/hidden-visually.module.css"
+    ]
+  },
+  {
+    "name": "hidden",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "polymorphism",
+      "responsive-props"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/hidden/index.ts",
+      "src/components/reactist/ui/hidden/hidden.tsx",
+      "src/components/reactist/ui/hidden/hidden.module.css"
+    ]
+  },
+  {
+    "name": "divider",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "responsive-props",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/divider/index.ts",
+      "src/components/reactist/ui/divider/divider.tsx",
+      "src/components/reactist/ui/divider/divider.module.css"
+    ]
+  },
+  {
+    "name": "heading",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "responsive-props",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/heading/index.ts",
+      "src/components/reactist/ui/heading/heading.tsx",
+      "src/components/reactist/ui/heading/heading.module.css"
+    ]
+  },
+  {
+    "name": "text",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "polymorphism",
+      "responsive-props",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/text/index.ts",
+      "src/components/reactist/ui/text/text.tsx",
+      "src/components/reactist/ui/text/text.module.css"
+    ]
+  },
+  {
+    "name": "stack",
+    "type": "registry:file",
+    "dependencies": [
+      "react-keyed-flatten-children@^1.3.0"
+    ],
+    "registryDependencies": [
+      "box",
+      "divider",
+      "polymorphism",
+      "responsive-props",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/stack/index.ts",
+      "src/components/reactist/ui/stack/stack.tsx"
+    ]
+  },
+  {
+    "name": "inline",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "polymorphism",
+      "responsive-props",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/inline/index.ts",
+      "src/components/reactist/ui/inline/inline.tsx"
+    ]
+  },
+  {
+    "name": "columns",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "polymorphism",
+      "responsive-props",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/columns/index.ts",
+      "src/components/reactist/ui/columns/columns.tsx",
+      "src/components/reactist/ui/columns/columns.module.css"
+    ]
+  },
+  {
+    "name": "tooltip",
+    "type": "registry:file",
+    "dependencies": [
+      "@ariakit/react@~0.4.19"
+    ],
+    "registryDependencies": [
+      "box",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/tooltip/index.ts",
+      "src/components/reactist/ui/tooltip/tooltip.tsx",
+      "src/components/reactist/ui/tooltip/tooltip.module.css"
+    ]
+  },
+  {
+    "name": "button",
+    "type": "registry:file",
+    "dependencies": [
+      "@ariakit/react@~0.4.19",
+      "classnames@^2.2.5"
+    ],
+    "registryDependencies": [
+      "box",
+      "spinner",
+      "tooltip",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/button/index.ts",
+      "src/components/reactist/ui/button/button.tsx",
+      "src/components/reactist/ui/button/button.module.css"
+    ]
+  },
+  {
+    "name": "text-link",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "polymorphism",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/text-link/index.ts",
+      "src/components/reactist/ui/text-link/text-link.tsx",
+      "src/components/reactist/ui/text-link/text-link.module.css"
+    ]
+  },
+  {
+    "name": "badge",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/badge/index.ts",
+      "src/components/reactist/ui/badge/badge.tsx",
+      "src/components/reactist/ui/badge/badge.module.css"
+    ]
+  },
+  {
+    "name": "avatar",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "responsive-props",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/avatar/index.ts",
+      "src/components/reactist/ui/avatar/avatar.tsx",
+      "src/components/reactist/ui/avatar/avatar.module.css",
+      "src/components/reactist/ui/avatar/utils.ts"
+    ]
+  },
+  {
+    "name": "loading",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "spinner",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/loading/index.ts",
+      "src/components/reactist/ui/loading/loading.tsx"
+    ]
+  },
+  {
+    "name": "prose",
+    "type": "registry:file",
+    "dependencies": [
+      "marked@^4.2.12"
+    ],
+    "registryDependencies": [
+      "box",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/prose/index.ts",
+      "src/components/reactist/ui/prose/prose.tsx",
+      "src/components/reactist/ui/prose/prose.module.css"
+    ]
+  },
+  {
+    "name": "base-field",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "columns",
+      "spinner",
+      "stack",
+      "text",
+      "common-helpers",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/base-field/index.ts",
+      "src/components/reactist/ui/base-field/base-field.tsx",
+      "src/components/reactist/ui/base-field/base-field.module.css"
+    ]
+  },
+  {
+    "name": "text-field",
+    "type": "registry:file",
+    "dependencies": [
+      "use-callback-ref@^1.3.0"
+    ],
+    "registryDependencies": [
+      "base-field",
+      "box"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/text-field/index.ts",
+      "src/components/reactist/ui/text-field/text-field.tsx",
+      "src/components/reactist/ui/text-field/text-field.module.css"
+    ]
+  },
+  {
+    "name": "text-area",
+    "type": "registry:file",
+    "dependencies": [
+      "classnames@^2.2.5",
+      "use-callback-ref@^1.3.0"
+    ],
+    "registryDependencies": [
+      "base-field",
+      "box"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/text-area/index.ts",
+      "src/components/reactist/ui/text-area/text-area.tsx",
+      "src/components/reactist/ui/text-area/text-area.module.css"
+    ]
+  },
+  {
+    "name": "select-field",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "base-field",
+      "box"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/select-field/index.ts",
+      "src/components/reactist/ui/select-field/select-field.tsx",
+      "src/components/reactist/ui/select-field/select-field.module.css"
+    ]
+  },
+  {
+    "name": "checkbox-field",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "text"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/checkbox-field/index.ts",
+      "src/components/reactist/ui/checkbox-field/checkbox-field.tsx",
+      "src/components/reactist/ui/checkbox-field/checkbox-field.module.css",
+      "src/components/reactist/ui/checkbox-field/checkbox-icon.tsx",
+      "src/components/reactist/ui/checkbox-field/use-fork-ref.ts"
+    ]
+  },
+  {
+    "name": "switch-field",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "base-field",
+      "box",
+      "hidden-visually",
+      "stack",
+      "text",
+      "common-helpers"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/switch-field/index.ts",
+      "src/components/reactist/ui/switch-field/switch-field.tsx",
+      "src/components/reactist/ui/switch-field/switch-field.module.css"
+    ]
+  },
+  {
+    "name": "password-field",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "button",
+      "text-field",
+      "password-icons",
+      "base-field"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/password-field/index.ts",
+      "src/components/reactist/ui/password-field/password-field.tsx"
+    ]
+  },
+  {
+    "name": "banner-icon",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [],
+    "fileTargets": [
+      "src/components/reactist/ui/icons/banner-icon/banner-icon.tsx",
+      "src/components/reactist/ui/icons/banner-icon/banner-icon.module.css"
+    ]
+  },
+  {
+    "name": "banner",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "button",
+      "text-link",
+      "banner-icon",
+      "close-icon",
+      "common-helpers"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/banner/index.ts",
+      "src/components/reactist/ui/banner/banner.tsx",
+      "src/components/reactist/ui/banner/banner.module.css"
+    ]
+  },
+  {
+    "name": "notice",
+    "type": "registry:file",
+    "dependencies": [],
+    "registryDependencies": [
+      "box",
+      "columns",
+      "alert-icon",
+      "responsive-props",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/notice/index.ts",
+      "src/components/reactist/ui/notice/notice.tsx",
+      "src/components/reactist/ui/notice/notice.module.css"
+    ]
+  },
+  {
+    "name": "menu",
+    "type": "registry:file",
+    "dependencies": [
+      "@ariakit/react@~0.4.19",
+      "classnames@^2.2.5"
+    ],
+    "registryDependencies": [
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/menu/index.ts",
+      "src/components/reactist/ui/menu/menu.tsx",
+      "src/components/reactist/ui/menu/menu.less"
+    ]
+  },
+  {
+    "name": "tabs",
+    "type": "registry:file",
+    "dependencies": [
+      "@ariakit/react@~0.4.19",
+      "classnames@^2.2.5"
+    ],
+    "registryDependencies": [
+      "box",
+      "inline",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/tabs/index.ts",
+      "src/components/reactist/ui/tabs/tabs.tsx",
+      "src/components/reactist/ui/tabs/tabs.module.css"
+    ]
+  },
+  {
+    "name": "modal",
+    "type": "registry:file",
+    "dependencies": [
+      "@ariakit/react@~0.4.19",
+      "react-focus-lock@^2.9.1",
+      "aria-hidden@^1.2.1",
+      "classnames@^2.2.5"
+    ],
+    "registryDependencies": [
+      "box",
+      "button",
+      "columns",
+      "divider",
+      "close-icon",
+      "inline",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/modal/index.ts",
+      "src/components/reactist/ui/modal/modal.tsx",
+      "src/components/reactist/ui/modal/modal.module.css"
+    ]
+  },
+  {
+    "name": "toast",
+    "type": "registry:file",
+    "dependencies": [
+      "@ariakit/react@~0.4.19"
+    ],
+    "registryDependencies": [
+      "box",
+      "button",
+      "stack",
+      "text",
+      "close-icon",
+      "common-helpers",
+      "common-types"
+    ],
+    "fileTargets": [
+      "src/components/reactist/ui/toast/index.ts",
+      "src/components/reactist/ui/toast/static-toast.tsx",
+      "src/components/reactist/ui/toast/use-toasts.tsx",
+      "src/components/reactist/ui/toast/toast-animation.ts",
+      "src/components/reactist/ui/toast/toast.module.css"
+    ]
+  }
+]
+`;

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -172,6 +172,73 @@ const REGISTRY_ITEMS = [
         files: ['password-hidden-icon.tsx', 'password-visible-icon.tsx'],
         category: 'ui/icons',
     },
+
+    // Layer 2: Core layout
+    {
+        name: 'box',
+        srcDir: 'box',
+        files: ['index.ts', 'box.tsx', 'box.module.css', 'gap.module.css', 'margin.module.css', 'padding.module.css', 'width.module.css'],
+        category: 'ui',
+        registryDependencies: ['polymorphism', 'responsive-props', 'common-types', 'design-tokens'],
+        dependencies: ['classnames'],
+    },
+    {
+        name: 'hidden-visually',
+        srcDir: 'hidden-visually',
+        files: ['index.ts', 'hidden-visually.tsx', 'hidden-visually.module.css'],
+        category: 'ui',
+        registryDependencies: ['box', 'polymorphism'],
+    },
+    {
+        name: 'hidden',
+        srcDir: 'hidden',
+        files: ['index.ts', 'hidden.tsx', 'hidden.module.css'],
+        category: 'ui',
+        registryDependencies: ['box', 'polymorphism', 'responsive-props'],
+    },
+    {
+        name: 'divider',
+        srcDir: 'divider',
+        files: ['index.ts', 'divider.tsx', 'divider.module.css'],
+        category: 'ui',
+        registryDependencies: ['box', 'responsive-props', 'common-types'],
+    },
+    {
+        name: 'heading',
+        srcDir: 'heading',
+        files: ['index.ts', 'heading.tsx', 'heading.module.css'],
+        category: 'ui',
+        registryDependencies: ['box', 'responsive-props', 'common-types'],
+    },
+    {
+        name: 'text',
+        srcDir: 'text',
+        files: ['index.ts', 'text.tsx', 'text.module.css'],
+        category: 'ui',
+        registryDependencies: ['box', 'polymorphism', 'responsive-props', 'common-types'],
+    },
+    {
+        name: 'stack',
+        srcDir: 'stack',
+        files: ['index.ts', 'stack.tsx'],
+        category: 'ui',
+        registryDependencies: ['box', 'divider', 'polymorphism', 'responsive-props', 'common-types'],
+        dependencies: ['react-keyed-flatten-children'],
+    },
+    {
+        name: 'inline',
+        srcDir: 'inline',
+        files: ['index.ts', 'inline.tsx'],
+        category: 'ui',
+        registryDependencies: ['box', 'polymorphism', 'responsive-props', 'common-types'],
+    },
+    {
+        name: 'columns',
+        srcDir: 'columns',
+        files: ['index.ts', 'columns.tsx', 'columns.module.css'],
+        category: 'ui',
+        registryDependencies: ['box', 'polymorphism', 'responsive-props', 'common-types'],
+    },
 ]
 
 // ─── Build ───────────────────────────────────────────────────────────────────

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -239,6 +239,113 @@ const REGISTRY_ITEMS = [
         category: 'ui',
         registryDependencies: ['box', 'polymorphism', 'responsive-props', 'common-types'],
     },
+
+    // Layer 3: Interactive components
+    {
+        name: 'tooltip',
+        srcDir: 'tooltip',
+        files: ['index.ts', 'tooltip.tsx', 'tooltip.module.css'],
+        category: 'ui',
+        registryDependencies: ['box', 'common-types'],
+        dependencies: ['@ariakit/react'],
+    },
+    {
+        name: 'button',
+        srcDir: 'button',
+        files: ['index.ts', 'button.tsx', 'button.module.css'],
+        category: 'ui',
+        registryDependencies: ['box', 'spinner', 'tooltip', 'common-types'],
+        dependencies: ['@ariakit/react', 'classnames'],
+    },
+    {
+        name: 'text-link',
+        srcDir: 'text-link',
+        files: ['index.ts', 'text-link.tsx', 'text-link.module.css'],
+        category: 'ui',
+        registryDependencies: ['box', 'polymorphism', 'common-types'],
+    },
+    {
+        name: 'badge',
+        srcDir: 'badge',
+        files: ['index.ts', 'badge.tsx', 'badge.module.css'],
+        category: 'ui',
+        registryDependencies: ['box'],
+    },
+    {
+        name: 'avatar',
+        srcDir: 'avatar',
+        files: ['index.ts', 'avatar.tsx', 'avatar.module.css', 'utils.ts'],
+        category: 'ui',
+        registryDependencies: ['box', 'responsive-props', 'common-types'],
+    },
+    {
+        name: 'loading',
+        srcDir: 'loading',
+        files: ['index.ts', 'loading.tsx'],
+        category: 'ui',
+        registryDependencies: ['box', 'spinner', 'common-types'],
+    },
+    {
+        name: 'prose',
+        srcDir: 'prose',
+        files: ['index.ts', 'prose.tsx', 'prose.module.css'],
+        category: 'ui',
+        registryDependencies: ['box', 'common-types'],
+        dependencies: ['marked'],
+    },
+
+    // Layer 4: Form fields
+    {
+        name: 'base-field',
+        srcDir: 'base-field',
+        files: ['index.ts', 'base-field.tsx', 'base-field.module.css'],
+        category: 'ui',
+        registryDependencies: ['box', 'columns', 'spinner', 'stack', 'text', 'common-helpers', 'common-types'],
+    },
+    {
+        name: 'text-field',
+        srcDir: 'text-field',
+        files: ['index.ts', 'text-field.tsx', 'text-field.module.css'],
+        category: 'ui',
+        registryDependencies: ['base-field', 'box'],
+        dependencies: ['use-callback-ref'],
+    },
+    {
+        name: 'text-area',
+        srcDir: 'text-area',
+        files: ['index.ts', 'text-area.tsx', 'text-area.module.css'],
+        category: 'ui',
+        registryDependencies: ['base-field', 'box'],
+        dependencies: ['classnames', 'use-callback-ref'],
+    },
+    {
+        name: 'select-field',
+        srcDir: 'select-field',
+        files: ['index.ts', 'select-field.tsx', 'select-field.module.css'],
+        category: 'ui',
+        registryDependencies: ['base-field', 'box'],
+    },
+    {
+        name: 'checkbox-field',
+        srcDir: 'checkbox-field',
+        files: ['index.ts', 'checkbox-field.tsx', 'checkbox-field.module.css', 'checkbox-icon.tsx', 'use-fork-ref.ts'],
+        category: 'ui',
+        registryDependencies: ['box', 'text'],
+    },
+    {
+        name: 'switch-field',
+        srcDir: 'switch-field',
+        files: ['index.ts', 'switch-field.tsx', 'switch-field.module.css'],
+        category: 'ui',
+        registryDependencies: ['base-field', 'box', 'hidden-visually', 'stack', 'text', 'common-helpers'],
+    },
+    {
+        name: 'password-field',
+        srcDir: 'password-field',
+        files: ['index.ts', 'password-field.tsx'],
+        category: 'ui',
+        registryDependencies: ['button', 'text-field', 'password-icons', 'base-field'],
+    },
 ]
 
 // ─── Build ───────────────────────────────────────────────────────────────────

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -28,13 +28,22 @@ function rewriteImport(importPath, sourceFile) {
     // Only rewrite relative imports
     if (!importPath.startsWith('.')) return null
 
+    // CSS module imports - always keep relative
+    if (importPath.endsWith('.css') || importPath.endsWith('.module.css')) {
+        return null
+    }
+
     // Resolve to absolute path
     const sourceDir = path.dirname(sourceFile)
     const resolved = path.resolve(sourceDir, importPath)
     const relative = path.relative(SRC, resolved)
+    const sourceRelative = path.relative(SRC, sourceFile)
 
-    // CSS module imports (same directory) - keep relative
-    if (importPath.endsWith('.css') || importPath.endsWith('.module.css')) {
+    // Same-directory imports (sibling files) - keep relative
+    // e.g. spinner/index.ts importing ./spinner → stays ./spinner
+    const sourceComponent = sourceRelative.split('/')[0]
+    const targetComponent = relative.split('/')[0]
+    if (sourceComponent === targetComponent && !relative.includes('/utils/') && !relative.includes('/styles/')) {
         return null
     }
 
@@ -134,6 +143,34 @@ const REGISTRY_ITEMS = [
         files: ['polymorphism.ts'],
         category: 'lib',
         registryDependencies: ['common-types'],
+    },
+
+    // Layer 1: Primitives
+    {
+        name: 'spinner',
+        srcDir: 'spinner',
+        files: ['index.ts', 'spinner.tsx', 'spinner.module.css'],
+        category: 'ui',
+        registryDependencies: ['design-tokens'],
+    },
+    {
+        name: 'close-icon',
+        srcDir: 'icons',
+        files: ['close-icon.tsx'],
+        category: 'ui/icons',
+    },
+    {
+        name: 'alert-icon',
+        srcDir: 'icons',
+        files: ['alert-icon.tsx'],
+        category: 'ui/icons',
+        registryDependencies: ['common-types'],
+    },
+    {
+        name: 'password-icons',
+        srcDir: 'icons',
+        files: ['password-hidden-icon.tsx', 'password-visible-icon.tsx'],
+        category: 'ui/icons',
     },
 ]
 

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -135,7 +135,7 @@ const REGISTRY_ITEMS = [
         srcDir: 'utils',
         files: ['common-types.ts'],
         category: 'lib',
-        dependencies: ['classnames'],
+        dependencies: ['classnames@^2.2.5'],
     },
     {
         name: 'common-helpers',
@@ -192,7 +192,7 @@ const REGISTRY_ITEMS = [
         files: ['index.ts', 'box.tsx', 'box.module.css', 'gap.module.css', 'margin.module.css', 'padding.module.css', 'width.module.css'],
         category: 'ui',
         registryDependencies: ['polymorphism', 'responsive-props', 'common-types', 'design-tokens'],
-        dependencies: ['classnames'],
+        dependencies: ['classnames@^2.2.5'],
     },
     {
         name: 'hidden-visually',
@@ -235,7 +235,7 @@ const REGISTRY_ITEMS = [
         files: ['index.ts', 'stack.tsx'],
         category: 'ui',
         registryDependencies: ['box', 'divider', 'polymorphism', 'responsive-props', 'common-types'],
-        dependencies: ['react-keyed-flatten-children'],
+        dependencies: ['react-keyed-flatten-children@^1.3.0'],
     },
     {
         name: 'inline',
@@ -259,7 +259,7 @@ const REGISTRY_ITEMS = [
         files: ['index.ts', 'tooltip.tsx', 'tooltip.module.css'],
         category: 'ui',
         registryDependencies: ['box', 'common-types'],
-        dependencies: ['@ariakit/react'],
+        dependencies: ['@ariakit/react@~0.4.19'],
     },
     {
         name: 'button',
@@ -267,7 +267,7 @@ const REGISTRY_ITEMS = [
         files: ['index.ts', 'button.tsx', 'button.module.css'],
         category: 'ui',
         registryDependencies: ['box', 'spinner', 'tooltip', 'common-types'],
-        dependencies: ['@ariakit/react', 'classnames'],
+        dependencies: ['@ariakit/react@~0.4.19', 'classnames@^2.2.5'],
     },
     {
         name: 'text-link',
@@ -303,7 +303,7 @@ const REGISTRY_ITEMS = [
         files: ['index.ts', 'prose.tsx', 'prose.module.css'],
         category: 'ui',
         registryDependencies: ['box', 'common-types'],
-        dependencies: ['marked'],
+        dependencies: ['marked@^4.2.12'],
     },
 
     // Layer 4: Form fields
@@ -320,7 +320,7 @@ const REGISTRY_ITEMS = [
         files: ['index.ts', 'text-field.tsx', 'text-field.module.css'],
         category: 'ui',
         registryDependencies: ['base-field', 'box'],
-        dependencies: ['use-callback-ref'],
+        dependencies: ['use-callback-ref@^1.3.0'],
     },
     {
         name: 'text-area',
@@ -328,7 +328,7 @@ const REGISTRY_ITEMS = [
         files: ['index.ts', 'text-area.tsx', 'text-area.module.css'],
         category: 'ui',
         registryDependencies: ['base-field', 'box'],
-        dependencies: ['classnames', 'use-callback-ref'],
+        dependencies: ['classnames@^2.2.5', 'use-callback-ref@^1.3.0'],
     },
     {
         name: 'select-field',
@@ -390,7 +390,7 @@ const REGISTRY_ITEMS = [
         files: ['index.ts', 'menu.tsx', 'menu.less'],
         category: 'ui',
         registryDependencies: ['common-types'],
-        dependencies: ['@ariakit/react', 'classnames'],
+        dependencies: ['@ariakit/react@~0.4.19', 'classnames@^2.2.5'],
     },
     {
         name: 'tabs',
@@ -398,7 +398,7 @@ const REGISTRY_ITEMS = [
         files: ['index.ts', 'tabs.tsx', 'tabs.module.css'],
         category: 'ui',
         registryDependencies: ['box', 'inline', 'common-types'],
-        dependencies: ['@ariakit/react', 'classnames'],
+        dependencies: ['@ariakit/react@~0.4.19', 'classnames@^2.2.5'],
     },
     {
         name: 'modal',
@@ -406,7 +406,7 @@ const REGISTRY_ITEMS = [
         files: ['index.ts', 'modal.tsx', 'modal.module.css'],
         category: 'ui',
         registryDependencies: ['box', 'button', 'columns', 'divider', 'close-icon', 'inline', 'common-types'],
-        dependencies: ['@ariakit/react', 'react-focus-lock', 'aria-hidden', 'classnames'],
+        dependencies: ['@ariakit/react@~0.4.19', 'react-focus-lock@^2.9.1', 'aria-hidden@^1.2.1', 'classnames@^2.2.5'],
     },
     {
         name: 'toast',
@@ -414,7 +414,7 @@ const REGISTRY_ITEMS = [
         files: ['index.ts', 'static-toast.tsx', 'use-toasts.tsx', 'toast-animation.ts', 'toast.module.css'],
         category: 'ui',
         registryDependencies: ['box', 'button', 'stack', 'text', 'close-icon', 'common-helpers', 'common-types'],
-        dependencies: ['@ariakit/react'],
+        dependencies: ['@ariakit/react@~0.4.19'],
     },
 ]
 

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -465,7 +465,20 @@ function build() {
     }
 
     fs.writeFileSync(path.join(ROOT, 'registry.json'), JSON.stringify(registryJson, null, 4) + '\n')
-    console.log(`Built ${REGISTRY_ITEMS.length} registry items`)
+
+    // Generate version manifest (published alongside registry for update detection)
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'))
+    const manifest = {
+        registryUrl: 'https://doist.github.io/reactist/r',
+        version: pkg.version,
+        generatedAt: new Date().toISOString(),
+        items: REGISTRY_ITEMS.map((item) => item.name),
+    }
+    const outputDir = path.join(ROOT, 'public', 'r')
+    fs.mkdirSync(outputDir, { recursive: true })
+    fs.writeFileSync(path.join(outputDir, 'manifest.json'), JSON.stringify(manifest, null, 4) + '\n')
+
+    console.log(`Built ${REGISTRY_ITEMS.length} registry items (v${pkg.version})`)
 }
 
 build()

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -1,0 +1,152 @@
+/**
+ * Prepares source files for shadcn registry build.
+ *
+ * Copies component source files to registry/ directory with import paths
+ * rewritten from relative (../box) to alias-based (@reactist/ui/box).
+ *
+ * Run via: npm run build:registry
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = path.resolve(import.meta.dirname, '..')
+const SRC = path.join(ROOT, 'src')
+const REGISTRY_DIR = path.join(ROOT, 'registry')
+
+// Import path mappings: relative source path → registry alias
+// Components in src/<name>/ → @reactist/ui/<name>
+// Utils in src/utils/ → @reactist/lib/<name>
+// Styles in src/styles/ → @reactist/styles/<name>
+
+const UTIL_FILES = ['common-types', 'common-helpers', 'responsive-props', 'polymorphism']
+
+/**
+ * Maps a relative import path from a source file to its @reactist alias.
+ * @param {string} importPath - The relative import path (e.g. '../box', '../utils/common-types')
+ * @param {string} sourceFile - The absolute path of the file containing the import
+ * @returns {string|null} The rewritten path, or null if no rewrite needed
+ */
+function rewriteImport(importPath, sourceFile) {
+    // Only rewrite relative imports
+    if (!importPath.startsWith('.')) return null
+
+    // Resolve to absolute path
+    const sourceDir = path.dirname(sourceFile)
+    const resolved = path.resolve(sourceDir, importPath)
+    const relative = path.relative(SRC, resolved)
+
+    // utils/* → @reactist/lib/*
+    if (relative.startsWith('utils/')) {
+        const name = relative.replace('utils/', '')
+        return `@reactist/lib/${name}`
+    }
+
+    // styles/* → @reactist/styles/*
+    if (relative.startsWith('styles/')) {
+        const name = relative.replace('styles/', '')
+        return `@reactist/styles/${name}`
+    }
+
+    // CSS module imports (same directory) - keep relative
+    if (importPath.endsWith('.css') || importPath.endsWith('.module.css')) {
+        return null
+    }
+
+    // Component directories → @reactist/ui/*
+    const parts = relative.split('/')
+    if (parts.length >= 1) {
+        return `@reactist/ui/${parts[0]}`
+    }
+
+    return null
+}
+
+/**
+ * Rewrites all import/require paths in a TypeScript/JavaScript source string.
+ */
+function rewriteImports(source, sourceFile) {
+    // Match: import ... from '...' / import '...' / export ... from '...'
+    return source.replace(
+        /((?:import|export)\s+(?:(?:type\s+)?(?:\{[^}]*\}|[^'"]*)\s+from\s+)?['"])([^'"]+)(['"])/g,
+        (match, prefix, importPath, suffix) => {
+            const rewritten = rewriteImport(importPath, sourceFile)
+            if (rewritten) {
+                return `${prefix}${rewritten}${suffix}`
+            }
+            return match
+        },
+    )
+}
+
+/**
+ * Copies a source file to the registry directory, rewriting imports.
+ * @param {string} srcPath - Absolute path to source file
+ * @param {string} destPath - Absolute path to destination
+ */
+function copyWithRewrite(srcPath, destPath) {
+    fs.mkdirSync(path.dirname(destPath), { recursive: true })
+
+    const ext = path.extname(srcPath)
+    if (['.ts', '.tsx', '.js', '.jsx'].includes(ext)) {
+        const content = fs.readFileSync(srcPath, 'utf-8')
+        const rewritten = rewriteImports(content, srcPath)
+        fs.writeFileSync(destPath, rewritten)
+    } else {
+        // CSS, etc - copy as-is
+        fs.copyFileSync(srcPath, destPath)
+    }
+}
+
+/**
+ * Registry item definitions. Each item maps to a shadcn registry entry.
+ * @type {Array<{name: string, type: string, srcDir: string, files: string[], registryDependencies?: string[], dependencies?: string[]}>}
+ */
+const REGISTRY_ITEMS = []
+
+// Build registry
+function build() {
+    // Clean
+    fs.rmSync(REGISTRY_DIR, { recursive: true, force: true })
+
+    for (const item of REGISTRY_ITEMS) {
+        const srcDir = path.join(SRC, item.srcDir)
+        for (const file of item.files) {
+            const srcPath = path.join(srcDir, file)
+            const destDir = item.type === 'registry:file' ? 'styles' : item.srcDir.startsWith('utils') ? 'lib' : 'ui'
+            const destPath = path.join(REGISTRY_DIR, destDir, item.name, file)
+            copyWithRewrite(srcPath, destPath)
+        }
+    }
+
+    // Generate registry.json with file paths pointing to registry/ dir
+    const registryJson = {
+        $schema: 'https://ui.shadcn.com/schema/registry.json',
+        name: 'reactist',
+        homepage: 'https://github.com/Doist/reactist',
+        items: REGISTRY_ITEMS.map((item) => ({
+            name: item.name,
+            type: item.type,
+            dependencies: item.dependencies || [],
+            registryDependencies: item.registryDependencies || [],
+            files: item.files.map((file) => {
+                const destDir = item.type === 'registry:file' ? 'styles' : item.srcDir.startsWith('utils') ? 'lib' : 'ui'
+                const registryPath = `registry/${destDir}/${item.name}/${file}`
+                const isCss = file.endsWith('.css')
+                const isHook = file.startsWith('use-') || file.startsWith('use.')
+                const fileType = isCss ? 'registry:file' : isHook ? 'registry:hook' : 'registry:component'
+                const entry = { path: registryPath, type: fileType }
+                if (isCss) {
+                    entry.target = `components/reactist/${destDir}/${item.name}/${file}`
+                }
+                return entry
+            }),
+        })),
+    }
+
+    fs.writeFileSync(path.join(ROOT, 'registry.json'), JSON.stringify(registryJson, null, 4) + '\n')
+
+    console.log(`Built ${REGISTRY_ITEMS.length} registry items`)
+}
+
+build()

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -84,7 +84,7 @@ function rewriteImport(importPath, sourceFile, registryItem) {
 }
 
 /**
- * Rewrites all import/require paths in a TypeScript/JavaScript source string.
+ * Rewrites all import/export paths in a TypeScript/JavaScript source string.
  */
 function rewriteImports(source, sourceFile, registryItem) {
     // Match: import ... from '...' / import '...' / export ... from '...'


### PR DESCRIPTION
## Short description

Adds a shadcn-compatible component registry build pipeline. Includes a `build:registry` script that generates registry JSON items from source components, a version manifest, snapshot tests, and CI integration for PR checks and GitHub Pages deployment.

## PR Checklist

- [x] Added tests for bugs / new features
- [x] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI