### PR TITLE
fix: Use size-based avatar outline widths

### DIFF
--- a/src/avatar/avatar.module.css
+++ b/src/avatar/avatar.module.css
@@ -48,79 +48,93 @@
 .avatar {
     --reactist-avatar-size: 36px;
     --reactist-avatar-rounded-radius: 5px;
+    --reactist-avatar-outline-width: 1px;
     --reactist-avatar-meta-fill: var(--reactist-avatar-meta-0-fill);
 
     background-color: var(--reactist-avatar-empty-fill);
     width: var(--reactist-avatar-size);
     height: var(--reactist-avatar-size);
 
-    outline: 2px solid var(--reactist-avatar-border-tint);
-    outline-offset: -2px;
+    outline: var(--reactist-avatar-outline-width) solid var(--reactist-avatar-border-tint);
+    outline-offset: calc(var(--reactist-avatar-outline-width) * -1);
 }
 
 .size-80 {
     --reactist-avatar-size: 80px;
     --reactist-avatar-rounded-radius: 10px;
+    --reactist-avatar-outline-width: 2px;
 }
 
 .size-72 {
     --reactist-avatar-size: 72px;
     --reactist-avatar-rounded-radius: 10px;
+    --reactist-avatar-outline-width: 2px;
 }
 
 .size-62 {
     --reactist-avatar-size: 62px;
     --reactist-avatar-rounded-radius: 8.5px;
+    --reactist-avatar-outline-width: 1.5px;
 }
 
 .size-50 {
     --reactist-avatar-size: 50px;
     --reactist-avatar-rounded-radius: 7px;
+    --reactist-avatar-outline-width: 1px;
 }
 
 .size-40 {
     --reactist-avatar-size: 40px;
     --reactist-avatar-rounded-radius: 5.5px;
+    --reactist-avatar-outline-width: 1px;
 }
 
 .size-36 {
     --reactist-avatar-size: 36px;
     --reactist-avatar-rounded-radius: 5px;
+    --reactist-avatar-outline-width: 1px;
 }
 
 .size-30 {
     --reactist-avatar-size: 30px;
     --reactist-avatar-rounded-radius: 5px;
+    --reactist-avatar-outline-width: 1px;
 }
 
 .size-28 {
     --reactist-avatar-size: 28px;
     --reactist-avatar-rounded-radius: 5px;
+    --reactist-avatar-outline-width: 0.8px;
 }
 
 .size-24 {
     --reactist-avatar-size: 24px;
     --reactist-avatar-rounded-radius: 3.2px;
+    --reactist-avatar-outline-width: 0.5px;
 }
 
 .size-20 {
     --reactist-avatar-size: 20px;
     --reactist-avatar-rounded-radius: 3px;
+    --reactist-avatar-outline-width: 0.5px;
 }
 
 .size-18 {
     --reactist-avatar-size: 18px;
     --reactist-avatar-rounded-radius: 3px;
+    --reactist-avatar-outline-width: 0.5px;
 }
 
 .size-16 {
     --reactist-avatar-size: 16px;
     --reactist-avatar-rounded-radius: 2px;
+    --reactist-avatar-outline-width: 0.5px;
 }
 
 .size-12 {
     --reactist-avatar-size: 12px;
     --reactist-avatar-rounded-radius: 1.6px;
+    --reactist-avatar-outline-width: 0.5px;
 }
 
 .avatar:has(.initials) {


### PR DESCRIPTION
## Short description

Avatar outlines now use a size-driven CSS variable. Previously, all avatars used a thick 2px outline. Now, the outline widths are:
- 2px for 80/72
- 1.5px for 62
- 1px for 50-30
- 0.8px for 28
- 0.5px for 24-12

This matches the design mocks.

## 📸 Demo

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>

<img width="732" height="330" alt="CleanShot 2026-06-04 at 12 24 39" src="https://github.com/user-attachments/assets/c427fcc3-8d04-4c7d-873a-11f7f0258303" />

</td><td>

<img width="732" height="330" alt="image" src="https://github.com/user-attachments/assets/001f3e32-8063-4303-b55f-737ba667fae7" />

</td></tr>
</tbody>
</table>

## PR Checklist

- [x] Reviewed and approved Chromatic visual regression tests in CI
