### PR TITLE
Bump GitHub Action pins to node24-compatible majors

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -21,7 +21,7 @@ jobs:
 
             - name: Cache project 'node_modules' directory
               id: node-modules-cache
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
                   path: node_modules/

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -38,7 +38,7 @@ jobs:
 
             - name: Cache project 'node_modules' directory
               id: node-modules-cache
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   key: node-modules-cache-${{ hashFiles('**/package-lock.json', '**/.node-version') }}
                   path: node_modules/


### PR DESCRIPTION
Bumps GitHub Action pins to majors that ship with the node24 runtime, ahead of GitHub's node20 deprecation.

- `actions/cache` v4 → v5

Tracking: https://github.com/Doist/platform-backlog/issues/1385
