### PR TITLE
feat!: remove warning tone from Badge component

### DIFF
--- a/src/badge/badge.mdx
+++ b/src/badge/badge.mdx
@@ -52,9 +52,6 @@ The following CSS custom properties are available to customize the badge compone
 
     --reactist-badge-attention-tint: #cf473a;
     --reactist-badge-attention-fill: #f9e3e2;
-
-    --reactist-badge-warning-tint: #faead1;
-    --reactist-badge-warning-fill: #eb8909;
 }
 ```
 

--- a/src/badge/badge.module.css
+++ b/src/badge/badge.module.css
@@ -12,9 +12,6 @@
 
     --reactist-badge-attention-tint: #cf473a;
     --reactist-badge-attention-fill: #f9e3e2;
-
-    --reactist-badge-warning-tint: #ffffff;
-    --reactist-badge-warning-fill: #eb8909;
 }
 
 .badge {
@@ -55,9 +52,4 @@
 .badge-attention {
     --reactist-badge-tint: var(--reactist-badge-attention-tint);
     --reactist-badge-fill: var(--reactist-badge-attention-fill);
-}
-
-.badge-warning {
-    --reactist-badge-tint: var(--reactist-badge-warning-tint);
-    --reactist-badge-fill: var(--reactist-badge-warning-fill);
 }

--- a/src/badge/badge.stories.jsx
+++ b/src/badge/badge.stories.jsx
@@ -37,9 +37,6 @@ function BadgeExamples() {
                     <div>
                         <Badge tone="attention" label="Attention" />
                     </div>
-                    <div>
-                        <Badge tone="warning" label="Warning" />
-                    </div>
                 </Stack>
             </Column>
             <Column width="content">
@@ -56,9 +53,6 @@ function BadgeExamples() {
                     </div>
                     <div>
                         <Badge tone="attention" label="Save 25%" />
-                    </div>
-                    <div>
-                        <Badge tone="warning" label="Deprecated" />
                     </div>
                 </Stack>
             </Column>
@@ -85,9 +79,6 @@ function DarkModeTemplate() {
                 // tone="attention"
                 '--reactist-badge-attention-tint': '#CF473A',
                 '--reactist-badge-attention-fill': '#351E1C',
-                // tone="warning
-                '--reactist-badge-warning-tint': '#cf473a',
-                '--reactist-badge-warning-fill': '#faead1',
             }}
         >
             <BadgeExamples />
@@ -127,7 +118,7 @@ export const Playground = {
 
     argTypes: {
         tone: {
-            options: ['info', 'positive', 'promote', 'attention', 'warning'],
+            options: ['info', 'positive', 'promote', 'attention'],
 
             control: {
                 type: 'inline-radio',

--- a/src/badge/badge.test.tsx
+++ b/src/badge/badge.test.tsx
@@ -22,14 +22,12 @@ describe('Badge', () => {
                 <Badge tone="positive" label="Positive" />
                 <Badge tone="promote" label="Promote" />
                 <Badge tone="attention" label="Attention" />
-                <Badge tone="warning" label="Warning" />
             </>,
         )
         expect(screen.getByText('Info')).toHaveClass('badge-info')
         expect(screen.getByText('Positive')).toHaveClass('badge-positive')
         expect(screen.getByText('Promote')).toHaveClass('badge-promote')
         expect(screen.getByText('Attention')).toHaveClass('badge-attention')
-        expect(screen.getByText('Warning')).toHaveClass('badge-warning')
     })
 
     it('passes through aria-related attributes', () => {

--- a/src/badge/badge.tsx
+++ b/src/badge/badge.tsx
@@ -4,7 +4,7 @@ import { Box } from '../box'
 
 import styles from './badge.module.css'
 
-type BadgeTone = 'info' | 'positive' | 'promote' | 'attention' | 'warning'
+type BadgeTone = 'info' | 'positive' | 'promote' | 'attention'
 
 type BadgeProps = {
     /**


### PR DESCRIPTION
Related: Doist/todoist-web#18544

## Short description

This PR removes the `warning` tone from `<Badge>`.

## PR Checklist

- [x] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI
