### PR TITLE
ci: reduce workflow-level permissions to least privilege

### DIFF
--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -13,12 +13,8 @@ permissions:
     id-token: write
     # Enable the use of GitHub Packages registry
     packages: write
-    # Enable `semantic-release` to publish a GitHub release and push commits
-    contents: write
-    # Enable `semantic-release` to post comments on issues
-    issues: write
-    # Enable `semantic-release` to post comments on pull requests
-    pull-requests: write
+    # Enable the CI validation workflow to checkout the repository
+    contents: read
 
 # The release workflow involves many crucial steps that once triggered shouldn't be cancelled until
 # finished, otherwise we might end up in an inconsistent state (e.g., published to GitHub Packages


### PR DESCRIPTION
## Short description

Reduces the release workflow's default `GITHUB_TOKEN` permissions to the minimum required. Since semantic-release now uses the GitHub App token for all write operations (pushing commits, creating releases, commenting on issues/PRs), the workflow token only needs `id-token: write` (OIDC provenance), `packages: write` (GitHub Packages publish), and `contents: read` (CI validation checkout).

Backported from Doist/typist#1291 and Doist/typist#1292.

## PR Checklist

- [x] Reviewed and approved Chromatic visual regression tests in CI