### PR TITLE
ci: Announce new releases on Twist

### DIFF
--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -74,6 +74,11 @@ jobs:
               run: |
                   npm run build
 
+            - name: Capture previous tag
+              id: previous_tag
+              run: |
+                  echo "tag=$(git describe --tags --abbrev=0 --exclude='*-*' 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
+
             # The Node.js environment is prepared based on the `.npmrc` file in the repo, which
             # configures Doist scoped packages to use the public npm registry with OIDC
             # authentication for the initial `semantic-release` publish, after which we remove the
@@ -110,3 +115,56 @@ jobs:
                   npm publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+
+            - name: Derive release announcement
+              if: ${{ steps.semantic-release.outputs.package-published == 'true' }}
+              id: announcement
+              env:
+                  PREVIOUS_TAG: ${{ steps.previous_tag.outputs.tag }}
+              run: |
+                  git fetch --force --tags origin
+
+                  new_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+                  if [ -z "${new_tag}" ] || [ "${new_tag}" = "${PREVIOUS_TAG}" ]; then
+                      echo "should_announce=false" >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+
+                  package_name="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).name")"
+                  package_version="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
+
+                  package_url="https://www.npmjs.com/package/${package_name}/v/${package_version}"
+                  release_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${new_tag}"
+                  repo_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+
+                  if [ -n "${PREVIOUS_TAG}" ]; then
+                      changelog="$(git log --no-merges --reverse --pretty='format:- %s (%H-%h)' "${PREVIOUS_TAG}..${new_tag}" | grep -v '^- chore(release): ' || true)"
+                  else
+                      changelog="$(git log --no-merges --reverse --pretty='format:- %s (%H-%h)' "${new_tag}" | grep -v '^- chore(release): ' || true)"
+                  fi
+
+                  if [ -z "${changelog}" ]; then
+                      changelog='- No additional commits listed.'
+                  else
+                      changelog="$(printf '%s\n' "${changelog}" | sed -E -e 's,\(([a-f0-9]+)-([a-f0-9]+)\),([`\2`]('"${repo_url}"'/commit/\1)),g' | sed -E -e 's,\(#([0-9]+)\),([#\1]('"${repo_url}"'/pull/\1)),g')"
+                  fi
+
+                  {
+                      echo "should_announce=true"
+                      echo "message<<EOF"
+                      echo "**Reactist ${new_tag} published 🚀**"
+                      echo
+                      printf '%s\n' "${changelog}"
+                      echo
+                      echo "[GitHub release](${release_url}) | [npm package](${package_url})"
+                      echo "EOF"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Announce release in Twist
+              if: ${{ steps.semantic-release.outputs.package-published == 'true' && steps.announcement.outputs.should_announce == 'true' }}
+              uses: Doist/twist-post-action@74a0255b75ad93c06b9eb1009960106efe13f5ca
+              with:
+                  message: ${{ steps.announcement.outputs.message }}
+                  install_id: ${{ secrets.TWIST_RELEASE_INSTALL_ID }}
+                  install_token: ${{ secrets.TWIST_RELEASE_INSTALL_TOKEN }}
+              continue-on-error: true


### PR DESCRIPTION
## Short description

Similar to all our other projects, new Reactist releases should be announced on Twist.

This implementation is heavily inspired by the battle-tested example in todoist-cli: https://github.com/Doist/todoist-cli/blob/048c64d899fb4491321ed9a53fa7805e30ff1aad/.github/workflows/release.yml#L85

Posts into the existing thread: https://twist.com/a/1585/ch/2263/t/1720867/

## PR Checklist

- [ ] CI is green
- [ ] Code looks sane