### PR TITLE
docs: refer to semantic-release instead of release-please

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,5 +21,5 @@ Feel free to leave unchecked or remove the lines that are not applicable.
 - [ ] Reviewed and approved Chromatic visual regression tests in CI
 
 <!--
-_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
+_Note:_ versioning is handled by [semantic-release](https://github.com/semantic-release/semantic-release), based on the PR title.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,11 @@ For generic React Testing Library patterns (component tests, hook tests, provide
 
 - PR titles must follow [conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`, etc.
 - `feat:` triggers a minor version bump, `fix:` triggers a patch, `feat!:` or `fix!:` triggers a major (breaking)
-- Versioning is automated by release-please based on PR title
+- Versioning is automated by semantic-release based on PR title
 - Pre-commit hooks run Prettier, ESLint, and React Compiler tracking - do not skip them
 
 <!-- shared-config:agents -->
+
 # AGENTS
 
 > [!WARNING]
@@ -220,4 +221,5 @@ When asked to create a pull request, follow this mandatory process:
 ## Enforcement
 
 These guidelines are **non-negotiable**. Deviation from this process constitutes a failure to follow core instructions. When in doubt, ask for clarification.
+
 <!-- /shared-config:agents -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ For generic React Testing Library patterns (component tests, hook tests, provide
 ## Commits and PRs
 
 - PR titles must follow [conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`, etc.
-- `feat:` triggers a minor version bump, `fix:` triggers a patch, `feat!:` or `fix!:` triggers a major (breaking)
+- `feat:` triggers a minor version bump, `fix:` and `perf:` trigger a patch, any type with `!` or a `BREAKING CHANGE:` footer triggers a major (breaking)
 - Versioning is automated by semantic-release based on PR title
 - Pre-commit hooks run Prettier, ESLint, and React Compiler tracking - do not skip them
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ This project uses [semantic-release](https://github.com/semantic-release/semanti
     - Any type below with an added `!` suffix (e.g. `feat!:`, `fix!:`) or a `BREAKING CHANGE:` footer for breaking changes (major version bump)
     - `feat:` for new features (minor version bump)
     - `fix:` for bug fixes (patch version bump)
-    - `style:` for code style changes
     - `perf:` for performance improvements (patch version bump)
     - `refactor:` for refactoring code
     - `test:` for adding/updating tests

--- a/README.md
+++ b/README.md
@@ -208,18 +208,20 @@ This project uses [semantic-release](https://github.com/semantic-release/semanti
 ## How it works
 
 1. Make your changes using [Conventional Commits](https://www.conventionalcommits.org/):
+    - Any type below with an added `!` suffix (e.g. `feat!:`, `fix!:`) or a `BREAKING CHANGE:` footer for breaking changes (major version bump)
     - `feat:` for new features (minor version bump)
     - `fix:` for bug fixes (patch version bump)
     - `style:` for code style changes
-    - `perf:` for performance improvements
+    - `perf:` for performance improvements (patch version bump)
     - `refactor:` for refactoring code
     - `test:` for adding/updating tests
     - `build:` for build/dependency changes
     - `docs:` for documentation changes
     - `ci:` for CI changes
     - `revert:` for reverting previous commits
-    - `feat!:` or `fix!:` for breaking changes (major version bump)
     - `chore:` for maintenance tasks (NOTE: these are not included in the changelog)
+
+    Any type can carry an optional scope, e.g. `feat(button):` or `perf(tooltip)!:`.
 
 2. When a PR is merged to `main`, the [Package Release](.github/workflows/publish-package-release.yml) workflow runs and semantic-release:
     - Reads the merged commit's conventional-commit type to determine the version bump
@@ -227,6 +229,6 @@ This project uses [semantic-release](https://github.com/semantic-release/semanti
     - Creates a new tag and GitHub release
     - Publishes the package to npm and GitHub Packages
 
-Merges with a releasing commit (`feat:`, `fix:`, `feat!:`, or `fix!:`, optionally scoped like `feat(button):` or `fix(tooltip)!:`) publish a release automatically. Merges that only contain non-releasing types (e.g. `chore:`, `docs:`) don't trigger one.
+A merge triggers a release only when it includes a type marked with a version bump above; otherwise nothing is published.
 
 The storybook hosted on GitHub pages will be automatically updated on each push to `main`. If there's a problem, try running the action manually from the [Actions settings](https://github.com/Doist/reactist/actions).

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ When you open a GitHub PR, you'll notice the "UI Review" and "UI Tests" CI steps
 
 # Releasing
 
-This project uses [release-please](https://github.com/googleapis/release-please) to automate version management and package publishing.
+This project uses [semantic-release](https://github.com/semantic-release/semantic-release) to automate version management and package publishing.
 
 ## How it works
 
@@ -221,16 +221,12 @@ This project uses [release-please](https://github.com/googleapis/release-please)
     - `feat!:` or `fix!:` for breaking changes (major version bump)
     - `chore:` for maintenance tasks (NOTE: these are not included in the changelog)
 
-2. When commits are pushed to `main`:
-    - Release-please automatically creates/updates a release PR
-    - The PR includes version bump and changelog updates
-    - Review the PR and merge when ready
+2. When a PR is merged to `main`, the [Package Release](.github/workflows/publish-package-release.yml) workflow runs and semantic-release:
+    - Reads the merged commit's conventional-commit type to determine the version bump
+    - Updates `CHANGELOG.md`, `package.json`, and `package-lock.json`, and commits them back to `main`
+    - Creates a new tag and GitHub release
+    - Publishes the package to npm and GitHub Packages
 
-3. After merging the release PR:
-    - A new GitHub release is automatically created
-    - A new tag is created
-    - The `publish` workflow is triggered
-    - The package is published to npm and GitHub Packages
-    - Storybook documentation is automatically updated
+Merges with a releasing commit (`feat:`, `fix:`, `feat!:`, or `fix!:`, optionally scoped like `feat(button):` or `fix(tooltip)!:`) publish a release automatically. Merges that only contain non-releasing types (e.g. `chore:`, `docs:`) don't trigger one.
 
 The storybook hosted on GitHub pages will be automatically updated on each push to `main`. If there's a problem, try running the action manually from the [Actions settings](https://github.com/Doist/reactist/actions).


### PR DESCRIPTION
## Short description

Updates various docs to remove references to [release-please](https://github.com/googleapis/release-please), as we've already moved onto [semantic-release](https://github.com/semantic-release/semantic-release) in https://github.com/Doist/reactist/pull/1024.

## PR Checklist

- [x] Updated docs (storybooks, readme)
