### PR TITLE
feat(tooltip): expose `--reactist-tooltip-font-size` custom property

### DIFF
--- a/src/tooltip/tooltip.mdx
+++ b/src/tooltip/tooltip.mdx
@@ -1,0 +1,54 @@
+import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Tooltip } from './tooltip'
+import * as TooltipStories from './tooltip.stories'
+
+<Meta of={TooltipStories} />
+
+# Tooltip
+
+<Description of={Tooltip} />
+
+<Canvas>
+    <Story of={TooltipStories.TooltipPlayground} />
+</Canvas>
+
+## Examples
+
+### Rich content
+
+<Canvas>
+    <Story of={TooltipStories.TooltipRichContent} />
+</Canvas>
+
+### Custom z-index
+
+<Canvas>
+    <Story of={TooltipStories.TooltipCustomZIndex} />
+</Canvas>
+
+### Global context
+
+<Canvas>
+    <Story of={TooltipStories.TooltipGlobalContext} />
+</Canvas>
+
+### Imperative control
+
+<Canvas>
+    <Story of={TooltipStories.TooltipImperativeControl} />
+</Canvas>
+
+## Props
+
+<Controls of={TooltipStories.TooltipPlayground} />
+
+## CSS custom properties
+
+The following CSS custom properties are available to customize the tooltip component appearance. The values appearing below are the default values.
+
+```css
+:root {
+    --reactist-tooltip-font-size: inherit;
+    --reactist-stacking-order-tooltip: 1000;
+}
+```

--- a/src/tooltip/tooltip.module.css
+++ b/src/tooltip/tooltip.module.css
@@ -1,5 +1,10 @@
+:root {
+    --reactist-tooltip-font-size: inherit;
+}
+
 .tooltip {
     text-overflow: ellipsis;
     max-width: 300px;
     z-index: var(--reactist-stacking-order-tooltip);
+    font-size: var(--reactist-tooltip-font-size);
 }


### PR DESCRIPTION
## Description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

We are adding a CSS custom property so consumers can set the default font-size used in `<Tooltip>`.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

- [x] Updated docs (storybooks, readme)
- [x] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->

