### PR TITLE
chore: set displayName on forwardRef components for readable Storybook source

### DIFF
--- a/src/avatar/avatar.tsx
+++ b/src/avatar/avatar.tsx
@@ -218,6 +218,8 @@ function getFailedImageSource(imageProps: ImageSources, image: HTMLImageElement)
     return matchingSource?.src ?? imageProps.src
 }
 
+Avatar.displayName = 'Avatar'
+
 export { Avatar }
 export type { AvatarProps }
 export type { AvatarImage, AvatarShape, AvatarSize } from './utils'

--- a/src/box/box.tsx
+++ b/src/box/box.tsx
@@ -297,4 +297,6 @@ export type {
     ReusableBoxProps,
 }
 
+Box.displayName = 'Box'
+
 export { Box, getBoxClassNames }

--- a/src/columns/columns.tsx
+++ b/src/columns/columns.tsx
@@ -111,4 +111,7 @@ export type {
     ColumnWidth,
 }
 
+Column.displayName = 'Column'
+Columns.displayName = 'Columns'
+
 export { Column, Columns }

--- a/src/heading/heading.tsx
+++ b/src/heading/heading.tsx
@@ -116,5 +116,7 @@ const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps & ObfuscatedCl
     },
 )
 
+Heading.displayName = 'Heading'
+
 export type { HeadingLevel, HeadingProps }
 export { Heading }

--- a/src/hidden-visually/hidden-visually.tsx
+++ b/src/hidden-visually/hidden-visually.tsx
@@ -28,4 +28,6 @@ const HiddenVisually = polymorphicComponent<'div', Props, 'omitClassName'>(
     },
 )
 
+HiddenVisually.displayName = 'HiddenVisually'
+
 export { HiddenVisually }

--- a/src/hidden/hidden.tsx
+++ b/src/hidden/hidden.tsx
@@ -102,5 +102,7 @@ const Hidden = polymorphicComponent<'div', HiddenProps>(function Hidden(
     )
 })
 
+Hidden.displayName = 'Hidden'
+
 export { Hidden }
 export type { HiddenProps }

--- a/src/inline/inline.tsx
+++ b/src/inline/inline.tsx
@@ -41,5 +41,7 @@ const Inline = polymorphicComponent<'div', InlineProps>(function Inline(
     )
 })
 
+Inline.displayName = 'Inline'
+
 export type { InlineAlign, InlineProps }
 export { Inline }

--- a/src/stack/stack.tsx
+++ b/src/stack/stack.tsx
@@ -72,5 +72,7 @@ const Stack = polymorphicComponent<'div', StackProps>(function Stack(
     )
 })
 
+Stack.displayName = 'Stack'
+
 export type { StackProps }
 export { Stack }

--- a/src/text-link/text-link.tsx
+++ b/src/text-link/text-link.tsx
@@ -43,5 +43,7 @@ const TextLink = polymorphicComponent<'a', TextLinkProps>(function TextLink(
     )
 })
 
+TextLink.displayName = 'TextLink'
+
 export { TextLink }
 export type { TextLinkProps }

--- a/src/text/text.tsx
+++ b/src/text/text.tsx
@@ -92,5 +92,7 @@ const Text = polymorphicComponent<'div', TextProps>(function Text(
     )
 })
 
+Text.displayName = 'Text'
+
 export type { TextProps }
 export { Text }


### PR DESCRIPTION
## Short description

This issue was discovered while implementing stories for https://github.com/Doist/reactist/pull/1089.

Our layout and typography primitives (`Box`, `Stack`, `Inline`, `Columns`, `Text`, etc.) are `forwardRef` components built through `polymorphicComponent`. In Storybook, docgen can't infer the correct component names through that wrapper, so with dynamic stories (i.e. ones that pass args), their code snippets would show `<React.ForwardRef>` instead of the real component names.

This PR solves it by setting an explicit `displayName` property on the component. I explored a different approach by having `polymorphicComponent` forward the underlying component names, however, they are stripped in prod mode so they won't work in the deployed storybook.

### Before / after

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="880" height="1446" alt="columns-before" src="https://github.com/user-attachments/assets/b58ab691-507a-4433-836a-29463bb6e3a0" /></td>
    <td><img width="880" height="1446" alt="columns-after" src="https://github.com/user-attachments/assets/2aa88056-70f8-4e38-ab25-3adf708ff664" /></td>
  </tr>
</table>

## PR Checklist

- [ ] Reviewed and approved Chromatic visual regression tests in CI
