### PR TITLE
feat(prose): add table styling support

### DIFF
--- a/src/prose/prose-example.ts
+++ b/src/prose/prose-example.ts
@@ -74,6 +74,14 @@ Now a nested list:
 
     Do not bump wooden spoon or it will fall.
 
+And here's a table, with column alignment:
+
+| Item    | Quantity | Price |
+| ------- | :------: | ----: |
+| Carrots |        3 | $1.20 |
+| Celery  |        1 | $0.95 |
+| Lentils |      500g | $2.40 |
+
 ---
 
 A horizontal rule follows.

--- a/src/prose/prose-example.ts
+++ b/src/prose/prose-example.ts
@@ -90,3 +90,13 @@ A horizontal rule follows.
 
 The End
 `)
+
+export const proseTableOverflowExample = marked(`
+Tables whose content cannot wrap any further (e.g. long unbreakable links) scroll horizontally
+instead of stretching the surrounding content:
+
+| Resource | Reference |
+| -------- | --------- |
+| Prose styles | https://github.com/Doist/reactist/blob/main/src/prose/prose.module.css |
+| Prose stories | https://github.com/Doist/reactist/blob/main/src/prose/prose.stories.tsx |
+`)

--- a/src/prose/prose-example.ts
+++ b/src/prose/prose-example.ts
@@ -100,3 +100,17 @@ instead of stretching the surrounding content:
 | Prose styles | https://github.com/Doist/reactist/blob/main/src/prose/prose.module.css |
 | Prose stories | https://github.com/Doist/reactist/blob/main/src/prose/prose.stories.tsx |
 `)
+
+export const proseTableColorsExample = marked(`
+Consumers can give the header row and odd/even body rows their own background colors via the
+\`--reactist-prose-table-header-fill\`, \`--reactist-prose-table-row-odd-fill\`, and
+\`--reactist-prose-table-row-even-fill\` custom properties (all default to \`transparent\`):
+
+| Item    | Quantity | Price |
+| ------- | :------: | ----: |
+| Carrots |        3 | $1.20 |
+| Celery  |        1 | $0.95 |
+| Lentils |     500g | $2.40 |
+| Onions  |        2 | $0.80 |
+| Stock   |       1L | $3.10 |
+`)

--- a/src/prose/prose.module.css
+++ b/src/prose/prose.module.css
@@ -12,6 +12,13 @@
     --reactist-prose-horizontal-rule-color: var(--reactist-divider-primary);
 
     --reactist-prose-table-border: var(--reactist-divider-primary);
+
+    /* `transparent` (the initial value of `background-color`) rather than `initial`, which is
+       special-cased in custom property values to mean "guaranteed invalid", or `inherit`, which
+       backgrounds achieve through transparency rather than inheritance. */
+    --reactist-prose-table-header-fill: transparent;
+    --reactist-prose-table-row-odd-fill: transparent;
+    --reactist-prose-table-row-even-fill: transparent;
 }
 
 /* Internals for spacing. These are not considered public API. */
@@ -235,6 +242,20 @@
 .prose td {
     border: 1px solid var(--reactist-prose-table-border);
     padding: calc(var(--reactist-prose-space-1) / 2) var(--reactist-prose-space-1);
+}
+
+/* The header fill goes on the row rather than `th` so that row headers in table bodies
+   (`<tbody><tr><th scope="row">…`) stripe with their row instead of picking up the header fill. */
+.prose thead tr {
+    background-color: var(--reactist-prose-table-header-fill);
+}
+
+.prose tbody tr:nth-child(odd) {
+    background-color: var(--reactist-prose-table-row-odd-fill);
+}
+
+.prose tbody tr:nth-child(even) {
+    background-color: var(--reactist-prose-table-row-even-fill);
 }
 
 .prose th {

--- a/src/prose/prose.module.css
+++ b/src/prose/prose.module.css
@@ -10,6 +10,8 @@
     --reactist-prose-link-hover-underline: #006f85;
 
     --reactist-prose-horizontal-rule-color: var(--reactist-divider-primary);
+
+    --reactist-prose-table-border: var(--reactist-divider-primary);
 }
 
 /* Internals for spacing. These are not considered public API. */
@@ -210,6 +212,52 @@
 .prose pre code {
     white-space: break-spaces;
     overflow: auto;
+}
+
+/* tables */
+
+.prose table {
+    /* Let wide tables scroll horizontally instead of stretching the surrounding content. */
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    overflow: auto;
+    margin-top: var(--reactist-prose-space-2);
+    border-collapse: collapse;
+
+    /* `.prose`'s `word-break: break-word` acts like `overflow-wrap: anywhere`, shrinking each
+       word's min-content width to a single character. That lets wide tables squeeze into
+       `max-width: 100%` by breaking words mid-word instead of overflowing into the scroll above. */
+    word-break: normal;
+}
+
+.prose th,
+.prose td {
+    border: 1px solid var(--reactist-prose-table-border);
+    padding: calc(var(--reactist-prose-space-1) / 2) var(--reactist-prose-space-1);
+}
+
+.prose th {
+    font-weight: 600;
+}
+
+/* Browsers center `th` by default; align with `td` instead. Markdown renderers express explicit
+   column alignment either as an inline `text-align` style (which wins over this rule) or as the
+   `align` attribute (which would lose to it, hence the `:not([align])` guard). */
+.prose th:not([align]) {
+    text-align: start;
+}
+
+/* Markdown table cells hold inline content only, but raw HTML tables can nest block elements
+   (e.g. `<td><p>…</p></td>`), whose margins would add awkward vertical spacing. */
+.prose th > :first-child,
+.prose td > :first-child {
+    margin-top: 0;
+}
+
+.prose th > :last-child,
+.prose td > :last-child {
+    margin-bottom: 0;
 }
 
 /* headings in relation to other tags */

--- a/src/prose/prose.stories.tsx
+++ b/src/prose/prose.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Box } from '../box'
 
 import { Prose } from './prose'
-import { proseExample } from './prose-example'
+import { proseExample, proseTableOverflowExample } from './prose-example'
 
 import type { ProseProps } from './prose'
 
@@ -67,4 +67,26 @@ ProsePlaygroundStory.argTypes = {
     children: { control: false },
     dangerouslySetInnerHTML: { control: false },
     exceptionallySetClassName: { control: false },
+}
+
+//
+// Table overflow
+//
+
+export function ProseTableOverflowStory() {
+    // The narrow container guarantees the table overflows into a horizontal scroll at any
+    // viewport size, so the snapshot exercises the scrolling layout deterministically.
+    return (
+        <Box padding="xlarge" style={{ maxWidth: 400 }}>
+            <Prose
+                darkModeTypography={false}
+                dangerouslySetInnerHTML={{ __html: proseTableOverflowExample }}
+            />
+        </Box>
+    )
+}
+
+ProseTableOverflowStory.storyName = 'Table overflow'
+ProseTableOverflowStory.parameters = {
+    chromatic: { disableSnapshot: false },
 }

--- a/src/prose/prose.stories.tsx
+++ b/src/prose/prose.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Box } from '../box'
 
 import { Prose } from './prose'
-import { proseExample, proseTableOverflowExample } from './prose-example'
+import { proseExample, proseTableColorsExample, proseTableOverflowExample } from './prose-example'
 
 import type { ProseProps } from './prose'
 
@@ -88,5 +88,32 @@ export function ProseTableOverflowStory() {
 
 ProseTableOverflowStory.storyName = 'Table overflow'
 ProseTableOverflowStory.parameters = {
+    chromatic: { disableSnapshot: false },
+}
+
+//
+// Table colors
+//
+
+export function ProseTableColorsStory() {
+    return (
+        <Box
+            padding="xlarge"
+            style={{
+                // @ts-expect-error
+                '--reactist-prose-table-header-fill': 'rgb(233, 239, 242)',
+                '--reactist-prose-table-row-even-fill': 'rgb(247, 250, 251)',
+            }}
+        >
+            <Prose
+                darkModeTypography={false}
+                dangerouslySetInnerHTML={{ __html: proseTableColorsExample }}
+            />
+        </Box>
+    )
+}
+
+ProseTableColorsStory.storyName = 'Table colors'
+ProseTableColorsStory.parameters = {
     chromatic: { disableSnapshot: false },
 }


### PR DESCRIPTION
Follow-up to https://github.com/Doist/comms-web/pull/395#discussion_r3395143218 — Comms now renders GFM tables in messages and should eventually use `<Prose>` instead of its forked prose CSS, but `<Prose>` had no table styling.

## Short description

- Adds bordered table styles to `<Prose>`, with a new public `--reactist-prose-table-border` custom property (defaults to `var(--reactist-divider-primary)`).
- Wide tables scroll horizontally (`display: block; width: max-content; max-width: 100%; overflow: auto`) instead of stretching the surrounding content, with `word-break: normal` so cell text doesn't collapse to one character per line under `.prose`'s `break-word`.
- Headers are bold and start-aligned, with a `th:not([align])` guard so explicit column alignment survives both renderer conventions: `marked` emits the presentational `align` attribute (which author CSS would override without the guard), while react-markdown emits inline `text-align` styles (which win regardless).
- Cells reset first/last-child block margins so raw HTML tables with block content (e.g. `<td><p>…</p></td>`) don't get awkward vertical spacing.
- Adds `--reactist-prose-table-header-fill`, `--reactist-prose-table-row-odd-fill`, and `--reactist-prose-table-row-even-fill` custom properties (all default to `transparent`) so consumers can color the header row and stripe body rows, demoed in a "Table colors" story.
- Adds a table (with column alignment) to the Storybook prose example, plus a dedicated width-constrained "Table overflow" story so Chromatic exercises the horizontal-scroll layout at any viewport.

Smoke tested in Storybook in light and dark playground modes and in the overflow story.

## Out of scope

- Keyboard-focusable scrolling for clipped tables in Safari: Prose is CSS-only over HTML it doesn't control, so it can't inject a focusable wrapper or `tabindex`. Chrome 130+/Firefox handle this natively for scrollers without focusable children; the wrapper belongs at the consumer's renderer level (tracked for the Comms migration). See the resolved review thread for details.

## PR Checklist

- [x] Added tests for bugs / new features (visual coverage via the new Chromatic stories; no unit-testable logic)
- [x] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


