### PR TITLE
feat(text-field): accept exceptionallySetClassName on the input element

### DIFF
--- a/src/text-field/text-field.test.tsx
+++ b/src/text-field/text-field.test.tsx
@@ -239,6 +239,17 @@ describe('TextField', () => {
         expect(inputElement).toHaveFocus()
     })
 
+    it('forwards exceptionallySetClassName to the underlying input element', () => {
+        render(
+            <TextField
+                data-testid="text-field"
+                label="Whatʼs your name?"
+                exceptionallySetClassName="custom-input-class"
+            />,
+        )
+        expect(screen.getByTestId('text-field')).toHaveClass('custom-input-class')
+    })
+
     describe('a11y', () => {
         it('renders with no a11y violations', async () => {
             const { container } = render(

--- a/src/text-field/text-field.tsx
+++ b/src/text-field/text-field.tsx
@@ -8,13 +8,15 @@ import { Box } from '../box'
 import styles from './text-field.module.css'
 
 import type { BaseFieldProps, BaseFieldVariantProps, FieldComponentProps } from '../base-field'
+import type { ObfuscatedClassName } from '../utils/common-types'
 
 type TextFieldType = 'email' | 'search' | 'tel' | 'text' | 'url'
 
 interface TextFieldProps
     extends Omit<FieldComponentProps<HTMLInputElement>, 'type' | 'supportsStartAndEndSlots'>,
         BaseFieldVariantProps,
-        Pick<BaseFieldProps, 'characterCountPosition'> {
+        Pick<BaseFieldProps, 'characterCountPosition'>,
+        ObfuscatedClassName {
     type?: TextFieldType
     startSlot?: React.ReactElement | string | number
     endSlot?: React.ReactElement | string | number
@@ -45,6 +47,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
         onChange: originalOnChange,
         characterCountPosition = 'below',
         endSlotPosition = 'bottom',
+        exceptionallySetClassName,
         ...props
     },
     ref,
@@ -107,6 +110,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
                         type={type}
                         ref={combinedRef}
                         maxLength={maxLength}
+                        className={exceptionallySetClassName}
                         onChange={(event) => {
                             originalOnChange?.(event)
                             onChange?.(event)


### PR DESCRIPTION
Closes: no issue (decided via the [exceptionallySetClassName ADR](https://github.com/Doist/component-libraries/blob/main/decisions/2026-05-20-exceptionally-set-classname.md), motivated by the [Reactist colour audit](https://github.com/Doist/component-libraries/blob/main/audits/2026-05-08-reactist-colour-audit.md)).

## Short description

`TextField` now accepts `exceptionallySetClassName` and forwards it as `className` on the underlying `<input>` element. This mirrors the existing Reactist convention used by `Box`, `Tooltip`, `Loading`, `Hidden`, `Heading`, `Inline`, `Stack`, etc.

The need was surfaced by the [DS-P005 migration](https://github.com/Doist/component-libraries/blob/main/plans/2026-05-20-deprecated-reactist-migration-plan.md). One comms-web `TextField`-bound callsite depends on a className landing on the input element: the composer's borderless link-toolbar popover ([`link-toolbar-popover.tsx`](https://github.com/Doist/comms-web/blob/main/src/composer/core/core-composer-content-input/toolbars/link-toolbar-popover.tsx)), which styles its input directly (`.linkToolbarContainer .linkInput`) for a borderless, no-padding presentation inside a custom container. Dropping that className hands the visuals back to `TextField` and breaks the popover's design. The migration plan's alternative is a per-surface CSS refactor that re-targets the input descendant.

### Scope notes

- **The Adaptive Cards case is `SelectField`, not this PR.** The other frequently-cited callsite (an Adaptive Cards host config that grabs the field element by class) is a `<select>` in `FormSelect`, handled by @pawelgrimm's separate cleanup. It is a `SelectField` concern, not a `<TextField>`/`<input>` one, so it does not justify this change. Earlier wording in this body conflated the two; corrected.
- **`SelectField` intentionally excluded.** Per the ADR caveat, the one current `SelectField` callsite that would need this (`FormSelect` → Adaptive Cards) is moving with a separate cleanup that may drop the integration. No need to pre-emptively expand the API.
- **`BaseField` needs no change.** It is an abstraction over the children render-prop pattern and does not directly render the inner field element. Forwarding happens in the concrete field component (`TextField`).

The escape-hatch framing in `ObfuscatedClassName`'s JSDoc still applies: adding the prop is not a green light for callers to style the design system freely; it is a deliberate, named exit ramp for cases the component cannot yet meet on its own.

## PR Checklist

- [x] Added tests for bugs / new features (one new test asserting the className lands on the input element)
- [ ] Updated docs (storybooks, readme). Happy to add a story showing the escape hatch if reviewers want; left out for now since the prop is intentionally discouraged.
- [ ] Reviewed and approved Chromatic visual regression tests in CI. Pending CI run; no visual diffs expected (the prop is opt-in and unused in stories).

## Related work

- ADR: [exceptionallySetClassName is the convention for Reactist field components](https://github.com/Doist/component-libraries/blob/main/decisions/2026-05-20-exceptionally-set-classname.md)
- Audit: [Reactist colour audit (2026-05-08)](https://github.com/Doist/component-libraries/blob/main/audits/2026-05-08-reactist-colour-audit.md)
- Twist discussion: [t/7796256](https://twist.com/a/1585/ch/81455/t/7796256/)
- Parent migration plan: [DS-P005 deprecated Reactist migration](https://github.com/Doist/component-libraries/blob/main/plans/2026-05-20-deprecated-reactist-migration-plan.md)
