### PR TITLE
feat: subdue read-only field border and drop hover

### DIFF
--- a/src/base-field/base-field.module.css
+++ b/src/base-field/base-field.module.css
@@ -36,7 +36,12 @@
     cursor: default;
 }
 
-.container.bordered:hover {
+/* Read-only fields use a subdued border and don't react to hover */
+.container.bordered.readOnly {
+    border-color: var(--reactist-divider-tertiary);
+}
+
+.container.bordered:not(.readOnly):hover {
     border-color: var(--reactist-inputs-hover) !important;
 }
 

--- a/src/base-field/base-field.tsx
+++ b/src/base-field/base-field.tsx
@@ -144,7 +144,10 @@ type ReadOnlyVariantProps = {
 }
 
 export type BaseFieldProps = WithEnhancedClassName &
-    Pick<HtmlInputProps<HTMLInputElement>, 'id' | 'hidden' | 'maxLength' | 'aria-describedby'> & {
+    Pick<
+        HtmlInputProps<HTMLInputElement>,
+        'id' | 'hidden' | 'maxLength' | 'aria-describedby' | 'readOnly'
+    > & {
         /**
          * The main label for this field element.
          *
@@ -279,6 +282,7 @@ function BaseField({
     characterCountPosition = 'below',
     endSlot,
     endSlotPosition = 'bottom',
+    readOnly,
 }: BaseFieldProps & BaseFieldVariantProps & WithEnhancedClassName) {
     const id = useId(originalId)
     const messageId = useId()
@@ -340,6 +344,7 @@ function BaseField({
                     styles.container,
                     tone === 'error' ? styles.error : null,
                     variant === 'bordered' ? styles.bordered : null,
+                    readOnly ? styles.readOnly : null,
                 ]}
                 maxWidth={maxWidth}
                 alignItems="center"

--- a/src/text-area/text-area.mdx
+++ b/src/text-area/text-area.mdx
@@ -50,6 +50,8 @@ Note that these variables are shared with other components such as `Textfield`, 
 
 When `readOnly` is set, the `readOnlyVariant` prop controls the field's visual treatment. The default `filled` variant adds a subtle grey fill to signal that the value is present but not editable. Use `plain` to remove the fill so the field looks identical to its editable state, which is useful when it sits alongside other read-only content that should not appear boxed-in.
 
+Either way, a read-only field uses a subdued border and does not react to hover, since it is not editable. It still shows a focus border, because read-only fields remain keyboard-focusable for reading and copying.
+
 <Canvas withToolbar>
     <Story of={TextAreaStories.ReadOnlyVariant} />
 </Canvas>

--- a/src/text-area/text-area.module.css
+++ b/src/text-area/text-area.module.css
@@ -29,7 +29,7 @@ See https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
     overflow-wrap: anywhere; /* to stop unnecessary horizontal expansion of text-area when `autoExpand` is enabled.*/
 }
 
-.textAreaContainer textarea.readOnly {
+.textAreaContainer textarea.readOnlyFilled {
     background-color: var(--reactist-field-readonly-background);
     color: var(--reactist-content-primary);
 }
@@ -50,8 +50,14 @@ See https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
     border: 1px solid var(--reactist-inputs-idle);
 }
 
-.textAreaContainer:not(.bordered) textarea:hover,
-.textAreaContainer.bordered:hover {
+/* Read-only fields use a subdued border and don't react to hover (see :not(.readOnly) below) */
+.textAreaContainer:not(.bordered) textarea.readOnly,
+.textAreaContainer.bordered.readOnly {
+    border-color: var(--reactist-divider-tertiary);
+}
+
+.textAreaContainer:not(.bordered) textarea:not(.readOnly):hover,
+.textAreaContainer.bordered:not(.readOnly):hover {
     border-color: var(--reactist-inputs-hover);
 }
 

--- a/src/text-area/text-area.stories.jsx
+++ b/src/text-area/text-area.stories.jsx
@@ -272,6 +272,19 @@ export const ReadOnlyVariant = {
                 readOnly
                 readOnlyVariant="plain"
             />
+            <TextArea
+                variant="bordered"
+                label="Filled, bordered"
+                value="Read-only with a grey fill"
+                readOnly
+            />
+            <TextArea
+                variant="bordered"
+                label="Plain, bordered"
+                value="Read-only with no fill"
+                readOnly
+                readOnlyVariant="plain"
+            />
         </Box>
     ),
 

--- a/src/text-area/text-area.test.tsx
+++ b/src/text-area/text-area.test.tsx
@@ -256,6 +256,14 @@ describe('TextArea', () => {
         expect(textareaElement).not.toHaveClass('readOnlyFilled')
     })
 
+    it('applies the read-only class to the container when variant is "bordered"', () => {
+        render(<TextArea label="Tell us a bit about you" readOnly variant="bordered" />)
+        const container = screen
+            .getByRole('textbox', { name: 'Tell us a bit about you' })
+            .closest('.textAreaContainer')
+        expect(container).toHaveClass('readOnly')
+    })
+
     it('can be a controlled field', async () => {
         function TestCase() {
             const [value, setValue] = React.useState('')

--- a/src/text-area/text-area.test.tsx
+++ b/src/text-area/text-area.test.tsx
@@ -230,27 +230,30 @@ describe('TextArea', () => {
         expect(textareaElement).toHaveValue('')
     })
 
-    it('applies the read-only fill by default', () => {
+    it('applies the read-only state and fill by default', () => {
         render(<TextArea label="Tell us a bit about you" readOnly />)
         expect(screen.getByRole('textbox', { name: 'Tell us a bit about you' })).toHaveClass(
             'readOnly',
+            'readOnlyFilled',
         )
     })
 
-    it('omits the read-only fill when readOnlyVariant is "plain", but stays read-only', async () => {
+    it('omits the fill when readOnlyVariant is "plain", but stays read-only', async () => {
         render(<TextArea label="Tell us a bit about you" readOnly readOnlyVariant="plain" />)
         const user = userEvent.setup()
         const textareaElement = screen.getByRole('textbox', { name: 'Tell us a bit about you' })
-        expect(textareaElement).not.toHaveClass('readOnly')
+        // Plain keeps the read-only state (subdued border, no hover) but drops the grey fill
+        expect(textareaElement).toHaveClass('readOnly')
+        expect(textareaElement).not.toHaveClass('readOnlyFilled')
         await user.type(textareaElement, 'I love to travel around the world')
         expect(textareaElement).toHaveValue('')
     })
 
-    it('does not apply the read-only fill to an editable field', () => {
+    it('does not apply any read-only styling to an editable field', () => {
         render(<TextArea label="Tell us a bit about you" />)
-        expect(screen.getByRole('textbox', { name: 'Tell us a bit about you' })).not.toHaveClass(
-            'readOnly',
-        )
+        const textareaElement = screen.getByRole('textbox', { name: 'Tell us a bit about you' })
+        expect(textareaElement).not.toHaveClass('readOnly')
+        expect(textareaElement).not.toHaveClass('readOnlyFilled')
     })
 
     it('can be a controlled field', async () => {

--- a/src/text-area/text-area.tsx
+++ b/src/text-area/text-area.tsx
@@ -89,7 +89,8 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(function T
     const textAreaClassName = classNames([
         autoExpand ? styles.disableResize : null,
         disableResize ? styles.disableResize : null,
-        props.readOnly && readOnlyVariant === 'filled' ? styles.readOnly : null,
+        props.readOnly ? styles.readOnly : null,
+        props.readOnly && readOnlyVariant === 'filled' ? styles.readOnlyFilled : null,
     ])
 
     return (
@@ -103,10 +104,12 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(function T
             tone={tone}
             hidden={hidden}
             aria-describedby={ariaDescribedBy}
+            readOnly={props.readOnly}
             className={[
                 styles.textAreaContainer,
                 tone === 'error' ? styles.error : null,
                 variant === 'bordered' ? styles.bordered : null,
+                props.readOnly ? styles.readOnly : null,
             ]}
             maxWidth={maxWidth}
             maxLength={maxLength}

--- a/src/text-field/text-field.mdx
+++ b/src/text-field/text-field.mdx
@@ -91,6 +91,8 @@ The `characterCountPosition` prop is used to position the character count elemen
 
 When `readOnly` is set, the `readOnlyVariant` prop controls the field's visual treatment. The default `filled` variant adds a subtle grey fill to signal that the value is present but not editable. Use `plain` to remove the fill so the field looks identical to its editable state, which is useful when it sits alongside other read-only content that should not appear boxed-in.
 
+Either way, a read-only field uses a subdued border and does not react to hover, since it is not editable. It still shows a focus border, because read-only fields remain keyboard-focusable for reading and copying.
+
 <Canvas withToolbar>
     <Story of={TextFieldStories.ReadOnlyVariant} />
 </Canvas>

--- a/src/text-field/text-field.module.css
+++ b/src/text-field/text-field.module.css
@@ -3,11 +3,11 @@
     height: var(--reactist-input-wrapper-height);
 }
 
-.inputWrapper.readOnly {
+.inputWrapper.readOnlyFilled {
     background-color: var(--reactist-field-readonly-background);
 }
 
-.inputWrapper.readOnly input {
+.inputWrapper.readOnlyFilled input {
     background-color: var(--reactist-field-readonly-background);
     color: var(--reactist-content-primary);
 }
@@ -20,6 +20,11 @@
     overflow: clip;
 }
 
+/* Read-only fields use a subdued border and don't react to hover (see :not(.readOnly) below) */
+.inputWrapper:not(.bordered).readOnly {
+    border-color: var(--reactist-divider-tertiary);
+}
+
 .inputWrapper.bordered {
     --reactist-input-wrapper-height: 24px;
 }
@@ -29,7 +34,7 @@
     height: var(--reactist-input-wrapper-height);
 }
 
-.inputWrapper:not(.bordered):hover {
+.inputWrapper:not(.bordered):not(.readOnly):hover {
     border-color: var(--reactist-inputs-hover);
 }
 

--- a/src/text-field/text-field.stories.jsx
+++ b/src/text-field/text-field.stories.jsx
@@ -515,6 +515,19 @@ export const ReadOnlyVariant = {
                 readOnly
                 readOnlyVariant="plain"
             />
+            <TextField
+                variant="bordered"
+                label="Filled, bordered"
+                value="Read-only with a grey fill"
+                readOnly
+            />
+            <TextField
+                variant="bordered"
+                label="Plain, bordered"
+                value="Read-only with no fill"
+                readOnly
+                readOnlyVariant="plain"
+            />
         </Box>
     ),
 

--- a/src/text-field/text-field.test.tsx
+++ b/src/text-field/text-field.test.tsx
@@ -188,29 +188,33 @@ describe('TextField', () => {
         expect(inputElement).toHaveValue('')
     })
 
-    it('applies the read-only fill by default', () => {
+    it('applies the read-only state and fill by default', () => {
         render(<TextField label="Whatʼs your job title?" readOnly />)
         const wrapper = screen
             .getByRole('textbox', { name: 'Whatʼs your job title?' })
             .closest('.inputWrapper')
-        expect(wrapper).toHaveClass('readOnly')
+        expect(wrapper).toHaveClass('readOnly', 'readOnlyFilled')
     })
 
-    it('omits the read-only fill when readOnlyVariant is "plain", but stays read-only', async () => {
+    it('omits the fill when readOnlyVariant is "plain", but stays read-only', async () => {
         render(<TextField label="Whatʼs your job title?" readOnly readOnlyVariant="plain" />)
         const user = userEvent.setup()
         const inputElement = screen.getByRole('textbox', { name: 'Whatʼs your job title?' })
-        expect(inputElement.closest('.inputWrapper')).not.toHaveClass('readOnly')
+        const wrapper = inputElement.closest('.inputWrapper')
+        // Plain keeps the read-only state (subdued border, no hover) but drops the grey fill
+        expect(wrapper).toHaveClass('readOnly')
+        expect(wrapper).not.toHaveClass('readOnlyFilled')
         await user.type(inputElement, 'Software developer')
         expect(inputElement).toHaveValue('')
     })
 
-    it('does not apply the read-only fill to an editable field', () => {
+    it('does not apply any read-only styling to an editable field', () => {
         render(<TextField label="Whatʼs your job title?" />)
         const wrapper = screen
             .getByRole('textbox', { name: 'Whatʼs your job title?' })
             .closest('.inputWrapper')
         expect(wrapper).not.toHaveClass('readOnly')
+        expect(wrapper).not.toHaveClass('readOnlyFilled')
     })
 
     it('can be a controlled input field', async () => {

--- a/src/text-field/text-field.test.tsx
+++ b/src/text-field/text-field.test.tsx
@@ -217,6 +217,14 @@ describe('TextField', () => {
         expect(wrapper).not.toHaveClass('readOnlyFilled')
     })
 
+    it('applies the read-only class to the bordered container when variant is "bordered"', () => {
+        render(<TextField label="Whatʼs your job title?" readOnly variant="bordered" />)
+        const container = screen
+            .getByRole('textbox', { name: 'Whatʼs your job title?' })
+            .closest('.bordered')
+        expect(container).toHaveClass('readOnly')
+    })
+
     it('can be a controlled input field', async () => {
         function TestCase() {
             const [value, setValue] = React.useState('')

--- a/src/text-field/text-field.tsx
+++ b/src/text-field/text-field.tsx
@@ -82,6 +82,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
             hidden={hidden}
             aria-describedby={ariaDescribedBy}
             characterCountPosition={characterCountPosition}
+            readOnly={props.readOnly}
             supportsStartAndEndSlots
             endSlot={endSlot}
             endSlotPosition={variant === 'bordered' ? endSlotPosition : undefined}
@@ -94,7 +95,10 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
                         styles.inputWrapper,
                         tone === 'error' ? styles.error : null,
                         variant === 'bordered' ? styles.bordered : null,
-                        props.readOnly && readOnlyVariant === 'filled' ? styles.readOnly : null,
+                        props.readOnly ? styles.readOnly : null,
+                        props.readOnly && readOnlyVariant === 'filled'
+                            ? styles.readOnlyFilled
+                            : null,
                     ]}
                     onClick={handleClick}
                 >


### PR DESCRIPTION
_No linked issue. Follow-up to #1059, stacked on `feat/readonly-variant-fields` (base of this PR). Review #1059 first; this targets that branch and will retarget `main` once #1059 merges._

## Short description

Read-only `TextField` and `TextArea` reused the editable idle border and still brightened it on hover and focus. On a field you cannot edit, that hover/focus reaction reads as interactive. This refines the read-only treatment:

- **Subdued border.** Read-only fields use `--reactist-divider-tertiary` (one step lighter than the editable idle border) so a locked field is visually quieter.
- **No hover reaction.** The hover border-brightening is gated out for read-only fields.
- **Focus is kept.** Read-only fields remain keyboard-focusable (you can tab in to read and copy), so removing the focus indicator would break [WCAG 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html). The focus border stays.

This applies to the read-only state regardless of `readOnlyVariant`; the variant only toggles the grey fill. It covers the default and the `bordered` variant of both components.

## Implementation notes

- The read-only fill class is split out as `readOnlyFilled`, so the read-only **state** (subdued border, no hover) and the **fill** (grey background) are independent. `plain` read-only fields get the subdued border without the fill.
- `BaseField` gains a `readOnly` prop. The bordered border is drawn by `BaseField`, so it needs the read-only signal to gate hover and apply the subdued color. The prop is optional and additive.
- Error tone still wins: the alert border uses `!important`, so a read-only field in an error state keeps its red border.

## Scope

This is intentionally separate from #1059. #1059 is purely additive (a new prop, no change to existing appearance). This PR changes the **default** read-only appearance of every field across the app, so it carries the visual diffs and is reviewed on its own.

## PR Checklist

- [x] Added tests for bugs / new features
- [x] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI
