### PR TITLE
fix: fill the bordered container for read-only filled fields

### DIFF
--- a/src/base-field/base-field.module.css
+++ b/src/base-field/base-field.module.css
@@ -41,6 +41,12 @@
     border-color: var(--reactist-divider-tertiary);
 }
 
+/* In the bordered variant the container owns the border and padding, so a filled read-only field
+   is filled here (rather than on the inner field) to reach the border edge to edge */
+.container.bordered.readOnlyFilled {
+    background-color: var(--reactist-field-readonly-background);
+}
+
 .container.bordered:not(.readOnly):hover {
     border-color: var(--reactist-inputs-hover) !important;
 }

--- a/src/base-field/base-field.tsx
+++ b/src/base-field/base-field.tsx
@@ -226,6 +226,14 @@ export type BaseFieldProps = WithEnhancedClassName &
         maxLength?: number
 
         /**
+         * Used internally by field components to fill the bordered container when the field is
+         * read-only with the `filled` variant. In the bordered variant the container owns the
+         * border and padding, so the fill must live here for it to reach the border edge to edge.
+         * Not exposed as part of the public props of such components.
+         */
+        readOnlyFilled?: boolean
+
+        /**
          * Used internally by components composed using `BaseField`. It is not exposed as part of
          * the public props of such components.
          */
@@ -283,6 +291,7 @@ function BaseField({
     endSlot,
     endSlotPosition = 'bottom',
     readOnly,
+    readOnlyFilled,
 }: BaseFieldProps & BaseFieldVariantProps & WithEnhancedClassName) {
     const id = useId(originalId)
     const messageId = useId()
@@ -345,6 +354,7 @@ function BaseField({
                     tone === 'error' ? styles.error : null,
                     variant === 'bordered' ? styles.bordered : null,
                     readOnly ? styles.readOnly : null,
+                    readOnlyFilled ? styles.readOnlyFilled : null,
                 ]}
                 maxWidth={maxWidth}
                 alignItems="center"

--- a/src/text-area/text-area.test.tsx
+++ b/src/text-area/text-area.test.tsx
@@ -256,6 +256,29 @@ describe('TextArea', () => {
         expect(textareaElement).not.toHaveClass('readOnlyFilled')
     })
 
+    it('fills the bordered container when read-only and filled', () => {
+        render(<TextArea variant="bordered" label="Tell us a bit about you" readOnly />)
+        const container = screen
+            .getByRole('textbox', { name: 'Tell us a bit about you' })
+            .closest('.container')
+        expect(container).toHaveClass('bordered', 'readOnlyFilled')
+    })
+
+    it('does not fill the bordered container when read-only and plain', () => {
+        render(
+            <TextArea
+                variant="bordered"
+                label="Tell us a bit about you"
+                readOnly
+                readOnlyVariant="plain"
+            />,
+        )
+        const container = screen
+            .getByRole('textbox', { name: 'Tell us a bit about you' })
+            .closest('.container')
+        expect(container).not.toHaveClass('readOnlyFilled')
+    })
+
     it('can be a controlled field', async () => {
         function TestCase() {
             const [value, setValue] = React.useState('')

--- a/src/text-area/text-area.tsx
+++ b/src/text-area/text-area.tsx
@@ -105,6 +105,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(function T
             hidden={hidden}
             aria-describedby={ariaDescribedBy}
             readOnly={props.readOnly}
+            readOnlyFilled={props.readOnly && readOnlyVariant === 'filled'}
             className={[
                 styles.textAreaContainer,
                 tone === 'error' ? styles.error : null,

--- a/src/text-field/text-field.test.tsx
+++ b/src/text-field/text-field.test.tsx
@@ -217,6 +217,30 @@ describe('TextField', () => {
         expect(wrapper).not.toHaveClass('readOnlyFilled')
     })
 
+    it('fills the bordered container when read-only and filled', () => {
+        render(<TextField variant="bordered" label="Whatʼs your job title?" readOnly />)
+        const container = screen
+            .getByRole('textbox', { name: 'Whatʼs your job title?' })
+            .closest('.container')
+        expect(container).toHaveClass('bordered', 'readOnlyFilled')
+    })
+
+    it('does not fill the bordered container when read-only and plain', () => {
+        render(
+            <TextField
+                variant="bordered"
+                label="Whatʼs your job title?"
+                readOnly
+                readOnlyVariant="plain"
+            />,
+        )
+        const container = screen
+            .getByRole('textbox', { name: 'Whatʼs your job title?' })
+            .closest('.container')
+        expect(container).toHaveClass('bordered', 'readOnly')
+        expect(container).not.toHaveClass('readOnlyFilled')
+    })
+
     it('can be a controlled input field', async () => {
         function TestCase() {
             const [value, setValue] = React.useState('')

--- a/src/text-field/text-field.tsx
+++ b/src/text-field/text-field.tsx
@@ -83,6 +83,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
             aria-describedby={ariaDescribedBy}
             characterCountPosition={characterCountPosition}
             readOnly={props.readOnly}
+            readOnlyFilled={props.readOnly && readOnlyVariant === 'filled'}
             supportsStartAndEndSlots
             endSlot={endSlot}
             endSlotPosition={variant === 'bordered' ? endSlotPosition : undefined}


### PR DESCRIPTION
_No linked issue. Follow-up to #1060, stacked on `feat/readonly-field-subdued-border` (base of this PR). Review #1059 and #1060 first; this targets #1060's branch and will retarget `main` once those merge._

## Short description

In the `bordered` variant, the container owns the border and padding while the field sits inside it. A read-only `filled` field put its grey on the inner field, so the fill showed up as an inset band that did not reach the border:

Before: grey band floating inside a white padded box.
After: the whole bordered box is filled, so a read-only field reads as one cohesive grey card.

The fill now lives on the container for the bordered variant. The default variant is unchanged, since its field already fills edge to edge.

## Implementation notes

- `BaseField` gains an internal `readOnlyFilled` signal (not part of the public field props). The field components pass `readOnly && readOnlyVariant === 'filled'`.
- The container fill is scoped to `.container.bordered.readOnlyFilled`, so the default variant's container is never filled (only its inner field is, as before).
- `plain` bordered read-only fields are unaffected: subdued border, no fill.

## Scope

Separate from #1060 on purpose. #1060 refines the read-only border and hover for every field; this is a narrow appearance fix for one variant combination (bordered + filled + read-only).

## PR Checklist

- [x] Added tests for bugs / new features
- [x] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI
