### PR TITLE
fix: contain scroll chaining inside menu lists (Doist/Issues#20168)

### DIFF
--- a/src/menu/menu.module.css
+++ b/src/menu/menu.module.css
@@ -3,6 +3,7 @@
     min-height: 44px;
     max-height: var(--popover-available-height); /* defined by ariakit */
     overflow: auto;
+    overscroll-behavior: contain;
     display: block;
     white-space: nowrap;
     background: hsla(0, 100%, 100%, 0.99);


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Closes https://github.com/Doist/Issues/issues/20168

## Short description

Add overscroll containment to the shared `MenuList` scroll container so tall menus keep wheel scrolling inside the menu instead of passing it through to scrollable surfaces behind the portal-rendered menu. This gives the calendar task context menu the containment it was missing without changing Todoist-specific code.