### PR TITLE
docs: defer the "No Figma link" hint until the entry is prepared

### DIFF
--- a/.storybook/figma/figma-tool.tsx
+++ b/.storybook/figma/figma-tool.tsx
@@ -44,8 +44,12 @@ export const FigmaTool = React.memo(function FigmaTool() {
 
     // Standalone documentation pages (unattached MDX, e.g. tips & tricks pages not associated
     // with a component) do not have a corresponding Figma design.
-    const tags = api.getCurrentStoryData()?.tags ?? []
-    if (tags.includes(Tag.UNATTACHED_MDX)) {
+    const storyData = api.getCurrentStoryData()
+    if (storyData?.tags?.includes(Tag.UNATTACHED_MDX)) {
+        return null
+    }
+
+    if (!storyData?.prepared) {
         return null
     }
 


### PR DESCRIPTION


## Short description

This follow up fix to #1076 and #1080 eliminates a flash of the "No Figma link" badge on stories/docs pages off of a fresh page load. It does so by leveraging Storybook's `getCurrentStoryData().prepared` value off of its Context

## Test plan

- Run Storybook locally. In the steps below, don't just rely on the client-side routing, but reload each page instead
- Navigate to a story that has a Figma link defined (e.g. `Button`) and reload
  - [ ] No "No Figma link" badge flashes before the Figma button appears
- Navigate to a docs page with a Figma link (e.g. `Avatar` docs) and reload
  - [ ] No badge flash there either
- Open a story/component with no `figma` param (e.g. `Box`) and reload
  - [ ] The "No Figma link" badge is rendered
- Open a `FIGMA_NOT_NEEDED` story (e.g. `KeyCapturer`) and reload
  - [ ] Neither the badge nor the button are shown
- Open an unattached-MDX docs page (e.g. a Tips & tricks page)
  - [ ] Neither the badge nor the button are shown

## Demo

First load of a linked story (e.g. `Button`):

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>

https://github.com/user-attachments/assets/e4c3f8fb-adcd-476d-8772-39c2d773f451




</td>
    <td>

https://github.com/user-attachments/assets/29048e1c-0759-4b5b-9951-5ce8118eac1b




</td>
  </tr>
</table>

## PR Checklist

- [ ] Added tests for bugs / new features 
- [x] Updated docs 
- [ ] Reviewed and approved Chromatic visual regression tests in CI
