### PR TITLE
feat: add readOnlyVariant to TextField and TextArea

### DIFF
--- a/src/base-field/base-field.tsx
+++ b/src/base-field/base-field.tsx
@@ -124,6 +124,25 @@ type BaseFieldVariantProps = {
     variant?: BaseFieldVariant
 }
 
+type ReadOnlyVariant = 'filled' | 'plain'
+
+type ReadOnlyVariantProps = {
+    /**
+     * Controls the visual treatment of the field while it is `readOnly`.
+     *
+     * - `'filled'` (the default) gives the field a subtle grey fill, signalling that a value is
+     *   present but not editable.
+     * - `'plain'` removes the fill, so the read-only field looks visually identical to its
+     *   editable state. Use this when the field sits alongside other read-only content that
+     *   should not appear boxed-in.
+     *
+     * Has no effect unless `readOnly` is also set.
+     *
+     * @default 'filled'
+     */
+    readOnlyVariant?: ReadOnlyVariant
+}
+
 export type BaseFieldProps = WithEnhancedClassName &
     Pick<HtmlInputProps<HTMLInputElement>, 'id' | 'hidden' | 'maxLength' | 'aria-describedby'> & {
         /**
@@ -376,4 +395,10 @@ function BaseField({
 }
 
 export { BaseField, FieldMessage }
-export type { BaseFieldVariant, BaseFieldVariantProps, FieldComponentProps }
+export type {
+    BaseFieldVariant,
+    BaseFieldVariantProps,
+    FieldComponentProps,
+    ReadOnlyVariant,
+    ReadOnlyVariantProps,
+}

--- a/src/text-area/text-area.mdx
+++ b/src/text-area/text-area.mdx
@@ -45,3 +45,11 @@ Note that these variables are shared with other components such as `Textfield`, 
 <Canvas>
     <Story of={TextAreaStories.AutoExpandWithInitialValue} />
 </Canvas>
+
+## Read-only variant
+
+When `readOnly` is set, the `readOnlyVariant` prop controls the field's visual treatment. The default `filled` variant adds a subtle grey fill to signal that the value is present but not editable. Use `plain` to remove the fill so the field looks identical to its editable state, which is useful when it sits alongside other read-only content that should not appear boxed-in.
+
+<Canvas withToolbar>
+    <Story of={TextAreaStories.ReadOnlyVariant} />
+</Canvas>

--- a/src/text-area/text-area.module.css
+++ b/src/text-area/text-area.module.css
@@ -29,7 +29,7 @@ See https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
     overflow-wrap: anywhere; /* to stop unnecessary horizontal expansion of text-area when `autoExpand` is enabled.*/
 }
 
-.textAreaContainer textarea[readonly] {
+.textAreaContainer textarea.readOnly {
     background-color: var(--reactist-field-readonly-background);
     color: var(--reactist-content-primary);
 }

--- a/src/text-area/text-area.stories.jsx
+++ b/src/text-area/text-area.stories.jsx
@@ -117,6 +117,7 @@ export const InteractiveProps = {
         maxLength: null,
         disabled: false,
         readOnly: false,
+        readOnlyVariant: 'filled',
     },
 
     argTypes: {
@@ -242,6 +243,43 @@ export const InteractiveProps = {
             },
 
             defaultValue: false,
+        },
+
+        readOnlyVariant: {
+            options: ['filled', 'plain'],
+
+            control: {
+                type: 'inline-radio',
+            },
+
+            defaultValue: 'filled',
+        },
+    },
+}
+
+export const ReadOnlyVariant = {
+    render: () => (
+        <Box maxWidth="small" display="flex" flexDirection="column" gap="large">
+            <TextArea
+                label="Filled (default)"
+                value="Read-only with a grey fill"
+                readOnly
+                readOnlyVariant="filled"
+            />
+            <TextArea
+                label="Plain"
+                value="Read-only with no fill"
+                readOnly
+                readOnlyVariant="plain"
+            />
+        </Box>
+    ),
+
+    name: 'Read-only variant',
+
+    parameters: {
+        chromatic: {
+            disableSnapshot: false,
         },
     },
 }

--- a/src/text-area/text-area.test.tsx
+++ b/src/text-area/text-area.test.tsx
@@ -230,6 +230,27 @@ describe('TextArea', () => {
         expect(textareaElement).toHaveValue('')
     })
 
+    it('applies the read-only fill by default', () => {
+        render(<TextArea label="Tell us a bit about you" readOnly />)
+        expect(screen.getByRole('textbox', { name: 'Tell us a bit about you' })).toHaveClass(
+            'readOnly',
+        )
+    })
+
+    it('omits the read-only fill when readOnlyVariant is "plain"', () => {
+        render(<TextArea label="Tell us a bit about you" readOnly readOnlyVariant="plain" />)
+        expect(screen.getByRole('textbox', { name: 'Tell us a bit about you' })).not.toHaveClass(
+            'readOnly',
+        )
+    })
+
+    it('does not apply the read-only fill to an editable field', () => {
+        render(<TextArea label="Tell us a bit about you" />)
+        expect(screen.getByRole('textbox', { name: 'Tell us a bit about you' })).not.toHaveClass(
+            'readOnly',
+        )
+    })
+
     it('can be a controlled field', async () => {
         function TestCase() {
             const [value, setValue] = React.useState('')

--- a/src/text-area/text-area.test.tsx
+++ b/src/text-area/text-area.test.tsx
@@ -237,11 +237,13 @@ describe('TextArea', () => {
         )
     })
 
-    it('omits the read-only fill when readOnlyVariant is "plain"', () => {
+    it('omits the read-only fill when readOnlyVariant is "plain", but stays read-only', async () => {
         render(<TextArea label="Tell us a bit about you" readOnly readOnlyVariant="plain" />)
-        expect(screen.getByRole('textbox', { name: 'Tell us a bit about you' })).not.toHaveClass(
-            'readOnly',
-        )
+        const user = userEvent.setup()
+        const textareaElement = screen.getByRole('textbox', { name: 'Tell us a bit about you' })
+        expect(textareaElement).not.toHaveClass('readOnly')
+        await user.type(textareaElement, 'I love to travel around the world')
+        expect(textareaElement).toHaveValue('')
     })
 
     it('does not apply the read-only fill to an editable field', () => {

--- a/src/text-area/text-area.tsx
+++ b/src/text-area/text-area.tsx
@@ -8,10 +8,15 @@ import { Box } from '../box'
 
 import styles from './text-area.module.css'
 
-import type { BaseFieldVariantProps, FieldComponentProps } from '../base-field'
+import type {
+    BaseFieldVariantProps,
+    FieldComponentProps,
+    ReadOnlyVariantProps,
+} from '../base-field'
 
 interface TextAreaProps
     extends Omit<FieldComponentProps<HTMLTextAreaElement>, 'characterCountPosition'>,
+        ReadOnlyVariantProps,
         Omit<
             BaseFieldVariantProps,
             'supportsStartAndEndSlots' | 'endSlot' | 'endSlotPosition' | 'value'
@@ -70,6 +75,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(function T
         autoExpand = false,
         disableResize = false,
         onChange: originalOnChange,
+        readOnlyVariant = 'filled',
         ...props
     },
     ref,
@@ -83,6 +89,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(function T
     const textAreaClassName = classNames([
         autoExpand ? styles.disableResize : null,
         disableResize ? styles.disableResize : null,
+        props.readOnly && readOnlyVariant === 'filled' ? styles.readOnly : null,
     ])
 
     return (

--- a/src/text-field/text-field.mdx
+++ b/src/text-field/text-field.mdx
@@ -86,3 +86,11 @@ The `characterCountPosition` prop is used to position the character count elemen
 <Canvas withToolbar>
     <Story of={TextFieldStories.CharacterCountPosition} />
 </Canvas>
+
+## Read-only variant
+
+When `readOnly` is set, the `readOnlyVariant` prop controls the field's visual treatment. The default `filled` variant adds a subtle grey fill to signal that the value is present but not editable. Use `plain` to remove the fill so the field looks identical to its editable state, which is useful when it sits alongside other read-only content that should not appear boxed-in.
+
+<Canvas withToolbar>
+    <Story of={TextFieldStories.ReadOnlyVariant} />
+</Canvas>

--- a/src/text-field/text-field.stories.jsx
+++ b/src/text-field/text-field.stories.jsx
@@ -217,6 +217,7 @@ export const InteractiveProps = {
         maxLength: null,
         disabled: false,
         readOnly: false,
+        readOnlyVariant: 'filled',
         characterCountPosition: undefined,
         endSlotPosition: undefined,
     },
@@ -321,6 +322,16 @@ export const InteractiveProps = {
             },
 
             defaultValue: false,
+        },
+
+        readOnlyVariant: {
+            options: ['filled', 'plain'],
+
+            control: {
+                type: 'inline-radio',
+            },
+
+            defaultValue: 'filled',
         },
 
         characterCountPosition: {
@@ -487,4 +498,31 @@ export const CharacterCountPosition = {
     ),
 
     name: 'Character count position',
+}
+
+export const ReadOnlyVariant = {
+    render: () => (
+        <Box maxWidth="small" display="flex" flexDirection="column" gap="large">
+            <TextField
+                label="Filled (default)"
+                value="Read-only with a grey fill"
+                readOnly
+                readOnlyVariant="filled"
+            />
+            <TextField
+                label="Plain"
+                value="Read-only with no fill"
+                readOnly
+                readOnlyVariant="plain"
+            />
+        </Box>
+    ),
+
+    name: 'Read-only variant',
+
+    parameters: {
+        chromatic: {
+            disableSnapshot: false,
+        },
+    },
 }

--- a/src/text-field/text-field.test.tsx
+++ b/src/text-field/text-field.test.tsx
@@ -196,12 +196,13 @@ describe('TextField', () => {
         expect(wrapper).toHaveClass('readOnly')
     })
 
-    it('omits the read-only fill when readOnlyVariant is "plain"', () => {
+    it('omits the read-only fill when readOnlyVariant is "plain", but stays read-only', async () => {
         render(<TextField label="Whatʼs your job title?" readOnly readOnlyVariant="plain" />)
-        const wrapper = screen
-            .getByRole('textbox', { name: 'Whatʼs your job title?' })
-            .closest('.inputWrapper')
-        expect(wrapper).not.toHaveClass('readOnly')
+        const user = userEvent.setup()
+        const inputElement = screen.getByRole('textbox', { name: 'Whatʼs your job title?' })
+        expect(inputElement.closest('.inputWrapper')).not.toHaveClass('readOnly')
+        await user.type(inputElement, 'Software developer')
+        expect(inputElement).toHaveValue('')
     })
 
     it('does not apply the read-only fill to an editable field', () => {

--- a/src/text-field/text-field.test.tsx
+++ b/src/text-field/text-field.test.tsx
@@ -188,6 +188,30 @@ describe('TextField', () => {
         expect(inputElement).toHaveValue('')
     })
 
+    it('applies the read-only fill by default', () => {
+        render(<TextField label="Whatʼs your job title?" readOnly />)
+        const wrapper = screen
+            .getByRole('textbox', { name: 'Whatʼs your job title?' })
+            .closest('.inputWrapper')
+        expect(wrapper).toHaveClass('readOnly')
+    })
+
+    it('omits the read-only fill when readOnlyVariant is "plain"', () => {
+        render(<TextField label="Whatʼs your job title?" readOnly readOnlyVariant="plain" />)
+        const wrapper = screen
+            .getByRole('textbox', { name: 'Whatʼs your job title?' })
+            .closest('.inputWrapper')
+        expect(wrapper).not.toHaveClass('readOnly')
+    })
+
+    it('does not apply the read-only fill to an editable field', () => {
+        render(<TextField label="Whatʼs your job title?" />)
+        const wrapper = screen
+            .getByRole('textbox', { name: 'Whatʼs your job title?' })
+            .closest('.inputWrapper')
+        expect(wrapper).not.toHaveClass('readOnly')
+    })
+
     it('can be a controlled input field', async () => {
         function TestCase() {
             const [value, setValue] = React.useState('')

--- a/src/text-field/text-field.tsx
+++ b/src/text-field/text-field.tsx
@@ -7,13 +7,19 @@ import { Box } from '../box'
 
 import styles from './text-field.module.css'
 
-import type { BaseFieldProps, BaseFieldVariantProps, FieldComponentProps } from '../base-field'
+import type {
+    BaseFieldProps,
+    BaseFieldVariantProps,
+    FieldComponentProps,
+    ReadOnlyVariantProps,
+} from '../base-field'
 
 type TextFieldType = 'email' | 'search' | 'tel' | 'text' | 'url'
 
 interface TextFieldProps
     extends Omit<FieldComponentProps<HTMLInputElement>, 'type' | 'supportsStartAndEndSlots'>,
         BaseFieldVariantProps,
+        ReadOnlyVariantProps,
         Pick<BaseFieldProps, 'characterCountPosition'> {
     type?: TextFieldType
     startSlot?: React.ReactElement | string | number
@@ -45,6 +51,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
         onChange: originalOnChange,
         characterCountPosition = 'below',
         endSlotPosition = 'bottom',
+        readOnlyVariant = 'filled',
         ...props
     },
     ref,
@@ -87,7 +94,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
                         styles.inputWrapper,
                         tone === 'error' ? styles.error : null,
                         variant === 'bordered' ? styles.bordered : null,
-                        props.readOnly ? styles.readOnly : null,
+                        props.readOnly && readOnlyVariant === 'filled' ? styles.readOnly : null,
                     ]}
                     onClick={handleClick}
                 >


### PR DESCRIPTION
_No linked issue. Component-library follow-up from building read-only description views in todoist-web._

## Short description

`TextField` and `TextArea` hardcode a grey fill on their read-only state, with no way to opt out. Consumers that want a read-only field to read as plain text override the fill with their own CSS.

This adds a `readOnlyVariant` prop to both (also inherited by `PasswordField`):

- `filled` (default) keeps today's grey fill, so existing usage is unchanged.
- `plain` suppresses the fill, so a read-only field matches its editable appearance.

The prop only applies when `readOnly` is set. `TextArea`'s CSS moves from the `textarea[readonly]` selector to a `.readOnly` class so the fill can be gated on the variant; the default render is identical to before. The shared types live in `base-field`.

This is the first of three styling-only PRs for the read-only state (#1060 subdues the border and drops hover; #1061 fixes the bordered fill). None of them removes part of the component.

## On the two variants

Review asked whether we need two ([discussion](https://github.com/Doist/reactist/pull/1059#issuecomment-4685235318)). Long term, no: the goal is one read-only style for genuine inputs (a copyable token, a feed URL), with the no-fill case moving to a separate `EditableText` component for inline-editable display text.

`plain` stays for now because two todoist-web surfaces still render that way (`goal-edit-view`, `project-details-sidebar`). Both are being removed but exist in code today, so dropping the variant now would regress them. The prop replaces their CSS overrides in the meantime. Removing `plain` is a separate PR once those surfaces are gone.

## PR Checklist

- [x] Added tests for bugs / new features
- [x] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI
