### PR TITLE
fix: avoid ref access in useId

### DIFF
--- a/.react-compiler.rec.json
+++ b/.react-compiler.rec.json
@@ -19,9 +19,6 @@
     },
     "src/tooltip/tooltip.tsx": {
       "CompileError": 1
-    },
-    "src/utils/common-helpers.ts": {
-      "CompileError": 2
     }
   }
 }

--- a/src/utils/common-helpers.ts
+++ b/src/utils/common-helpers.ts
@@ -14,11 +14,6 @@ export function generateElementId(prefix: string): string {
  * @deprecated Use `useId` available from React 18 or above instead.
  */
 export function useId(providedId?: string): string {
-    const ref = React.useRef<string | null>(providedId ?? null)
-    // eslint-disable-next-line react-hooks/refs
-    if (!ref.current) {
-        ref.current = generateElementId('element')
-    }
-    // eslint-disable-next-line react-hooks/refs
-    return ref.current
+    const [id] = React.useState<string>(() => providedId || generateElementId('element'))
+    return id
 }


### PR DESCRIPTION
## Summary

- Replace the deprecated local `useId` ref cache with a lazy `useState` initializer so it no longer reads or writes refs during render.
- Remove `src/utils/common-helpers.ts` from the React Compiler violation record.

Closes #1067