### PR TITLE
docs(storybook): restore story defaults dropped by the Storybook 9 upgrade

### DIFF
--- a/src/badge/badge.stories.jsx
+++ b/src/badge/badge.stories.jsx
@@ -132,16 +132,12 @@ export const Playground = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'info',
         },
 
         label: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Upgrade',
         },
 
         id: {

--- a/src/banner/banner.stories.jsx
+++ b/src/banner/banner.stories.jsx
@@ -420,8 +420,6 @@ export const Playground = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'info',
         },
 
         image: {
@@ -436,16 +434,12 @@ export const Playground = {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Title of the Banner',
         },
 
         description: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Description of the Banner.',
         },
 
         action: {

--- a/src/box/box.stories.tsx
+++ b/src/box/box.stories.tsx
@@ -49,32 +49,41 @@ export function InteractivePropsStory({ children, ...props }: PartialProps<typeo
     )
 }
 
+InteractivePropsStory.args = {
+    children: 'The quick brown fox jumps over the lazy dog.',
+    display: 'block',
+    flexDirection: 'row',
+    flexWrap: 'nowrap',
+    borderRadius: 'none',
+    overlayScroll: false,
+}
+
 InteractivePropsStory.argTypes = {
     children: {
         control: { type: 'text' },
-        defaultValue: 'The quick brown fox jumps over the lazy dog.',
     },
-    display: select<BoxDisplay>(['block', 'inlineBlock', 'inline', 'flex', 'none'], 'block'),
-    flexDirection: selectWithNone<BoxFlexDirection>(['column', 'row'], 'row'),
-    flexWrap: selectWithNone<BoxFlexWrap>(['wrap', 'nowrap'], 'nowrap'),
-    alignItems: selectWithNone<BoxAlignItems>(
-        ['center', 'flexEnd', 'flexStart', 'baseline'],
-        'none',
-    ),
-    justifyContent: selectWithNone<BoxJustifyContent>(
-        ['center', 'flexEnd', 'flexStart', 'spaceBetween'],
-        'none',
-    ),
-    textAlign: selectWithNone<BoxTextAlign>(['start', 'center', 'end', 'justify'], 'none'),
-    background: selectWithNone<BoxBackground>(
-        ['default', 'aside', 'highlight', 'selected', 'toast'],
-        'none',
-    ),
-    borderRadius: select<BoxBorderRadius>(['standard', 'none', 'full'], 'none'),
+    display: select<BoxDisplay>(['block', 'inlineBlock', 'inline', 'flex', 'none']),
+    flexDirection: selectWithNone<BoxFlexDirection>(['column', 'row']),
+    flexWrap: selectWithNone<BoxFlexWrap>(['wrap', 'nowrap']),
+    alignItems: selectWithNone<BoxAlignItems>(['center', 'flexEnd', 'flexStart', 'baseline']),
+    justifyContent: selectWithNone<BoxJustifyContent>([
+        'center',
+        'flexEnd',
+        'flexStart',
+        'spaceBetween',
+    ]),
+    textAlign: selectWithNone<BoxTextAlign>(['start', 'center', 'end', 'justify']),
+    background: selectWithNone<BoxBackground>([
+        'default',
+        'aside',
+        'highlight',
+        'selected',
+        'toast',
+    ]),
+    borderRadius: select<BoxBorderRadius>(['standard', 'none', 'full']),
     ...reusableBoxProps(),
     overlayScroll: {
         control: { type: 'boolean' },
-        defaultValue: false,
     },
 }
 
@@ -155,8 +164,12 @@ export function PaddingStory({ padding }: { padding: Space }) {
     )
 }
 
+PaddingStory.args = {
+    padding: 'medium',
+}
+
 PaddingStory.argTypes = {
-    padding: selectSize('medium'),
+    padding: selectSize(),
 }
 
 const marginToPadding: Record<keyof BoxMarginProps, keyof BoxPaddingProps> = {
@@ -225,25 +238,26 @@ export function MarginStory({ margin }: { margin: Space }) {
     )
 }
 
+MarginStory.args = {
+    margin: 'medium',
+}
+
 MarginStory.argTypes = {
-    margin: select<SpaceWithNegatives | 'none'>(
-        [
-            'xxlarge',
-            'xlarge',
-            'large',
-            'medium',
-            'small',
-            'xsmall',
-            'none',
-            '-xsmall',
-            '-small',
-            '-medium',
-            '-large',
-            '-xlarge',
-            '-xxlarge',
-        ],
+    margin: select<SpaceWithNegatives | 'none'>([
+        'xxlarge',
+        'xlarge',
+        'large',
         'medium',
-    ),
+        'small',
+        'xsmall',
+        'none',
+        '-xsmall',
+        '-small',
+        '-medium',
+        '-large',
+        '-xlarge',
+        '-xxlarge',
+    ]),
 }
 
 export function OverlayScrollStory() {

--- a/src/button/button.stories.jsx
+++ b/src/button/button.stories.jsx
@@ -666,8 +666,6 @@ export const FullWidth = {
                 'Click me <em>now</em>',
                 'If you click me now, youʼll take away the biggest part of me',
             ],
-
-            defaultValue: 'Submit',
         },
 
         variant: {
@@ -676,8 +674,6 @@ export const FullWidth = {
             control: {
                 type: 'select',
             },
-
-            defaultValue: 'primary',
         },
 
         tone: {
@@ -686,8 +682,6 @@ export const FullWidth = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         size: {
@@ -696,8 +690,6 @@ export const FullWidth = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         shape: {
@@ -706,8 +698,6 @@ export const FullWidth = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         width: {
@@ -716,8 +706,6 @@ export const FullWidth = {
             control: {
                 type: 'select',
             },
-
-            defaultValue: 'full',
         },
 
         align: {
@@ -784,8 +772,6 @@ export const Playground = {
                 'Click me <em>now</em>',
                 'If you click me now, youʼll take away the biggest part of me',
             ],
-
-            defaultValue: 'Submit',
         },
 
         variant: {
@@ -794,8 +780,6 @@ export const Playground = {
             control: {
                 type: 'select',
             },
-
-            defaultValue: 'primary',
         },
 
         tone: {
@@ -804,8 +788,6 @@ export const Playground = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         size: {
@@ -814,8 +796,6 @@ export const Playground = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         shape: {
@@ -824,8 +804,6 @@ export const Playground = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         disabled: {
@@ -885,8 +863,6 @@ export const DarkMode = {
                 'Yes, cancel my subscription',
                 'Click me <em>now</em>',
             ],
-
-            defaultValue: 'Submit',
         },
 
         variant: {
@@ -895,8 +871,6 @@ export const DarkMode = {
             control: {
                 type: 'select',
             },
-
-            defaultValue: 'primary',
         },
 
         tone: {
@@ -905,8 +879,6 @@ export const DarkMode = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         size: {
@@ -915,8 +887,6 @@ export const DarkMode = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         disabled: {

--- a/src/button/icon-button.stories.jsx
+++ b/src/button/icon-button.stories.jsx
@@ -468,7 +468,6 @@ export const Playground = {
             },
 
             options: ['OK', 'Submit', 'Mark as done'],
-            defaultValue: 'Submit',
         },
 
         variant: {
@@ -477,8 +476,6 @@ export const Playground = {
             control: {
                 type: 'select',
             },
-
-            defaultValue: 'primary',
         },
 
         tone: {
@@ -487,8 +484,6 @@ export const Playground = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         size: {
@@ -497,8 +492,6 @@ export const Playground = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         shape: {
@@ -507,8 +500,6 @@ export const Playground = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         disabled: {
@@ -563,8 +554,6 @@ export const DarkMode = {
                 'Yes, cancel my subscription',
                 'Click me <em>now</em>',
             ],
-
-            defaultValue: 'Submit',
         },
 
         variant: {
@@ -573,8 +562,6 @@ export const DarkMode = {
             control: {
                 type: 'select',
             },
-
-            defaultValue: 'primary',
         },
 
         tone: {
@@ -583,8 +570,6 @@ export const DarkMode = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         size: {
@@ -593,8 +578,6 @@ export const DarkMode = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'normal',
         },
 
         disabled: {

--- a/src/columns/columns.stories.tsx
+++ b/src/columns/columns.stories.tsx
@@ -284,8 +284,12 @@ export function WidthsStory({ space }: PartialProps<typeof Columns>) {
     )
 }
 
+WidthsStory.args = {
+    space: 'medium',
+}
+
 WidthsStory.argTypes = {
-    space: selectSize('medium'),
+    space: selectSize(),
     align: { control: false },
     alignY: { control: false },
     ...disableResponsiveProps,
@@ -331,9 +335,14 @@ export function ResponsiveStory(args: PartialProps<typeof Columns>) {
     )
 }
 
+ResponsiveStory.args = {
+    space: 'medium',
+    collapseBelow: 'tablet',
+}
+
 ResponsiveStory.argTypes = {
-    space: selectSize('medium'),
-    collapseBelow: selectWithNone<ColumnsCollapseBelow>(['tablet', 'desktop'], 'tablet'),
+    space: selectSize(),
+    collapseBelow: selectWithNone<ColumnsCollapseBelow>(['tablet', 'desktop']),
     align: { control: false },
     alignY: { control: false },
     ...disableResponsiveProps,
@@ -358,8 +367,12 @@ export function FlexChildStory(args: PartialProps<typeof Columns>) {
     )
 }
 
+FlexChildStory.args = {
+    space: 'medium',
+}
+
 FlexChildStory.argTypes = {
-    space: selectSize('medium'),
+    space: selectSize(),
     align: { control: false },
     alignY: { control: false },
     ...disableResponsiveProps,
@@ -391,8 +404,12 @@ export function NestedColumnsStory(args: PartialProps<typeof Columns>) {
     )
 }
 
+NestedColumnsStory.args = {
+    space: 'medium',
+}
+
 NestedColumnsStory.argTypes = {
-    space: selectSize('medium'),
+    space: selectSize(),
     align: { control: false },
     alignY: { control: false },
     ...disableResponsiveProps,

--- a/src/heading/heading.stories.tsx
+++ b/src/heading/heading.stories.tsx
@@ -109,16 +109,22 @@ export function ResponsiveHeadingStory(props: React.ComponentProps<typeof Headin
     )
 }
 
+ResponsiveHeadingStory.args = {
+    level: '1',
+    weight: 'regular',
+    tone: 'normal',
+    children: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit',
+}
+
 ResponsiveHeadingStory.argTypes = {
-    level: select(['1', '2', '3', '4', '5', '6'], '1'),
-    size: selectWithNone(['largest', 'larger', 'smaller'], 'none'),
-    weight: select(['regular', 'light'], 'regular'),
-    lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
-    tone: select(['normal', 'secondary', 'danger'], 'normal'),
+    level: select(['1', '2', '3', '4', '5', '6']),
+    size: selectWithNone(['largest', 'larger', 'smaller']),
+    weight: select(['regular', 'light']),
+    lineClamp: selectWithNone([1, 2, 3, 4, 5]),
+    tone: select(['normal', 'secondary', 'danger']),
     align: { control: false },
     children: {
         control: { type: 'text' },
-        defaultValue: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit',
     },
 }
 
@@ -130,15 +136,21 @@ export function HeadingPlaygroundStory(props: React.ComponentProps<typeof Headin
     )
 }
 
+HeadingPlaygroundStory.args = {
+    level: '1',
+    weight: 'regular',
+    tone: 'normal',
+    children: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit',
+}
+
 HeadingPlaygroundStory.argTypes = {
-    level: select(['1', '2', '3', '4', '5', '6'], '1'),
-    size: selectWithNone(['largest', 'larger', 'smaller'], 'none'),
-    weight: select(['regular', 'medium', 'light'], 'regular'),
-    lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
-    tone: select(['normal', 'secondary', 'danger'], 'normal'),
-    align: selectWithNone(['start', 'center', 'end', 'justify'], 'none'),
+    level: select(['1', '2', '3', '4', '5', '6']),
+    size: selectWithNone(['largest', 'larger', 'smaller']),
+    weight: select(['regular', 'medium', 'light']),
+    lineClamp: selectWithNone([1, 2, 3, 4, 5]),
+    tone: select(['normal', 'secondary', 'danger']),
+    align: selectWithNone(['start', 'center', 'end', 'justify']),
     children: {
         control: { type: 'text' },
-        defaultValue: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit',
     },
 }

--- a/src/inline/inline.stories.tsx
+++ b/src/inline/inline.stories.tsx
@@ -20,8 +20,11 @@ import type { InlineAlign } from './inline'
 export default {
     title: '📐 Layout/Inline',
     component: Inline,
+    args: {
+        space: 'medium',
+    },
     argTypes: {
-        space: selectSize('medium'),
+        space: selectSize(),
         align: selectWithNone<InlineAlign>(['left', 'center', 'right']),
         ...reusableBoxProps(),
     },
@@ -100,8 +103,12 @@ export function NestedStackStory({ space }: PartialProps<typeof Inline>) {
     )
 }
 
+NestedStackStory.args = {
+    space: 'xlarge',
+}
+
 NestedStackStory.argTypes = {
-    space: selectSize('xlarge'),
+    space: selectSize(),
     align: { control: false },
     ...disableResponsiveProps,
 }

--- a/src/notice/notice.stories.jsx
+++ b/src/notice/notice.stories.jsx
@@ -58,7 +58,6 @@ export const Playground = {
             },
 
             options: ['short', 'long', 'longer'],
-            defaultValue: 'short',
         },
 
         tone: {
@@ -67,16 +66,12 @@ export const Playground = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'info',
         },
 
         closeLabel: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Close',
         },
 
         id: {

--- a/src/password-field/password-field.stories.jsx
+++ b/src/password-field/password-field.stories.jsx
@@ -82,8 +82,6 @@ export const InteractiveProps = {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Password',
         },
 
         value: {
@@ -98,8 +96,6 @@ export const InteractiveProps = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'neutral',
         },
 
         maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
@@ -108,8 +104,6 @@ export const InteractiveProps = {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Toggle password visibility',
         },
 
         variant: {
@@ -118,49 +112,36 @@ export const InteractiveProps = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'default',
         },
 
         auxiliaryLabel: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Forgot your password?',
         },
 
         message: {
             control: {
                 type: 'text',
             },
-
-            defaultValue:
-                'Must be at least 100 characters long, and it should include each letter of the alphabet',
         },
 
         endSlot: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         placeholder: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Type your password',
         },
 
         disabled: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
     },
 }

--- a/src/password-field/password-field.stories.jsx
+++ b/src/password-field/password-field.stories.jsx
@@ -102,7 +102,7 @@ export const InteractiveProps = {
             defaultValue: 'neutral',
         },
 
-        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full'], 'small'),
+        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
 
         togglePasswordLabel: {
             control: {

--- a/src/select-field/select-field.stories.jsx
+++ b/src/select-field/select-field.stories.jsx
@@ -78,8 +78,6 @@ export const InteractiveProps = {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Theme',
         },
 
         value: {
@@ -94,8 +92,6 @@ export const InteractiveProps = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'neutral',
         },
 
         maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
@@ -106,33 +102,24 @@ export const InteractiveProps = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'default',
         },
 
         auxiliaryLabel: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Need help?',
         },
 
         message: {
             control: {
                 type: 'text',
             },
-
-            defaultValue:
-                'The theme you select will be applied immediately. If you upgrade to premium you will have more themes to choose from.',
         },
 
         disabled: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
     },
 }

--- a/src/select-field/select-field.stories.jsx
+++ b/src/select-field/select-field.stories.jsx
@@ -98,7 +98,7 @@ export const InteractiveProps = {
             defaultValue: 'neutral',
         },
 
-        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full'], 'small'),
+        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
 
         variant: {
             options: ['default', 'bordered'],

--- a/src/stack/stack.stories.tsx
+++ b/src/stack/stack.stories.tsx
@@ -57,8 +57,12 @@ export function InteractivePropsStory({
     )
 }
 
+InteractivePropsStory.args = {
+    itemCount: 5,
+}
+
 InteractivePropsStory.argTypes = {
-    itemCount: selectCount('Item count', 5),
+    itemCount: selectCount('Item count'),
 }
 
 export function ResponsiveStory({ itemCount }: { itemCount: number }) {
@@ -77,6 +81,10 @@ export function ResponsiveStory({ itemCount }: { itemCount: number }) {
             </Wrapper>
         </>
     )
+}
+
+ResponsiveStory.args = {
+    itemCount: 5,
 }
 
 ResponsiveStory.argTypes = {
@@ -109,8 +117,12 @@ export function NestedStacksStory(args: PartialProps<typeof Stack>) {
     )
 }
 
+NestedStacksStory.args = {
+    space: 'xlarge',
+}
+
 NestedStacksStory.argTypes = {
-    space: selectSize('xlarge'),
+    space: selectSize(),
     dividers: { control: false },
     ...disableResponsiveProps,
 }

--- a/src/switch-field/switch-field.stories.jsx
+++ b/src/switch-field/switch-field.stories.jsx
@@ -50,8 +50,6 @@ export const Playground = {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Show unread badge',
         },
 
         tone: {
@@ -60,24 +58,18 @@ export const Playground = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'neutral',
         },
 
         message: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Show an icon badge to indicate that there are new threads and messages.',
         },
 
         disabled: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
     },
 }

--- a/src/text-area/text-area.stories.jsx
+++ b/src/text-area/text-area.stories.jsx
@@ -128,16 +128,12 @@ export const InteractiveProps = {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'User bio',
         },
 
         controlled: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         value: {
@@ -149,8 +145,6 @@ export const InteractiveProps = {
             control: {
                 type: 'text',
             },
-
-            defaultValue: '',
         },
 
         tone: {
@@ -159,8 +153,6 @@ export const InteractiveProps = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'neutral',
         },
 
         maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
@@ -171,81 +163,60 @@ export const InteractiveProps = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'default',
         },
 
         auxiliaryLabel: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Need help?',
         },
 
         message: {
             control: {
                 type: 'text',
             },
-
-            defaultValue:
-                'You’ll have a better experience in our community if others get to know a little bit about you.',
         },
 
         rows: {
             control: {
                 type: 'number',
             },
-
-            defaultValue: 2,
         },
 
         autoExpand: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         disableResize: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         placeholder: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Tell us something about yourself. Don’t be shy.',
         },
 
         maxLength: {
             control: {
                 type: 'number',
             },
-
-            defaultValue: null,
         },
 
         disabled: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         readOnly: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
     },
 }
@@ -343,8 +314,6 @@ export const AutoExpand = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'neutral',
         },
 
         maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
@@ -355,8 +324,6 @@ export const AutoExpand = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'default',
         },
 
         auxiliaryLabel: {
@@ -367,40 +334,30 @@ export const AutoExpand = {
             control: {
                 type: 'text',
             },
-
-            defaultValue: '',
         },
 
         rows: {
             control: {
                 type: 'number',
             },
-
-            defaultValue: 2,
         },
 
         autoExpand: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         placeholder: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: '',
         },
 
         disabled: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
     },
 }
@@ -433,8 +390,6 @@ export const AutoExpandWithInitialValue = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'neutral',
         },
 
         maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
@@ -445,8 +400,6 @@ export const AutoExpandWithInitialValue = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'default',
         },
 
         auxiliaryLabel: {
@@ -457,56 +410,42 @@ export const AutoExpandWithInitialValue = {
             control: {
                 type: 'text',
             },
-
-            defaultValue: '',
         },
 
         rows: {
             control: {
                 type: 'number',
             },
-
-            defaultValue: 2,
         },
 
         autoExpand: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         disableResize: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         placeholder: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: '',
         },
 
         disabled: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         readOnly: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
     },
 }

--- a/src/text-area/text-area.stories.jsx
+++ b/src/text-area/text-area.stories.jsx
@@ -163,7 +163,7 @@ export const InteractiveProps = {
             defaultValue: 'neutral',
         },
 
-        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full'], 'small'),
+        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
 
         variant: {
             options: ['default', 'bordered'],
@@ -347,7 +347,7 @@ export const AutoExpand = {
             defaultValue: 'neutral',
         },
 
-        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full'], 'small'),
+        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
 
         variant: {
             options: ['default', 'bordered'],
@@ -437,7 +437,7 @@ export const AutoExpandWithInitialValue = {
             defaultValue: 'neutral',
         },
 
-        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full'], 'small'),
+        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
 
         variant: {
             options: ['default', 'bordered'],

--- a/src/text-field/text-field.stories.jsx
+++ b/src/text-field/text-field.stories.jsx
@@ -230,8 +230,6 @@ export const InteractiveProps = {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Your name',
         },
 
         value: {
@@ -246,8 +244,6 @@ export const InteractiveProps = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'neutral',
         },
 
         maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
@@ -256,16 +252,12 @@ export const InteractiveProps = {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         endSlot: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         variant: {
@@ -274,57 +266,42 @@ export const InteractiveProps = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: 'default',
         },
 
         auxiliaryLabel: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Need help?',
         },
 
         message: {
             control: {
                 type: 'text',
             },
-
-            defaultValue:
-                'We need your name for billing and shipping purposes. Make sure to enter it correctly.',
         },
 
         placeholder: {
             control: {
                 type: 'text',
             },
-
-            defaultValue: 'Enter your name as it appears in your ID',
         },
 
         maxLength: {
             control: {
                 type: 'number',
             },
-
-            defaultValue: null,
         },
 
         disabled: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         readOnly: {
             control: {
                 type: 'boolean',
             },
-
-            defaultValue: false,
         },
 
         characterCountPosition: {
@@ -333,8 +310,6 @@ export const InteractiveProps = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: undefined,
         },
 
         endSlotPosition: {
@@ -343,8 +318,6 @@ export const InteractiveProps = {
             control: {
                 type: 'inline-radio',
             },
-
-            defaultValue: undefined,
         },
     },
 }

--- a/src/text-field/text-field.stories.jsx
+++ b/src/text-field/text-field.stories.jsx
@@ -250,7 +250,7 @@ export const InteractiveProps = {
             defaultValue: 'neutral',
         },
 
-        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full'], 'small'),
+        maxWidth: selectWithNone(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
 
         startSlot: {
             control: {

--- a/src/text/text.stories.tsx
+++ b/src/text/text.stories.tsx
@@ -152,15 +152,21 @@ export function ResponsiveTextStory(props: React.ComponentProps<typeof Text>) {
     )
 }
 
+ResponsiveTextStory.args = {
+    size: 'body',
+    weight: 'regular',
+    tone: 'normal',
+    children: 'Lorem ipsum dolor sit amet consectetur, adipisicing elit',
+}
+
 ResponsiveTextStory.argTypes = {
-    size: select(['caption', 'copy', 'body', 'subtitle'], 'body'),
-    weight: select(['regular', 'semibold', 'bold'], 'regular'),
-    lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
-    tone: select(['normal', 'secondary', 'danger'], 'normal'),
+    size: select(['caption', 'copy', 'body', 'subtitle']),
+    weight: select(['regular', 'semibold', 'bold']),
+    lineClamp: selectWithNone([1, 2, 3, 4, 5]),
+    tone: select(['normal', 'secondary', 'danger']),
     align: { control: false },
     children: {
         control: { type: 'text' },
-        defaultValue: 'Lorem ipsum dolor sit amet consectetur, adipisicing elit',
     },
 }
 
@@ -172,14 +178,20 @@ export function TextPlaygroundStory(props: React.ComponentProps<typeof Text>) {
     )
 }
 
+TextPlaygroundStory.args = {
+    size: 'body',
+    weight: 'regular',
+    tone: 'normal',
+    children: 'Lorem ipsum dolor sit amet consectetur, adipisicing elit',
+}
+
 TextPlaygroundStory.argTypes = {
-    size: select(['caption', 'copy', 'body', 'subtitle'], 'body'),
-    weight: select(['regular', 'semibold', 'bold'], 'regular'),
-    lineClamp: selectWithNone([1, 2, 3, 4, 5], 'none'),
-    tone: select(['normal', 'secondary', 'danger'], 'normal'),
-    align: selectWithNone(['start', 'center', 'end', 'justify'], 'none'),
+    size: select(['caption', 'copy', 'body', 'subtitle']),
+    weight: select(['regular', 'semibold', 'bold']),
+    lineClamp: selectWithNone([1, 2, 3, 4, 5]),
+    tone: select(['normal', 'secondary', 'danger']),
+    align: selectWithNone(['start', 'center', 'end', 'justify']),
     children: {
         control: { type: 'text' },
-        defaultValue: 'Lorem ipsum dolor sit amet consectetur, adipisicing elit',
     },
 }

--- a/src/utils/storybook-helper.tsx
+++ b/src/utils/storybook-helper.tsx
@@ -12,47 +12,38 @@ import type { Space } from './common-types'
 
 type SelectTypeOptionsProp<T> = Extract<T, PropertyKey>[] | readonly Extract<T, PropertyKey>[]
 
-function select<T extends string | number>(options: SelectTypeOptionsProp<T>, defaultValue?: T) {
+function select<T extends string | number>(options: SelectTypeOptionsProp<T>) {
     return {
         control: {
             type: 'select',
         },
         options,
-        defaultValue,
     }
 }
 
-function selectWithNone<T extends string | number>(
-    options: SelectTypeOptionsProp<T>,
-    defaultValue: T | 'none' = 'none',
-) {
+function selectWithNone<T extends string | number>(options: SelectTypeOptionsProp<T>) {
     return {
         control: {
             type: 'select',
         },
         options: ['none', ...options],
-        defaultValue,
         mapping: {
             none: undefined,
         },
     }
 }
 
-function selectSize(defaultValue: Space | 'none' = 'none') {
-    return selectWithNone<Space>(
-        ['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge'],
-        defaultValue,
-    )
+function selectSize() {
+    return selectWithNone<Space>(['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge'])
 }
 
-function selectCount(label: string, defaultValue = 5) {
+function selectCount(label: string) {
     return {
         control: {
             type: 'number',
             min: 1,
         },
         name: label,
-        defaultValue,
     }
 }
 


### PR DESCRIPTION

## Short description

Box's Margin Story crashes because it expected a `margin` arg to be provided, but it was never supplied. This is because it was passed in through `argTypes.margin.defaultValue`, and Storybook dropped `defaultValue` as a source of initial args in v7, [in favour of ](https://storybook.js.org/docs/api/arg-types)`args`. 

On top of fixing the crash, we also remove all other defaultValues, and move them into args instead.

## Reference

- #1038
- [Storybook ArgTypes API](https://storybook.js.org/docs/api/arg-types)

## Demo

**Margin Story** crashed on mount. The empty `margin` control in the "before" screenshot is the root cause:

<table>
  <tr>
    <th width="50%">Before</th>
    <th width="50%">After</th>
  </tr>
  <tr>
    <td><img width="1280" height="860" alt="before-margin" src="https://github.com/user-attachments/assets/1d60cffb-2b0d-4765-8e5d-df80a513b8fc" /></td>
    <td><img width="1280" height="860" alt="after-margin" src="https://github.com/user-attachments/assets/76400b6b-f292-446f-9c3a-02d7e13b5a77" /></td>
  </tr>
</table>

**Interactive Props Story** didn't crash, but rendered an empty canvas with every control unset:

<table>
  <tr>
    <th width="50%">Before</th>
    <th width="50%">After</th>
  </tr>
  <tr>
    <td><img width="1280" height="860" alt="before-interactive" src="https://github.com/user-attachments/assets/b3301035-a33f-4652-807e-634dd6fa9778" /></td>
    <td><img width="1280" height="860" alt="after-interactive" src="https://github.com/user-attachments/assets/63ea42be-fbc1-47e3-a806-2565d039402a" /></td>
  </tr>
</table>

**Padding Story** rendered, but with `padding` undefined:

<table>
  <tr>
    <th width="50%">Before</th>
    <th width="50%">After</th>
  </tr>
  <tr>
    <td><img width="1280" height="860" alt="before-padding" src="https://github.com/user-attachments/assets/d67971ae-70be-4a85-9027-62707ee65263" /></td>
    <td><img width="1280" height="860" alt="after-padding" src="https://github.com/user-attachments/assets/3cc95813-ff3c-4f46-a06e-4d3d4fde0d7e" /></td>
  </tr>
</table>

## Test plan

- Start Storybook locally and navigate to http://localhost:6006/?path=/story/%F0%9F%93%90-layout-box--margin-story
  - [ ] The story doesn't crash, and seven bordered boxes render

## PR Checklist

- [ ] Added tests for bugs / new features
- [x] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI