### PR TITLE
ci: deploy storybook on merges to main instead of tags

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -2,8 +2,8 @@ name: Deploy Storybook to Pages
 
 on:
     push:
-        tags:
-            - 'v*'
+        branches:
+            - main
     workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -13,11 +13,9 @@ permissions:
     id-token: write
     actions: read
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
     group: 'pages'
-    cancel-in-progress: false
+    cancel-in-progress: true
 
 jobs:
     # Single deploy job since we're just deploying


### PR DESCRIPTION
## Short description

The public Storybook hasn't auto-deployed since the `v30.1.0` release after migrating to semantic-release (#1024), as each release commit uses `[skip ci]` in its commit message. This updates the workflow to be based off of each commit to `main` instead, which while fixes the issue, also keeps the docs updated after `docs:` commits as those don't generate releases.

## PR Checklist

- [ ] Updated docs (storybooks, readme)
