### PR TITLE
docs(storybook): fix crash when Reactist tooltip is triggered in the Storybook frame

### DIFF
--- a/.plop/templates/component/component.stories.tsx.hbs
+++ b/.plop/templates/component/component.stories.tsx.hbs
@@ -7,10 +7,26 @@ const meta = {
     title: 'Design system/{{pascalCase name}}',
     component: {{pascalCase name}},
     parameters: {
+        /**
+         * Storybook toolbar badges
+         * Used to highlight the web accessibility standards the component meets or
+         * whether the component is deprecated.
+         * Possible values: `accessible`, `partiallyAccessible`, `notAccessible`, `deprecated`
+         * @see .storybook/badges/README.md
+         */
         badges: ['accessible'],
-        // Link a Figma design to show it in the toolbar, or set `figma: false`
-        // to hide the tool on pages with no matching design (e.g. hook docs):
-        // figma: { path: 'Figma file › Page › Section › Component', url: 'https://www.figma.com/design/…?node-id=…' },
+
+        /**
+         * Figma design link
+         * Used to link to the component's design in Figma
+         * For non-visual components, set `figma: FIGMA_NOT_NEEDED` (imported from
+         * `.storybook/figma/constants`) to hide the "No Figma link" hint.
+         * @see .storybook/figma/README.md
+         */
+        figma: {
+            path: 'Figma file › Page › Section › Component', 
+            url: 'https://www.figma.com/design/…?node-id=…', 
+        },
     },
 } satisfies Meta<typeof {{pascalCase name}}>
 

--- a/.plop/templates/component/component.stories.tsx.hbs
+++ b/.plop/templates/component/component.stories.tsx.hbs
@@ -14,18 +14,18 @@ const meta = {
          * Possible values: `accessible`, `partiallyAccessible`, `notAccessible`, `deprecated`
          * @see .storybook/badges/README.md
          */
-        badges: ['accessible'],
+        badges: ['notAccessible'],
 
         /**
          * Figma design link
-         * Used to link to the component's design in Figma
-         * For non-visual components, set `figma: FIGMA_NOT_NEEDED` (imported from
-         * `.storybook/figma/constants`) to hide the "No Figma link" hint.
+         * Used to link to the component's design in Figma. Until you add one, the toolbar shows a
+         * "No Figma link" reminder; for non-visual components set `figma: FIGMA_NOT_NEEDED` (imported
+         * from `.storybook/figma/constants`).
          * @see .storybook/figma/README.md
          */
         figma: {
-            path: 'Figma file › Page › Section › Component', 
-            url: 'https://www.figma.com/design/…?node-id=…', 
+            // path: 'Figma file › Page › Section › Component',
+            // url: 'https://www.figma.com/design/…?node-id=…',
         },
     },
 } satisfies Meta<typeof {{pascalCase name}}>

--- a/.storybook/badges/README.md
+++ b/.storybook/badges/README.md
@@ -1,0 +1,36 @@
+# Badges toolbar tool
+
+Allows adding a toolbar badge (or badges) for the current story, used to flag things viewers should know at a glance, e.g. a component's accessibility status or deprecation.
+
+## Usage
+
+Set the `badges` parameter on the component's CSF `meta`:
+
+```ts
+const meta = {
+    title: '📝 Form/CheckboxField',
+    component: CheckboxField,
+    parameters: {
+        badges: ['accessible'],
+    },
+}
+```
+
+You can list more than one key:
+
+```ts
+badges: ['partiallyAccessible', 'deprecated']
+```
+
+### MDX docs
+
+Badges come from the story parameters, so an MDX docs page inherits them when it is **attached** to a stories file via `<Meta of={ComponentStories} />`. Storybook will **drop** parameters set directly on a standalone `<Meta title="…" />` (i.e. no `of`).
+
+## Available badges
+
+| Key                   | Label                       | Tone             |
+| --------------------- | --------------------------- | ---------------- |
+| `accessible`          | ✔ Accessible (WCAG 2.0 AA) | positive (green) |
+| `partiallyAccessible` | ⚠ Partially Accessible     | warning (orange) |
+| `notAccessible`       | ✖ Not accessible           | attention (red)  |
+| `deprecated`          | ✖ Deprecated               | attention (red)  |

--- a/.storybook/badges/badges-tool.tsx
+++ b/.storybook/badges/badges-tool.tsx
@@ -2,11 +2,10 @@ import * as React from 'react'
 
 import { useParameter } from 'storybook/manager-api'
 
-import { Badge } from '../../src/badge/badge'
-import { Inline } from '../../src/inline'
+import { Badge, BadgeGroup } from '../components/badge'
 
 import { resolveBadges } from './badges'
-import { BADGES_CONFIG_PARAMETER, BADGES_PARAMETER } from './constants'
+import { BADGES_CONFIG_PARAMETER, BADGES_PARAMETER, TOOL_ID } from './constants'
 
 const emptyBadges: unknown[] = []
 const emptyBadgesConfig: Record<string, unknown> = {}
@@ -25,10 +24,14 @@ export const BadgesTool = React.memo(function BadgesTool() {
     }
 
     return (
-        <Inline space="xsmall">
-            {badges.map(({ id, title, tone }) => (
-                <Badge key={id} tone={tone} label={title} />
+        <BadgeGroup
+            key={TOOL_ID}
+            aria-label="Story badges"
+            title={badges.map(({ title }) => title).join(', ')}
+        >
+            {badges.map(({ id, title, styles }, index) => (
+                <Badge key={`${id}-${index}`} label={title} styles={styles} />
             ))}
-        </Inline>
+        </BadgeGroup>
     )
 })

--- a/.storybook/badges/badges-tool.tsx
+++ b/.storybook/badges/badges-tool.tsx
@@ -2,10 +2,16 @@ import * as React from 'react'
 
 import { useParameter } from 'storybook/manager-api'
 
-import { Badge, BadgeGroup } from '../components/badge'
+import { Badge } from '../components/badge'
 
 import { resolveBadges } from './badges'
 import { BADGES_CONFIG_PARAMETER, BADGES_PARAMETER, TOOL_ID } from './constants'
+
+const containerStyle: React.CSSProperties = {
+    alignItems: 'center',
+    display: 'inline-flex',
+    gap: '4px',
+}
 
 const emptyBadges: unknown[] = []
 const emptyBadgesConfig: Record<string, unknown> = {}
@@ -24,14 +30,15 @@ export const BadgesTool = React.memo(function BadgesTool() {
     }
 
     return (
-        <BadgeGroup
+        <div
             key={TOOL_ID}
             aria-label="Story badges"
+            style={containerStyle}
             title={badges.map(({ title }) => title).join(', ')}
         >
             {badges.map(({ id, title, styles }, index) => (
                 <Badge key={`${id}-${index}`} label={title} styles={styles} />
             ))}
-        </BadgeGroup>
+        </div>
     )
 })

--- a/.storybook/badges/badges.test.ts
+++ b/.storybook/badges/badges.test.ts
@@ -6,46 +6,42 @@ describe('resolveBadges', () => {
             resolveBadges(['accessible', 'deprecated'], {
                 accessible: {
                     title: 'Accessible',
-                    tone: 'positive',
+                    styles: { color: 'green' },
                 },
                 deprecated: {
                     title: 'Deprecated',
-                    tone: 'attention',
+                    styles: { color: 'red' },
                 },
             }),
         ).toEqual([
             {
                 id: 'accessible',
                 title: 'Accessible',
-                tone: 'positive',
+                styles: { color: 'green' },
             },
             {
                 id: 'deprecated',
                 title: 'Deprecated',
-                tone: 'attention',
+                styles: { color: 'red' },
             },
         ])
     })
 
     it('filters unknown badges and invalid badge entries', () => {
         expect(
-            resolveBadges(['accessible', 'missing', 42, 'untitled', 'untoned'], {
+            resolveBadges(['accessible', 'missing', 42, 'untitled'], {
                 accessible: {
                     title: 'Accessible',
-                    tone: 'positive',
                 },
                 untitled: {
-                    tone: 'positive',
-                },
-                untoned: {
-                    title: 'Untoned',
+                    styles: { color: 'orange' },
                 },
             }),
         ).toEqual([
             {
                 id: 'accessible',
                 title: 'Accessible',
-                tone: 'positive',
+                styles: undefined,
             },
         ])
     })
@@ -57,14 +53,20 @@ describe('resolveBadges', () => {
         expect(resolveBadges(['accessible'], [])).toEqual([])
     })
 
-    it('rejects an unknown tone', () => {
+    it('ignores non-object styles', () => {
         expect(
             resolveBadges(['accessible'], {
                 accessible: {
                     title: 'Accessible',
-                    tone: 'rainbow',
+                    styles: 'color: green',
                 },
             }),
-        ).toEqual([])
+        ).toEqual([
+            {
+                id: 'accessible',
+                title: 'Accessible',
+                styles: undefined,
+            },
+        ])
     })
 })

--- a/.storybook/badges/badges.ts
+++ b/.storybook/badges/badges.ts
@@ -1,30 +1,28 @@
-import type { BadgeProps } from '../../src/badge/badge'
+import type { CSSProperties } from 'react'
 
-type BadgeTone = BadgeProps['tone']
+type UnknownRecord = Record<string, unknown>
+
+type BadgeConfig = {
+    title?: unknown
+    styles?: unknown
+}
 
 type ResolvedBadge = {
     id: string
     title: string
-    tone: BadgeTone
+    styles: CSSProperties | undefined
 }
 
-// Ensure valid tones are checked against the Badge's tone prop
-const TONE_SET: Record<BadgeTone, true> = {
-    info: true,
-    positive: true,
-    promote: true,
-    attention: true,
-    warning: true,
-}
-
-const VALID_TONES = Object.keys(TONE_SET) as BadgeTone[]
-
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isRecord(value: unknown): value is UnknownRecord {
     return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function isBadgeTone(value: unknown): value is BadgeTone {
-    return typeof value === 'string' && (VALID_TONES as readonly string[]).includes(value)
+function isBadgeConfig(value: unknown): value is BadgeConfig {
+    return isRecord(value)
+}
+
+function resolveStyles(styles: unknown): CSSProperties | undefined {
+    return isRecord(styles) ? (styles as CSSProperties) : undefined
 }
 
 function resolveBadges(badges: unknown, badgesConfig: unknown): ResolvedBadge[] {
@@ -39,11 +37,7 @@ function resolveBadges(badges: unknown, badgesConfig: unknown): ResolvedBadge[] 
 
         const badgeConfig = badgesConfig[badge]
 
-        if (!isRecord(badgeConfig) || typeof badgeConfig.title !== 'string') {
-            return []
-        }
-
-        if (!isBadgeTone(badgeConfig.tone)) {
+        if (!isBadgeConfig(badgeConfig) || typeof badgeConfig.title !== 'string') {
             return []
         }
 
@@ -51,7 +45,7 @@ function resolveBadges(badges: unknown, badgesConfig: unknown): ResolvedBadge[] 
             {
                 id: badge,
                 title: badgeConfig.title,
-                tone: badgeConfig.tone,
+                styles: resolveStyles(badgeConfig.styles),
             },
         ]
     })

--- a/.storybook/components/badge-tones.ts
+++ b/.storybook/components/badge-tones.ts
@@ -1,0 +1,14 @@
+import type { CSSProperties } from 'react'
+
+/**
+ * Toolbar badge colors mirroring the Reactist Badge tones (see `src/badge/badge.module.css`)
+ */
+const reactistBadgeTones: Record<string, CSSProperties> = {
+    info: { color: '#666666', backgroundColor: '#eeeeee', borderColor: '#666666' },
+    positive: { color: '#058527', backgroundColor: '#e0f0e3', borderColor: '#058527' },
+    promote: { color: '#8f4700', backgroundColor: '#faead1', borderColor: '#8f4700' },
+    attention: { color: '#cf473a', backgroundColor: '#f9e3e2', borderColor: '#cf473a' },
+    warning: { color: '#ffffff', backgroundColor: '#eb8909', borderColor: '#eb8909' },
+}
+
+export { reactistBadgeTones }

--- a/.storybook/components/badge.tsx
+++ b/.storybook/components/badge.tsx
@@ -4,7 +4,6 @@ const containerStyle: React.CSSProperties = {
     alignItems: 'center',
     display: 'inline-flex',
     gap: '4px',
-    marginInline: '6px',
 }
 
 const badgeStyle: React.CSSProperties = {

--- a/.storybook/components/badge.tsx
+++ b/.storybook/components/badge.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react'
 
-const containerStyle: React.CSSProperties = {
-    alignItems: 'center',
-    display: 'inline-flex',
-    gap: '4px',
-}
-
 const badgeStyle: React.CSSProperties = {
     alignItems: 'center',
     border: '1px solid currentColor',
@@ -30,13 +24,5 @@ function Badge({ label, styles }: BadgeProps) {
     return <span style={{ ...badgeStyle, ...styles }}>{label}</span>
 }
 
-function BadgeGroup({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-    return (
-        <div style={containerStyle} {...props}>
-            {children}
-        </div>
-    )
-}
-
-export { Badge, BadgeGroup }
+export { Badge }
 export type { BadgeProps }

--- a/.storybook/components/badge.tsx
+++ b/.storybook/components/badge.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+
+const containerStyle: React.CSSProperties = {
+    alignItems: 'center',
+    display: 'inline-flex',
+    gap: '4px',
+    marginInline: '6px',
+}
+
+const badgeStyle: React.CSSProperties = {
+    alignItems: 'center',
+    border: '1px solid currentColor',
+    borderRadius: '3px',
+    boxSizing: 'border-box',
+    display: 'inline-flex',
+    fontSize: '12px',
+    fontWeight: 600,
+    lineHeight: '14px',
+    minHeight: '20px',
+    padding: '2px 6px',
+    whiteSpace: 'nowrap',
+}
+
+interface BadgeProps {
+    label: string
+    styles?: React.CSSProperties
+}
+
+/** A toolbar badge used for the Storybook frame */
+function Badge({ label, styles }: BadgeProps) {
+    return <span style={{ ...badgeStyle, ...styles }}>{label}</span>
+}
+
+function BadgeGroup({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+    return (
+        <div style={containerStyle} {...props}>
+            {children}
+        </div>
+    )
+}
+
+export { Badge, BadgeGroup }
+export type { BadgeProps }

--- a/.storybook/figma/README.md
+++ b/.storybook/figma/README.md
@@ -1,0 +1,47 @@
+# Figma toolbar tool
+
+Allows adding a toolbar link from the current story to its Figma design, so anyone can jump to the source of truth at a glance. When no design is linked, a neutral "No Figma link" hint shows as a reminder to add one.
+
+## Usage
+
+Set the `figma` parameter on the component's CSF `meta`. Provide the design's `url`, plus an optional `path` breadcrumb shown as the link's tooltip:
+
+```tsx
+const meta = {
+    title: '📊 Data display/Avatar',
+    component: Avatar,
+    parameters: {
+        figma: {
+            url: 'https://www.figma.com/design/…?node-id=123-456',
+            path: 'Web › Components / Todoist › Avatar',
+        },
+    },
+}
+```
+
+Link several frames at once by passing an array:
+
+```tsx
+figma: [
+    { url: 'https://www.figma.com/design/…?node-id=1-1', path: 'Default' },
+    { url: 'https://www.figma.com/design/…?node-id=1-2', path: 'Compact' },
+]
+```
+
+### MDX docs
+
+A Figma link comes from the story parameters, so an MDX docs page inherits it when it is **attached** to a stories file via `<Meta of={ComponentStories} />`. Storybook will **drop** parameters set directly on a standalone `<Meta title="…" />` (i.e. no `of`). Standalone documentation pages not attached to stories (e.g. the intro and Tips & tricks pages) will never show the "No Figma link" hint.
+
+## Opting out
+
+Non-visual entries (behaviour utilities, hooks) have no Figma design and shouldn't be flagged. Mark them with `FIGMA_NOT_NEEDED` to hide the hint:
+
+```tsx
+import { FIGMA_NOT_NEEDED } from '../../.storybook/figma/constants'
+
+const meta = {
+    title: '⚙️ Utility/KeyCapturer',
+    component: KeyCapturer,
+    parameters: { figma: FIGMA_NOT_NEEDED },
+}
+```

--- a/.storybook/figma/constants.ts
+++ b/.storybook/figma/constants.ts
@@ -1,3 +1,12 @@
 export const ADDON_ID = 'reactist/figma'
 export const TOOL_ID = `${ADDON_ID}/tool`
 export const FIGMA_PARAMETER = 'figma'
+
+/**
+ * Constant to be used with the `figma` parameter to mark a story as intentionally having no Figma design,
+ * hiding the "No Figma link" hint. Use this for non-visual entries like behavior utilities or hooks, as well
+ * as non-component-specific or non-visual documentation.
+ *
+ * Requires non-falsey values because Storybook's manager coerces them to `undefined`.
+ */
+export const FIGMA_NOT_NEEDED = 'not-needed'

--- a/.storybook/figma/figma-tool.tsx
+++ b/.storybook/figma/figma-tool.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Button } from 'storybook/internal/components'
 import { Tag, useParameter, useStorybookApi } from 'storybook/manager-api'
 
-import { Badge, BadgeGroup } from '../components/badge'
+import { Badge } from '../components/badge'
 import { reactistBadgeTones } from '../components/badge-tones'
 
 import { FIGMA_NOT_NEEDED, FIGMA_PARAMETER } from './constants'
@@ -49,9 +49,5 @@ export const FigmaTool = React.memo(function FigmaTool() {
         return null
     }
 
-    return (
-        <BadgeGroup>
-            <Badge label="No Figma link" styles={reactistBadgeTones.info} />
-        </BadgeGroup>
-    )
+    return <Badge label="No Figma link" styles={reactistBadgeTones.info} />
 })

--- a/.storybook/figma/figma-tool.tsx
+++ b/.storybook/figma/figma-tool.tsx
@@ -1,39 +1,57 @@
 import * as React from 'react'
 
-import { useParameter } from 'storybook/manager-api'
+import { Button } from 'storybook/internal/components'
+import { Tag, useParameter, useStorybookApi } from 'storybook/manager-api'
 
-import { Badge } from '../../src/badge/badge'
-import { IconButton } from '../../src/button/button'
-import { Inline } from '../../src/inline'
+import { Badge, BadgeGroup } from '../components/badge'
+import { reactistBadgeTones } from '../components/badge-tones'
 
-import { FIGMA_PARAMETER } from './constants'
+import { FIGMA_NOT_NEEDED, FIGMA_PARAMETER } from './constants'
 import { resolveFigmaLinks } from './figma'
 import { FigmaIcon } from './figma-icon'
 
 export const FigmaTool = React.memo(function FigmaTool() {
     const figmaParameter = useParameter(FIGMA_PARAMETER, undefined)
+    const api = useStorybookApi()
     const links = React.useMemo(() => resolveFigmaLinks(figmaParameter), [figmaParameter])
 
-    if (figmaParameter === false) {
+    if (links.length > 0) {
+        return (
+            <>
+                {links.map((link) => (
+                    <Button
+                        key={link.url}
+                        asChild
+                        variant="ghost"
+                        padding="small"
+                        ariaLabel={`View in Figma: ${link.path}`}
+                        tooltip={link.path}
+                    >
+                        <a href={link.url} target="_blank" rel="noopener noreferrer">
+                            <FigmaIcon />
+                        </a>
+                    </Button>
+                ))}
+            </>
+        )
+    }
+
+    // FIGMA_NOT_NEEDED marks a story as intentionally having no Figma design and opts out of
+    // the "No Figma Link" hint
+    if (figmaParameter === FIGMA_NOT_NEEDED) {
+        return null
+    }
+
+    // Standalone documentation pages (unattached MDX, e.g. tips & tricks pages not associated
+    // with a component) do not have a corresponding Figma design.
+    const tags = api.getCurrentStoryData()?.tags ?? []
+    if (tags.includes(Tag.UNATTACHED_MDX)) {
         return null
     }
 
     return (
-        <Inline space="xsmall">
-            {links.length === 0 ? (
-                <Badge tone="info" label="No Figma link" />
-            ) : (
-                links.map((link) => (
-                    <IconButton
-                        key={link.url}
-                        variant="quaternary"
-                        icon={<FigmaIcon />}
-                        aria-label={`View in Figma: ${link.path}`}
-                        tooltip={link.path}
-                        render={<a href={link.url} target="_blank" rel="noopener noreferrer" />}
-                    />
-                ))
-            )}
-        </Inline>
+        <BadgeGroup>
+            <Badge label="No Figma link" styles={reactistBadgeTones.info} />
+        </BadgeGroup>
     )
 })

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import type { Preview } from '@storybook/react-vite'
 import { create } from 'storybook/theming/create'
 import BaseDecorator from './BaseDecorator'
+import { reactistBadgeTones } from './components/badge-tones'
 import '../src/styles/design-tokens.css'
 import '../stories/components/styles/story.css'
 
@@ -37,24 +38,22 @@ const preview: Preview = {
         chromatic: {
             disableSnapshot: true,
         },
-        // The \uFE0E after each symbol forces text (not emoji) presentation, so the glyph
-        // inherits the badge tint color instead of falling back to the black emoji font.
         badgesConfig: {
             accessible: {
-                title: '✔\uFE0E Accessible (WCAG 2.0 AA)',
-                tone: 'positive',
+                title: '✔︎ Accessible (WCAG 2.0 AA)',
+                styles: reactistBadgeTones.positive,
             },
             partiallyAccessible: {
-                title: '⚠\uFE0E Partially Accessible',
-                tone: 'warning',
+                title: '⚠︎ Partially Accessible',
+                styles: reactistBadgeTones.warning,
             },
             notAccessible: {
-                title: '✖\uFE0E Not accessible',
-                tone: 'attention',
+                title: '✖︎ Not accessible',
+                styles: reactistBadgeTones.attention,
             },
             deprecated: {
-                title: '✖\uFE0E Deprecated',
-                tone: 'attention',
+                title: '✖︎ Deprecated',
+                styles: reactistBadgeTones.attention,
             },
         },
     },

--- a/src/hooks/use-previous/use-previous.mdx
+++ b/src/hooks/use-previous/use-previous.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs/blocks'
 import { usePrevious } from './use-previous'
 
-<Meta title="🪝 Hooks/usePrevious" component={usePrevious} parameters={{ figma: false }} />
+<Meta title="🪝 Hooks/usePrevious" component={usePrevious} />
 
 # usePrevious
 

--- a/src/modal/modal.mdx
+++ b/src/modal/modal.mdx
@@ -1,17 +1,8 @@
 import { Meta, ArgTypes, Description } from '@storybook/addon-docs/blocks'
 import { Modal, ModalHeader, ModalBody, ModalFooter, ModalActions, ModalCloseButton } from './modal'
+import * as ModalStories from './modal.stories'
 
-<Meta
-    title="🪟 Overlays/Modal/Docs"
-    component={Modal}
-    parameters={{
-        badges: ['accessible'],
-        figma: {
-            path: 'Web › Components / Todoist › Settings › Modal / Header',
-            url: 'https://www.figma.com/design/LYlWNzvhMDh907l07mPPQk/Product-Library---Web?node-id=7443-241153',
-        },
-    }}
-/>
+<Meta of={ModalStories} />
 
 # Modal
 

--- a/src/modal/modal.stories.tsx
+++ b/src/modal/modal.stories.tsx
@@ -32,7 +32,7 @@ import {
 import type { JSX } from 'react'
 
 export default {
-    title: '🪟 Overlays/Modal/Examples',
+    title: '🪟 Overlays/Modal',
     component: ModalComponents.Modal,
     parameters: {
         viewMode: 'story',

--- a/stories/components/KeyCapturer.stories.tsx
+++ b/stories/components/KeyCapturer.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import { action } from 'storybook/actions'
 
+import { FIGMA_NOT_NEEDED } from '../../.storybook/figma/constants'
 import KeyCapturer from '../../src/components/key-capturer'
 import { Stack } from '../../src/stack'
 
@@ -10,6 +11,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 const meta: Meta<typeof KeyCapturer> = {
     title: '⚙️ Utility/KeyCapturer',
     component: KeyCapturer,
+    parameters: {
+        figma: FIGMA_NOT_NEEDED,
+    },
 }
 export default meta
 

--- a/stories/reactist/Reactist.mdx
+++ b/stories/reactist/Reactist.mdx
@@ -1,6 +1,6 @@
 import { Story, Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Reactist" parameters={{ figma: false }} />
+<Meta title="Reactist" />
 
 ## Welcome
 

--- a/stories/reactist/nesting-vs-polymorphism.mdx
+++ b/stories/reactist/nesting-vs-polymorphism.mdx
@@ -1,6 +1,6 @@
 import { Story, Meta } from '@storybook/addon-docs/blocks'
 
-<Meta title="Tips and tricks/Nesting vs combining via polymorphism" parameters={{ figma: false }} />
+<Meta title="Tips and tricks/Nesting vs combining via polymorphism" />
 
 # Nesting vs. combining via polymorphism
 

--- a/stories/reactist/simplified-nested-markup.mdx
+++ b/stories/reactist/simplified-nested-markup.mdx
@@ -1,9 +1,6 @@
 import { Story, Meta } from '@storybook/addon-docs/blocks'
 
-<Meta
-    title="Tips and tricks/Simplified markup of the Stack and Inline components"
-    parameters={{ figma: false }}
-/>
+<Meta title="Tips and tricks/Simplified markup of the Stack and Inline components" />
 
 # Simplified markup of the `Stack` and `Inline` components
 

--- a/stories/reactist/single-child-stack-columns.mdx
+++ b/stories/reactist/single-child-stack-columns.mdx
@@ -1,9 +1,6 @@
 import { Story, Meta } from '@storybook/addon-docs/blocks'
 
-<Meta
-    title="Tips and tricks/About Stack or Columns with a single child"
-    parameters={{ figma: false }}
-/>
+<Meta title="Tips and tricks/About Stack or Columns with a single child" />
 
 # About `Stack` or `Columns` with a single child
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,13 @@
 {
     "extends": "@doist/tsconfig",
-    "include": ["src", "types", ".storybook", ".storybook/figma/**/*", ".storybook/badges/**/*"],
+    "include": [
+        "src",
+        "types",
+        ".storybook",
+        ".storybook/components/**/*",
+        ".storybook/figma/**/*",
+        ".storybook/badges/**/*"
+    ],
     "compilerOptions": {
         "allowJs": true,
         "module": "esnext",
@@ -17,6 +24,7 @@
             "@storybook/react": ["node_modules/@storybook/react/dist/index.d.ts"],
             "@storybook/react-vite": ["node_modules/@storybook/react-vite/dist/index.d.ts"],
             "storybook/actions": ["node_modules/storybook/dist/actions/index.d.ts"],
+            "storybook/internal/components": ["node_modules/storybook/dist/components/index.d.ts"],
             "storybook/manager-api": ["node_modules/storybook/dist/manager-api/index.d.ts"],
             "storybook/test": ["node_modules/storybook/dist/test/index.d.ts"],
             "*": ["src/*", "node_modules/*"]

--- a/tsconfig.react18.json
+++ b/tsconfig.react18.json
@@ -6,6 +6,7 @@
             "@storybook/react": ["node_modules/@storybook/react/dist/index.d.ts"],
             "@storybook/react-vite": ["node_modules/@storybook/react-vite/dist/index.d.ts"],
             "storybook/actions": ["node_modules/storybook/dist/actions/index.d.ts"],
+            "storybook/internal/components": ["node_modules/storybook/dist/components/index.d.ts"],
             "storybook/manager-api": ["node_modules/storybook/dist/manager-api/index.d.ts"],
             "storybook/test": ["node_modules/storybook/dist/test/index.d.ts"],
             "react": ["node_modules/@types/react-18"],


### PR DESCRIPTION
### Short description

Unfortunately, we're not able to render our components within the Storybook manager, because it runs its own bundled React 18 without a JSX runtime. However, since Reactist components require one, the bundler will retrieve it from the version we've installed, causing a version mismatch that crashes. A better explanation can be found in https://github.com/storybookjs/storybook/issues/32095.

So in this PR, we go back to using non-Reactist components for our Figma buttons and badges. We also fixed documentation pages that were incorrectly showing the "No Figma link" badge.

|Before|After|
|-|-|
|<img width="740" height="188" alt="image" src="https://github.com/user-attachments/assets/23d6349e-58df-413c-82d2-8e8fb20716fc" />|<img width="345" height="88" alt="image" src="https://github.com/user-attachments/assets/0d1006bb-089c-4671-b7fa-04994ae0f14d" />|
|-|<img width="341" height="70" alt="image" src="https://github.com/user-attachments/assets/d38a0f19-d8a8-40e6-8511-ff8e594a2d71" />|

#### Verifying

- [x] Hover a Figma link button in the toolbar (e.g. **Button** docs): does not crash
- [x] Open a doc-only page (**Reactist** intro, **Tips & tricks**, **usePrevious**, **KeyCapturer**): no "No Figma link" appears in the toolbar
- [x] Open a component with no design (e.g. **CheckboxField**): still shows "No Figma link"
- [x] Open **Modal**: single entry; the Docs page shows the Figma link and the Accessible badge

### PR Checklist

- [x] Updated docs (storybooks, readme)
- [x] Reviewed and approved Chromatic visual regression tests in CI
