### PR TITLE
fix(tooltip): Let ariakit merge the child ref to avoid React ref warning

### DIFF
--- a/src/tooltip/tooltip.test.tsx
+++ b/src/tooltip/tooltip.test.tsx
@@ -159,7 +159,7 @@ describe('Tooltip', () => {
         jest.useRealTimers()
     })
 
-    it("does not interfere with the trigger element's ref forwarding", () => {
+    it("does not interfere with the trigger element's ref forwarding", async () => {
         const buttonRef = React.createRef<HTMLButtonElement>()
 
         render(
@@ -168,7 +168,14 @@ describe('Tooltip', () => {
             </Tooltip>,
         )
 
-        expect(buttonRef.current).toBe(screen.getByRole('button'))
+        const button = screen.getByRole('button', { name: 'Click me' })
+        expect(buttonRef.current).toBe(button)
+
+        const user = userEvent.setup()
+        await user.hover(button)
+        expect(
+            await screen.findByRole('tooltip', { name: 'tooltip content here' }),
+        ).toBeInTheDocument()
     })
 
     it('supports components with an "as" prop as the anchor', async () => {

--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -144,22 +144,9 @@ const Tooltip = React.forwardRef<TooltipStore, TooltipProps>(
             return child
         }
 
-        /* eslint-disable react-hooks/refs */
-        const rawRef =
-            'ref' in child.props
-                ? child.props.ref
-                : // child.ref access kept for React 18 compatibility
-                  (child as { ref?: unknown }).ref
-
-        if (typeof rawRef === 'string') {
-            throw new Error('Tooltip: String refs cannot be used as they cannot be forwarded')
-        }
-
-        const childRef = rawRef as React.Ref<HTMLDivElement>
-
         return (
             <>
-                <TooltipAnchor render={child} store={tooltip} ref={childRef} />
+                <TooltipAnchor render={child} store={tooltip} />
                 {isOpen && content ? (
                     <AriakitTooltip
                         store={tooltip}
@@ -184,7 +171,6 @@ const Tooltip = React.forwardRef<TooltipStore, TooltipProps>(
                 ) : null}
             </>
         )
-        /* eslint-enable react-hooks/refs */
     },
 )
 


### PR DESCRIPTION
## Short description

In #1074, we tried to match `Tooltip`'s previous implementation where we extract and pass along its child's ref to Ariakit, while keeping React 18 and 19 compatibility.. However, this causes a dev mode warning in React 18 when we try to test `props.ref`:

> Warning: `ref` is not a prop. Trying to access it will result in `undefined` being returned.
> If you need to access the same value within the child component, you should pass it as a different
> prop. (https://reactjs.org/link/special-props)

Turns out, Ariakit already merges the child element's ref and check for `props.ref` through its `render` prop:

* https://github.com/ariakit/ariakit/blob/f6b6376e57f910c9163b89a36e717a1e857fe43c/packages/ariakit-react-core/src/utils/system.tsx#L39
* https://github.com/ariakit/ariakit/blob/f6b6376e57f910c9163b89a36e717a1e857fe43c/packages/ariakit-react-core/src/utils/misc.ts#L41-L44

So we can remove this logic and let Ariakit handle it: `<TooltipAnchor render={child} store={tooltip} />`

## PR Checklist

- [x] Added tests for bugs / new features
- [ ] Reviewed and approved Chromatic visual regression tests in CI
