### PR TITLE
feat(menu): style icon-less link items like text links

### DIFF
--- a/src/menu/menu.mdx
+++ b/src/menu/menu.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import KeyboardShortcut from '../components/keyboard-shortcut'
 import { Button, IconButton } from '../button'
 import { Inline } from '../inline'
@@ -15,26 +15,20 @@ import * as MenuStories from './menu.stories'
 A set of components that provide the means to construct a menu that can be triggered
 via an element or as a context menu.
 
-<Canvas>
-    <Story of={MenuStories.SimpleMenuStory} />
-</Canvas>
+<Canvas of={MenuStories.SimpleMenuStory} />
 
 ### `tooltip`
 
 The `tooltip` prop allows a tooltip to be shown over the menu button.
 
-<Canvas>
-    <Story of={MenuStories.TooltipStory} />
-</Canvas>
+<Canvas of={MenuStories.TooltipStory} />
 
 ### `modal`
 
 By default, interaction with elements below the menu is disallowed when the menu is open. This behaviour can
 be changed by passing `modal={false}` to `<MenuList>`
 
-<Canvas>
-    <Story of={MenuStories.OutsideInteractionStory} />
-</Canvas>
+<Canvas of={MenuStories.OutsideInteractionStory} />
 
 ### `<SubMenu>`
 
@@ -42,17 +36,13 @@ You may nest the `<SubMenu>` component within `<Menu>` to create submenus.
 
 On smaller viewports where there isn't enough space to render the submenu on either side, it will be rendered under its parent menu item instead.
 
-<Canvas>
-    <Story of={MenuStories.SubMenuStory} />
-</Canvas>
+<Canvas of={MenuStories.SubMenuStory} />
 
 ### Link menu items
 
 A `MenuItem` rendered as a link (via `render`) that has no icon is automatically styled like a text link. Link items that include an icon keep the default menu item styling.
 
-<Canvas>
-    <Story of={MenuStories.LinkMenuItemStory} />
-</Canvas>
+<Canvas of={MenuStories.LinkMenuItemStory} />
 
 ### `<ContextMenuTrigger>`
 
@@ -61,15 +51,11 @@ for the menu.
 
 In the demo below, right click on the Settings button, or click on the more button:
 
-<Canvas>
-    <Story of={MenuStories.ContextMenuTriggerStory} />
-</Canvas>
+<Canvas of={MenuStories.ContextMenuTriggerStory} />
 
 ### Extra Features
 
 You may also use `<MenuGroup>` to group menu items, `disable` a menu item, or
 return `false` from `onSelect` to prevent the menu from closing when an item is selected.
 
-<Canvas>
-    <Story of={MenuStories.ExtraFeaturesStory} />
-</Canvas>
+<Canvas of={MenuStories.ExtraFeaturesStory} />

--- a/src/menu/menu.mdx
+++ b/src/menu/menu.mdx
@@ -46,6 +46,14 @@ On smaller viewports where there isn't enough space to render the submenu on eit
     <Story of={MenuStories.SubMenuStory} />
 </Canvas>
 
+### Link menu items
+
+A `MenuItem` rendered as a link (via `render`) that has no icon is automatically styled like a text link. Link items that include an icon keep the default menu item styling.
+
+<Canvas>
+    <Story of={MenuStories.LinkMenuItemStory} />
+</Canvas>
+
 ### `<ContextMenuTrigger>`
 
 Using the `<ContextMenuTrigger>` component, an element can be defined as the right-click context menu trigger

--- a/src/menu/menu.module.css
+++ b/src/menu/menu.module.css
@@ -64,7 +64,7 @@
 }
 
 /* Link menu items without an icon are styled like a text link */
-:global(.reactist_menulist) a[role='menuitem']:not(:has(svg)) {
+:global(.reactist_menulist) a[role='menuitem']:not(:has(svg)):not([aria-disabled='true']) {
     color: var(--reactist-text-link-idle-tint, var(--reactist-actionable-tertiary-idle-tint));
     --reactist-content-primary: var(
         --reactist-text-link-idle-tint,
@@ -72,8 +72,8 @@
     );
 }
 
-:global(.reactist_menulist) a[role='menuitem']:not(:has(svg)):hover,
-:global(.reactist_menulist) a[role='menuitem']:not(:has(svg)):focus {
+:global(.reactist_menulist) a[role='menuitem']:not(:has(svg)):not([aria-disabled='true']):hover,
+:global(.reactist_menulist) a[role='menuitem']:not(:has(svg)):not([aria-disabled='true']):focus {
     color: var(--reactist-text-link-hover-tint, var(--reactist-actionable-tertiary-hover-tint));
     --reactist-content-primary: var(
         --reactist-text-link-hover-tint,

--- a/src/menu/menu.module.css
+++ b/src/menu/menu.module.css
@@ -63,6 +63,24 @@
     text-decoration: none;
 }
 
+/* Link menu items without an icon are styled like a text link */
+:global(.reactist_menulist) a[role='menuitem']:not(:has(svg)) {
+    color: var(--reactist-text-link-idle-tint, var(--reactist-actionable-tertiary-idle-tint));
+    --reactist-content-primary: var(
+        --reactist-text-link-idle-tint,
+        var(--reactist-actionable-tertiary-idle-tint)
+    );
+}
+
+:global(.reactist_menulist) a[role='menuitem']:not(:has(svg)):hover,
+:global(.reactist_menulist) a[role='menuitem']:not(:has(svg)):focus {
+    color: var(--reactist-text-link-hover-tint, var(--reactist-actionable-tertiary-hover-tint));
+    --reactist-content-primary: var(
+        --reactist-text-link-hover-tint,
+        var(--reactist-actionable-tertiary-hover-tint)
+    );
+}
+
 /* sub-menus need to be shifted a bit towards the top to be aligned with its menu item */
 :global(.reactist_menulist) [role='menu'] {
     margin-top: -5px;

--- a/src/menu/menu.stories.jsx
+++ b/src/menu/menu.stories.jsx
@@ -198,6 +198,49 @@ export const SubMenuStory = {
     },
 }
 
+export const LinkMenuItemStory = {
+    render: () => (
+        <Menu>
+            <MenuButton render={<Button variant="primary" endIcon={<ArrowDown />} />}>
+                Menu with links
+            </MenuButton>
+            <MenuList aria-label="Menu with links">
+                <MenuItem>Regular item</MenuItem>
+                <MenuItem
+                    render={
+                        <a
+                            href="https://github.com/Doist/reactist"
+                            target="_blank"
+                            rel="noreferrer noopener"
+                        />
+                    }
+                >
+                    <ArrowRight />
+                    Link with an icon
+                </MenuItem>
+                <hr />
+                <MenuItem
+                    render={
+                        <a href="https://doist.com" target="_blank" rel="noreferrer noopener" />
+                    }
+                >
+                    <Text size="copy">Link without an icon</Text>
+                </MenuItem>
+            </MenuList>
+        </Menu>
+    ),
+
+    name: 'Link Menu Item Story',
+
+    parameters: {
+        docs: {
+            source: {
+                type: 'code',
+            },
+        },
+    },
+}
+
 export const ContextMenuTriggerStory = {
     render: () => (
         <Stack space="small">

--- a/src/menu/menu.stories.jsx
+++ b/src/menu/menu.stories.jsx
@@ -226,6 +226,14 @@ export const LinkMenuItemStory = {
                 >
                     <Text size="copy">Link without an icon</Text>
                 </MenuItem>
+                <MenuItem
+                    disabled
+                    render={
+                        <a href="https://doist.com" target="_blank" rel="noreferrer noopener" />
+                    }
+                >
+                    <Text size="copy">Disabled link without an icon</Text>
+                </MenuItem>
             </MenuList>
         </Menu>
     ),


### PR DESCRIPTION
## Short description

Menu items that are links (rendered via `render`) and have no icon now use the text-link color, instead of the default menu item color. Link items that include an icon are left untouched.

This came out of Quick Add 2.0, where the "Edit task actions" entry is a link shown in the theme's accent color. That color was a one-off override on the menu item, with no real pattern behind it. Rather than keep it as an exception, Panos and I agreed to make it a proper, reusable pattern here in Reactist, so todoist-web (and anything else) can drop the override.

It's CSS-only (`a[role='menuitem']:not(:has(svg))`), so it applies automatically with no new prop or API. Added a story and a short note to the docs.

Smoke tested in todoist-web across all themes.

## Reference

- [Discussion with Panos](https://comms.todoist.com/69/ch/CW8EkaRYvfSKaKSF3D8Nq/t/CbiRrT9BKv3tzbtwMrZJo/)

## PR Checklist

- [x] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI
