### PR TITLE
docs: render correct story per Canvas in Storybook 10

### DIFF
--- a/src/badge/badge.mdx
+++ b/src/badge/badge.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import * as BadgeStories from './badge.stories'
 
 import { Box } from '../box'
@@ -19,21 +19,15 @@ A badge used to bring attention to a particular UI element or functionality.
 
 The use of variants does not provide extra semantic meaning and is strictly visual. Ensure your content provides the necessary context for users by using the `aria-label` prop if needed.
 
-<Canvas>
-    <Story of={BadgeStories.Playground} />
-</Canvas>
+<Canvas of={BadgeStories.Playground} />
 
 ## Examples
 
-<Canvas>
-    <Story of={BadgeStories.MainDemo} />
-</Canvas>
+<Canvas of={BadgeStories.MainDemo} />
 
 ## Inside other elements
 
-<Canvas>
-    <Story of={BadgeStories.InsideOtherElements} />
-</Canvas>
+<Canvas of={BadgeStories.InsideOtherElements} />
 
 ## Props
 
@@ -70,6 +64,4 @@ Even though Reactist does not yet owns the concept of dark mode, and leaves it f
 up, here's a demo on how easily you can prepare badges for dark mode by setting CSS custom
 properties.
 
-<Canvas>
-    <Story of={BadgeStories.DarkMode} />
-</Canvas>
+<Canvas of={BadgeStories.DarkMode} />

--- a/src/banner/banner.mdx
+++ b/src/banner/banner.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import { Box } from '../box'
 import { Text } from '../text'
 import { Stack } from '../stack'
@@ -15,9 +15,7 @@ import * as BannerStories from './banner.stories'
 
 A simple banner component meant to be used to _inform_ the user of promotional content, disclaimers, warnings, as well as success and error states.
 
-<Canvas>
-    <Story of={BannerStories.Playground} />
-</Canvas>
+<Canvas of={BannerStories.Playground} />
 
 ## Examples
 
@@ -25,9 +23,7 @@ A simple banner component meant to be used to _inform_ the user of promotional c
 
 Banners can feature different icons or no icon at all. When the type is neutral, a custom icon can be provided; otherwise, preset icons corresponding to the respective type will be used.
 
-<Canvas>
-    <Story of={BannerStories.IconVariants} />
-</Canvas>
+<Canvas of={BannerStories.IconVariants} />
 
 ### Actions
 
@@ -35,17 +31,13 @@ Banners can have an optional dismiss action, or a primary or tertiary CTA, but n
 
 These actions can be combined, such as a primary CTA with a dismiss option, or a primary CTA with a dismiss option and an inline link.
 
-<Canvas>
-    <Story of={BannerStories.Actions} />
-</Canvas>
+<Canvas of={BannerStories.Actions} />
 
 ### Copy
 
 Banners have two content options: a regular text that can span over multiple lines, or a bold header and a description with a secondary text color.
 
-<Canvas>
-    <Story of={BannerStories.Copy} />
-</Canvas>
+<Canvas of={BannerStories.Copy} />
 
 ### Image
 
@@ -53,17 +45,13 @@ Banners can include images placed at the top, separated from the copy by a divid
 
 Image banners do not feature icons but can include body text or a combination of a header and description. They also support optional inline links and a dismiss action.
 
-<Canvas>
-    <Story of={BannerStories.Image} />
-</Canvas>
+<Canvas of={BannerStories.Image} />
 
 ### Content
 
 Banners can include extra content.
 
-<Canvas>
-    <Story of={BannerStories.Content} />
-</Canvas>
+<Canvas of={BannerStories.Content} />
 
 ## Props
 
@@ -95,6 +83,4 @@ Even though Reactist does not yet owns the concept of dark mode, and leaves it f
 up, here's a demo on how easily you can prepare banners for dark mode by setting CSS custom
 properties.
 
-<Canvas>
-    <Story of={BannerStories.DarkMode} />
-</Canvas>
+<Canvas of={BannerStories.DarkMode} />

--- a/src/button/button.mdx
+++ b/src/button/button.mdx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import { Box } from '../box'
 import { Inline } from '../inline'
 import { Stack } from '../stack'
@@ -18,9 +18,7 @@ import * as ButtonStories from './button.stories'
 
 ## Main demo
 
-<Canvas>
-    <Story of={ButtonStories.MainDemo} />
-</Canvas>
+<Canvas of={ButtonStories.MainDemo} />
 
 ## With label and icon
 
@@ -30,18 +28,14 @@ this purpose.
 Nothing prevents you from passing both a `startIcon` and an `endIcon` at the same time. However,
 this is discouraged, and not guaranteed to be supported in the future.
 
-<Canvas>
-    <Story of={ButtonStories.WithLabelAndIcon} />
-</Canvas>
+<Canvas of={ButtonStories.WithLabelAndIcon} />
 
 ## With different size
 
 Buttons have a default `normal` size, but they can also be larger or smaller. Use the `size` prop
 for this purpose.
 
-<Canvas>
-    <Story of={ButtonStories.WithDifferentSize} />
-</Canvas>
+<Canvas of={ButtonStories.WithDifferentSize} />
 
 ## Customized colors
 
@@ -66,32 +60,24 @@ styles for buttons.
 
 And here's how that look like:
 
-<Canvas>
-    <Story of={ButtonStories.CustomizedColors} />
-</Canvas>
+<Canvas of={ButtonStories.CustomizedColors} />
 
 ## Full-width
 
 Buttons can be set to take the full width of their container by using the `width` prop.
 
-<Canvas>
-    <Story of={ButtonStories.FullWidth} />
-</Canvas>
+<Canvas of={ButtonStories.FullWidth} />
 
 ## Playground
 
-<Canvas>
-    <Story of={ButtonStories.Playground} />
-</Canvas>
+<Canvas of={ButtonStories.Playground} />
 
 ## Dark mode
 
 Even though Reactist does not yet owns the concept of dark mode, and leaves it for apps to set it
 up, here's a demo on how easily you can set it up by manipulating color variables only.
 
-<Canvas>
-    <Story of={ButtonStories.DarkMode} />
-</Canvas>
+<Canvas of={ButtonStories.DarkMode} />
 
 ## Colors
 

--- a/src/button/icon-button.mdx
+++ b/src/button/icon-button.mdx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import { Box } from '../box'
 import { Inline } from '../inline'
 import { Stack } from '../stack'
@@ -18,18 +18,14 @@ import * as IconButtonStories from './icon-button.stories'
 
 ## Main demo
 
-<Canvas>
-    <Story of={IconButtonStories.MainDemo} />
-</Canvas>
+<Canvas of={IconButtonStories.MainDemo} />
 
 ### With different size
 
 Buttons have a default `normal` size, but they can also be larger or smaller. Use the `size` prop
 for this purpose.
 
-<Canvas>
-    <Story of={IconButtonStories.WithDifferentSize} />
-</Canvas>
+<Canvas of={IconButtonStories.WithDifferentSize} />
 
 ### Customized colors
 
@@ -54,24 +50,18 @@ styles for buttons.
 
 And here's how that look like:
 
-<Canvas>
-    <Story of={IconButtonStories.CustomizedColors} />
-</Canvas>
+<Canvas of={IconButtonStories.CustomizedColors} />
 
 ### Playground
 
-<Canvas>
-    <Story of={IconButtonStories.Playground} />
-</Canvas>
+<Canvas of={IconButtonStories.Playground} />
 
 ### Dark mode
 
 Even though Reactist does not yet owns the concept of dark mode, and leaves it for apps to set it
 up, here's a demo on how easily you can set it up by manipulating color variables only.
 
-<Canvas>
-    <Story of={IconButtonStories.DarkMode} />
-</Canvas>
+<Canvas of={IconButtonStories.DarkMode} />
 
 ## Style customization
 

--- a/src/checkbox-field/checkbox-field.mdx
+++ b/src/checkbox-field/checkbox-field.mdx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import * as CheckboxFieldStories from './checkbox-field.stories'
 
 import { CheckboxField } from '.'
@@ -12,9 +12,7 @@ import { Text } from '../text'
 
 A checkbox field with a built-in label element.
 
-<Canvas>
-    <Story of={CheckboxFieldStories.BasicExample} />
-</Canvas>
+<Canvas of={CheckboxFieldStories.BasicExample} />
 
 ---
 
@@ -30,25 +28,19 @@ A checkbox field with an icon and a string. The icon is rendered to the left of 
 
 #### Image as Icon
 
-<Canvas>
-    <Story of={CheckboxFieldStories.ImageAsIcon} />
-</Canvas>
+<Canvas of={CheckboxFieldStories.ImageAsIcon} />
 
 #### React element as Icon
 
 In this example we are passing an SVG image as icon.
 
-<Canvas>
-    <Story of={CheckboxFieldStories.ReactElementAsIcon} />
-</Canvas>
+<Canvas of={CheckboxFieldStories.ReactElementAsIcon} />
 
 ### ReactNode as Label
 
 A checkbox field with a `ReactNode` as label.
 
-<Canvas>
-    <Story of={CheckboxFieldStories.ReactNodeAsLabel} />
-</Canvas>
+<Canvas of={CheckboxFieldStories.ReactNodeAsLabel} />
 
 <CheckboxField
     label={
@@ -60,12 +52,8 @@ A checkbox field with a `ReactNode` as label.
 
 ### Indeterminate Example
 
-<Canvas>
-    <Story of={CheckboxFieldStories.IndeterminateExample} />
-</Canvas>
+<Canvas of={CheckboxFieldStories.IndeterminateExample} />
 
 ## Accessibility
 
-<Canvas>
-    <Story of={CheckboxFieldStories.AccessibilityExamples} />
-</Canvas>
+<Canvas of={CheckboxFieldStories.AccessibilityExamples} />

--- a/src/loading/loading.mdx
+++ b/src/loading/loading.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import { Box } from '../box'
 import { Text } from '../text'
 import { Stack } from '../stack'
@@ -11,9 +11,7 @@ import * as LoadingStories from './loading.stories'
 
 A loading indicator that comes in three sizes.
 
-<Canvas>
-    <Story of={LoadingStories.AllSizes} />
-</Canvas>
+<Canvas of={LoadingStories.AllSizes} />
 
 ---
 
@@ -28,20 +26,14 @@ A loading indicator that comes in three sizes.
 The loading indicator adopts the current brand background color defined in the `--reactist-spinner-tint`
 CSS variable.
 
-<Canvas withToolbar>
-    <Story of={LoadingStories.CustomizeColor} />
-</Canvas>
+<Canvas withToolbar of={LoadingStories.CustomizeColor} />
 
 ## Accessibility
 
-<Canvas>
-    <Story of={LoadingStories.AccessibilityAttributes} />
-</Canvas>
+<Canvas of={LoadingStories.AccessibilityAttributes} />
 
 #### Usage Considerations
 
 If the `Loading` component is describing the loading progress of a particular region of a page, you should use the `aria-describedby` attribute to point to the status, and set the `aria-busy` attribute to `true` on the region until it is finished loading.
 
-<Canvas>
-    <Story of={LoadingStories.AccessibilityConsiderations} />
-</Canvas>
+<Canvas of={LoadingStories.AccessibilityConsiderations} />

--- a/src/notice/notice.mdx
+++ b/src/notice/notice.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import { Text } from '../text'
 import { Stack } from '../stack'
 import { Notice } from './notice'
@@ -10,9 +10,7 @@ import * as NoticeStories from './notice.stories'
 
 A simple Notice component.
 
-<Canvas>
-    <Story of={NoticeStories.Playground} />
-</Canvas>
+<Canvas of={NoticeStories.Playground} />
 
 ---
 

--- a/src/password-field/password-field.mdx
+++ b/src/password-field/password-field.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import * as PasswordFieldStories from './password-field.stories'
 
 import { Stack } from '../stack'
@@ -13,9 +13,7 @@ import { selectWithNone } from '../utils/storybook-helper'
 
 A component used to accept password input from the user.
 
-<Canvas>
-    <Story of={PasswordFieldStories.InteractiveProps} />
-</Canvas>
+<Canvas of={PasswordFieldStories.InteractiveProps} />
 
 <Controls of={PasswordFieldStories.InteractiveProps} />
 
@@ -30,10 +28,6 @@ Note that these variables are shared with other components such as `Textfield`, 
 --reactist-inputs-alert
 ```
 
-<Canvas withToolbar>
-    <Story of={PasswordFieldStories.MessageTone} />
-</Canvas>
+<Canvas withToolbar of={PasswordFieldStories.MessageTone} />
 
-<Canvas withToolbar>
-    <Story of={PasswordFieldStories.WithoutLabel} />
-</Canvas>
+<Canvas withToolbar of={PasswordFieldStories.WithoutLabel} />

--- a/src/select-field/select-field.mdx
+++ b/src/select-field/select-field.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import * as SelectFieldStories from './select-field.stories'
 
 import { SelectField } from './'
@@ -13,9 +13,7 @@ import { selectWithNone } from '../utils/storybook-helper'
 
 A component that provides a menu of options, similar to the native `<select>` HTML element.
 
-<Canvas>
-    <Story of={SelectFieldStories.InteractiveProps} />
-</Canvas>
+<Canvas of={SelectFieldStories.InteractiveProps} />
 
 <Controls of={SelectFieldStories.InteractiveProps} />
 
@@ -30,10 +28,6 @@ Note that these variables are shared with other components such as `Textfield`, 
 --reactist-inputs-alert
 ```
 
-<Canvas withToolbar>
-    <Story of={SelectFieldStories.MessageTone} />
-</Canvas>
+<Canvas withToolbar of={SelectFieldStories.MessageTone} />
 
-<Canvas withToolbar>
-    <Story of={SelectFieldStories.WithoutLabel} />
-</Canvas>
+<Canvas withToolbar of={SelectFieldStories.WithoutLabel} />

--- a/src/switch-field/switch-field.mdx
+++ b/src/switch-field/switch-field.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import { SwitchField } from './switch-field'
 import { Stack } from '../stack'
 import { Text } from '../text'
@@ -10,9 +10,7 @@ import * as SwitchFieldStories from './switch-field.stories'
 
 A checkbox with a built-in label element that visually looks like a toggle switch.
 
-<Canvas>
-    <Story of={SwitchFieldStories.Playground} />
-</Canvas>
+<Canvas of={SwitchFieldStories.Playground} />
 
 ---
 
@@ -34,6 +32,4 @@ The following CSS custom properties are available to customize the SwitchField's
 
 ## Accessibility
 
-<Canvas>
-    <Story of={SwitchFieldStories.AccessibilityAttributes} />
-</Canvas>
+<Canvas of={SwitchFieldStories.AccessibilityAttributes} />

--- a/src/tabs/tabs.mdx
+++ b/src/tabs/tabs.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import { Tabs, TabList, Tab, TabPanel, TabAwareSlot } from './tabs'
 import { Box } from '../box'
 import { Text } from '../text'
@@ -13,9 +13,7 @@ A set of components that allow tabs to be rendered, which controls the visibilit
 This component is powered by [Ariakit's Tab component](https://ariakit.org/examples/tab). For more details of its expected
 behaviour, see [ARIA: tab role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role).
 
-<Canvas>
-    <Story of={TabsStories.MainDemo} />
-</Canvas>
+<Canvas of={TabsStories.MainDemo} />
 
 ## `<Tabs>`
 
@@ -105,41 +103,29 @@ The following CSS custom properties are also available to customize other tabs' 
 
 ### Themed variant
 
-<Canvas withToolbar>
-    <Story of={TabsStories.ThemedVariant} />
-</Canvas>
+<Canvas withToolbar of={TabsStories.ThemedVariant} />
 
 ### Full container width tabs
 
-<Canvas withToolbar>
-    <Story of={TabsStories.FullContainerWidthTabs} />
-</Canvas>
+<Canvas withToolbar of={TabsStories.FullContainerWidthTabs} />
 
 ### Tabs aligned to the center
 
-<Canvas withToolbar>
-    <Story of={TabsStories.TabsAlignedToTheCenter} />
-</Canvas>
+<Canvas withToolbar of={TabsStories.TabsAlignedToTheCenter} />
 
 ### Selected tab with slide animation
 
-<Canvas withToolbar>
-    <Story of={TabsStories.SelectedTabWithSlideAnimation} />
-</Canvas>
+<Canvas withToolbar of={TabsStories.SelectedTabWithSlideAnimation} />
 
 ### Using the `<TabAwareSlot>` component
 
-<Canvas withToolbar>
-    <Story of={TabsStories.UsingTheTabAwareSlotComponent} />
-</Canvas>
+<Canvas withToolbar of={TabsStories.UsingTheTabAwareSlotComponent} />
 
 ### Multiple `<TabList>` instances
 
 As long as they exist within the same `<Tabs>` component tree, multiple `<TabList>` instances can be rendered.
 
-<Canvas withToolbar>
-    <Story of={TabsStories.MultipleTabListInstances} />
-</Canvas>
+<Canvas withToolbar of={TabsStories.MultipleTabListInstances} />
 
 ### Polymorphism
 
@@ -148,6 +134,4 @@ can be specified with the `as` prop.
 
 Note that when combined with the `renderMode="active"` prop, the entire tabpanel will be affected, including the actual polymorphic component/element passed into `as`.
 
-<Canvas withToolbar>
-    <Story of={TabsStories.Polymorphism} />
-</Canvas>
+<Canvas withToolbar of={TabsStories.Polymorphism} />

--- a/src/text-area/text-area.mdx
+++ b/src/text-area/text-area.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import * as TextAreaStories from './text-area.stories'
 
 import { Box } from '../box'
@@ -13,9 +13,7 @@ import { selectWithNone } from '../utils/storybook-helper'
 
 A component with an expandable writing area used to accept longer textual input from the user.
 
-<Canvas>
-    <Story of={TextAreaStories.InteractiveProps} />
-</Canvas>
+<Canvas of={TextAreaStories.InteractiveProps} />
 
 <Controls of={TextAreaStories.InteractiveProps} />
 
@@ -30,18 +28,10 @@ Note that these variables are shared with other components such as `Textfield`, 
 --reactist-inputs-alert
 ```
 
-<Canvas withToolbar>
-    <Story of={TextAreaStories.MessageTone} />
-</Canvas>
+<Canvas withToolbar of={TextAreaStories.MessageTone} />
 
-<Canvas withToolbar>
-    <Story of={TextAreaStories.WithoutLabel} />
-</Canvas>
+<Canvas withToolbar of={TextAreaStories.WithoutLabel} />
 
-<Canvas>
-    <Story of={TextAreaStories.AutoExpand} />
-</Canvas>
+<Canvas of={TextAreaStories.AutoExpand} />
 
-<Canvas>
-    <Story of={TextAreaStories.AutoExpandWithInitialValue} />
-</Canvas>
+<Canvas of={TextAreaStories.AutoExpandWithInitialValue} />

--- a/src/text-field/text-field.mdx
+++ b/src/text-field/text-field.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import * as TextFieldStories from './text-field.stories'
 
 import { TextField } from './'
@@ -16,9 +16,7 @@ import { selectWithNone } from '../utils/storybook-helper'
 
 A component used to accept textual input from the user.
 
-<Canvas>
-    <Story of={TextFieldStories.InteractiveProps} />
-</Canvas>
+<Canvas of={TextFieldStories.InteractiveProps} />
 
 <Controls of={TextFieldStories.InteractiveProps} />
 
@@ -33,21 +31,13 @@ Note that these variables are shared with other components such as `PasswordFiel
 --reactist-inputs-alert
 ```
 
-<Canvas withToolbar>
-    <Story of={TextFieldStories.MessageTone} />
-</Canvas>
+<Canvas withToolbar of={TextFieldStories.MessageTone} />
 
-<Canvas withToolbar>
-    <Story of={TextFieldStories.WithoutLabel} />
-</Canvas>
+<Canvas withToolbar of={TextFieldStories.WithoutLabel} />
 
-<Canvas withToolbar>
-    <Story of={TextFieldStories.Icons} />
-</Canvas>
+<Canvas withToolbar of={TextFieldStories.Icons} />
 
-<Canvas withToolbar>
-    <Story of={TextFieldStories.ActionButton} />
-</Canvas>
+<Canvas withToolbar of={TextFieldStories.ActionButton} />
 
 As an alternative to the `message` prop, you can also use tooltips to
 associate a description to a text field. **This is not recommended in
@@ -59,30 +49,22 @@ is only needed to convey that the value being typed is invalid, and at
 the same time, the field forces the value back to valid when blurred.
 Hence, the description is never needed when the field is not focused anyway.
 
-<Canvas withToolbar>
-    <Story of={TextFieldStories.WithTooltip} />
-</Canvas>
+<Canvas withToolbar of={TextFieldStories.WithTooltip} />
 
 ## Variants
 
 The `variant` prop is used to change the style of the text field. The default variant is `default`. The other variant is `bordered`.
 
-<Canvas withToolbar>
-    <Story of={TextFieldStories.BorderedVariant} />
-</Canvas>
+<Canvas withToolbar of={TextFieldStories.BorderedVariant} />
 
 ## Max length
 
 The `maxLength` prop is used to limit the number of characters that the user can input. When the user tries to input more characters than the maximum allowed, the field won't accept the input.
 
-<Canvas withToolbar>
-    <Story of={TextFieldStories.MaxLength} />
-</Canvas>
+<Canvas withToolbar of={TextFieldStories.MaxLength} />
 
 ## Character count position
 
 The `characterCountPosition` prop is used to position the character count element. It can be shown <strong>below</strong> the field, <strong>inline</strong> with the field or <strong>hidden</strong>.
 
-<Canvas withToolbar>
-    <Story of={TextFieldStories.CharacterCountPosition} />
-</Canvas>
+<Canvas withToolbar of={TextFieldStories.CharacterCountPosition} />

--- a/src/text-link/text-link.mdx
+++ b/src/text-link/text-link.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks'
 import { Stack } from '../stack'
 import { TextLink } from './text-link'
 import * as TextLinkStories from './text-link.stories'
@@ -9,9 +9,7 @@ import * as TextLinkStories from './text-link.stories'
 
 A component used to create text-based hyperlinks.
 
-<Canvas>
-    <Story of={TextLinkStories.MainDemo} />
-</Canvas>
+<Canvas of={TextLinkStories.MainDemo} />
 
 ## Props
 
@@ -21,9 +19,7 @@ A component used to create text-based hyperlinks.
 
 When using nested elements inside a `TextLink`, hover styles are properly applied to all children.
 
-<Canvas>
-    <Story of={TextLinkStories.NestedElements} />
-</Canvas>
+<Canvas of={TextLinkStories.NestedElements} />
 
 ## Style
 
@@ -31,6 +27,4 @@ The `color` prop can be used to change the color of the link. The default color 
 
 The `underline` prop can be used to change the underline style of the link. The default is `true`.
 
-<Canvas>
-    <Story of={TextLinkStories.Colors} />
-</Canvas>
+<Canvas of={TextLinkStories.Colors} />

--- a/src/tooltip/tooltip.mdx
+++ b/src/tooltip/tooltip.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Controls, Description } from '@storybook/addon-docs/blocks'
 import { Tooltip } from './tooltip'
 import * as TooltipStories from './tooltip.stories'
 
@@ -8,35 +8,25 @@ import * as TooltipStories from './tooltip.stories'
 
 <Description of={Tooltip} />
 
-<Canvas>
-    <Story of={TooltipStories.TooltipPlayground} />
-</Canvas>
+<Canvas of={TooltipStories.TooltipPlayground} />
 
 ## Examples
 
 ### Rich content
 
-<Canvas>
-    <Story of={TooltipStories.TooltipRichContent} />
-</Canvas>
+<Canvas of={TooltipStories.TooltipRichContent} />
 
 ### Custom z-index
 
-<Canvas>
-    <Story of={TooltipStories.TooltipCustomZIndex} />
-</Canvas>
+<Canvas of={TooltipStories.TooltipCustomZIndex} />
 
 ### Global context
 
-<Canvas>
-    <Story of={TooltipStories.TooltipGlobalContext} />
-</Canvas>
+<Canvas of={TooltipStories.TooltipGlobalContext} />
 
 ### Imperative control
 
-<Canvas>
-    <Story of={TooltipStories.TooltipImperativeControl} />
-</Canvas>
+<Canvas of={TooltipStories.TooltipImperativeControl} />
 
 ## Props
 


### PR DESCRIPTION


## Short description

Storybook 10 resolves which story a `<Canvas>` renders from the `of` prop on the Canvas itself, and the legacy `<Canvas><Story of={X} /></Canvas>` nesting (Storybook 6 API) is no longer supported. This causes each block in our existing docs pages to fallback to the default story.

## Reference

- #1083, where the Canvas regression was first found and fixed for `menu.mdx`.

## Test plan

- Run `npm run storybook` and open each component's Docs page
- [ ] Every canvas renders its own distinct story rather than repeating the primary story

## Demo

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="1083" height="824" alt="image" src="https://github.com/user-attachments/assets/2d2a22f3-d4a5-4d21-8851-4bdb61c29717" /></td>
    <td><img width="1061" height="1023" alt="image" src="https://github.com/user-attachments/assets/bcb1f15b-265d-4f51-9828-f86b63583d9b" /></td>
  </tr>
</table>

## PR Checklist

- [x] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI
