### PR TITLE
chore: announce package releases in Comms

### DIFF
--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -160,11 +160,15 @@ jobs:
                       echo "EOF"
                   } >> "$GITHUB_OUTPUT"
 
-            - name: Announce release in Twist
+            - name: Announce release in Comms
               if: ${{ steps.semantic-release.outputs.package-published == 'true' && steps.announcement.outputs.should_announce == 'true' }}
-              uses: Doist/twist-post-action@74a0255b75ad93c06b9eb1009960106efe13f5ca
+              uses: Doist/comms-actions/post-comment-action@cf057e327f43e3ded8a54ebc871911d2b44027e4
               with:
-                  message: ${{ steps.announcement.outputs.message }}
-                  install_id: ${{ secrets.TWIST_RELEASE_INSTALL_ID }}
-                  install_token: ${{ secrets.TWIST_RELEASE_INSTALL_TOKEN }}
+                  comms-client-id: ${{ secrets.COMMS_CLIENT_ID }}
+                  comms-client-secret: ${{ secrets.COMMS_CLIENT_SECRET }}
+                  comms-username: ${{ secrets.COMMS_USERNAME }}
+                  comms-password: ${{ secrets.COMMS_PASSWORD }}
+                  workspace-id: 69
+                  thread-id: BPZsUohfX5WV4tFJKMHAh
+                  content: ${{ steps.announcement.outputs.message }}
               continue-on-error: true


### PR DESCRIPTION
## Short description

Replaces the package release announcement step with `Doist/comms-actions/post-comment-action`.

The workflow now posts the existing release announcement content to Comms.

## PR Checklist

- [x] Added tests for bugs / new features (N/A: workflow-only change; validated YAML parsing)
- [x] Updated docs (storybooks, readme) (N/A)
- [x] Reviewed and approved Chromatic visual regression tests in CI (N/A)
