### PR TITLE
feat: add provisional Table component

### DIFF
--- a/.react-compiler.rec.json
+++ b/.react-compiler.rec.json
@@ -17,6 +17,9 @@
     "src/menu/menu.tsx": {
       "CompileError": 2
     },
+    "src/table/table.tsx": {
+      "CompileError": 1
+    },
     "src/tooltip/tooltip.tsx": {
       "CompileError": 1
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
+                "@tanstack/react-table": "8.21.3",
                 "aria-hidden": "^1.2.1",
                 "dayjs": "^1.8.10",
                 "patch-package": "^6.4.6",
@@ -6942,6 +6943,39 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/@tanstack/react-table": {
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+            "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/table-core": "8.21.3"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
+            }
+        },
+        "node_modules/@tanstack/table-core": {
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+            "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
         "node_modules/@testing-library/dom": {
@@ -22768,7 +22802,6 @@
             "version": "19.2.7",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
             "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
@@ -23812,7 +23845,6 @@
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
             "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/semantic-release": {

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     },
     "dependencies": {
         "@babel/runtime": "^7.28.4",
+        "@tanstack/react-table": "8.21.3",
         "aria-hidden": "^1.2.1",
         "dayjs": "^1.8.10",
         "patch-package": "^6.4.6",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -20,6 +20,7 @@ const external = [
     'classnames',
     'prop-types',
     '@ariakit/react',
+    '@tanstack/react-table',
     'aria-hidden',
     'dayjs',
     'dayjs/plugin/localizedFormat',

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export * from './badge'
 export * from './expansion-panel'
 export * from './menu'
 export * from './modal'
+export * from './table'
 export * from './tabs'
 export * from './tooltip'
 

--- a/src/table/index.ts
+++ b/src/table/index.ts
@@ -1,0 +1,1 @@
+export * from './table'

--- a/src/table/table.module.css
+++ b/src/table/table.module.css
@@ -1,0 +1,117 @@
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    color: var(--reactist-table-content, var(--reactist-content-primary));
+    font-family: var(--reactist-font-family);
+    font-size: var(--reactist-font-size-body);
+}
+
+.header {
+    border-bottom: 1px solid var(--reactist-table-divider, var(--reactist-divider-secondary));
+}
+
+.headerCell {
+    padding: var(--reactist-spacing-medium);
+    text-align: left;
+    user-select: none;
+}
+
+.headerCellSortable {
+    padding: 0;
+}
+
+.sortButton {
+    display: flex;
+    gap: var(--reactist-spacing-xsmall);
+    align-items: center;
+    width: 100%;
+    padding: var(--reactist-spacing-medium);
+    border: 0;
+    color: inherit;
+    font: inherit;
+    font-weight: var(--reactist-font-weight-medium);
+    text-align: left;
+    background: transparent;
+    cursor: pointer;
+}
+
+.sortButton:hover {
+    background-color: var(--reactist-table-header-hover, var(--reactist-bg-highlight));
+}
+
+.sortButton:focus-visible {
+    outline: 2px solid
+        var(--reactist-table-focus-ring, var(--reactist-actionable-primary-idle-fill));
+    outline-offset: -2px;
+}
+
+.headerCellContent {
+    display: inline-flex;
+    align-items: center;
+}
+
+.row {
+    border-bottom: 1px solid var(--reactist-table-divider, var(--reactist-divider-secondary));
+}
+
+.row.clickable {
+    cursor: pointer;
+}
+
+.header:has(+ tbody > .row[aria-selected='true']:first-child) {
+    border-bottom-color: transparent;
+}
+
+.row[aria-selected='true'],
+.row:has(+ .row[aria-selected='true']) {
+    border-bottom-color: transparent;
+}
+
+.row[aria-selected='true'] {
+    background-color: var(--reactist-table-selected-fill, var(--reactist-framework-fill-selected));
+}
+
+.row[aria-selected='true'] .cell:first-child {
+    border-start-start-radius: var(--reactist-border-radius-large);
+    border-end-start-radius: var(--reactist-border-radius-large);
+}
+
+.row[aria-selected='true'] .cell:last-child {
+    border-start-end-radius: var(--reactist-border-radius-large);
+    border-end-end-radius: var(--reactist-border-radius-large);
+}
+
+.row.clickable:focus-visible {
+    outline: 2px solid
+        var(--reactist-table-focus-ring, var(--reactist-actionable-primary-idle-fill));
+    outline-offset: -2px;
+}
+
+.cell {
+    padding: var(--reactist-spacing-small) var(--reactist-spacing-medium);
+    vertical-align: middle;
+}
+
+.emptyCell {
+    padding-block: var(--reactist-spacing-xxlarge);
+    color: var(--reactist-table-empty-content, var(--reactist-content-secondary));
+    text-align: center;
+}
+
+.sortIndicator {
+    display: inline-flex;
+    align-items: center;
+    width: 16px;
+    height: 16px;
+}
+
+.sortIndicatorIcon {
+    width: 16px;
+    height: 16px;
+    color: var(--reactist-table-sort-indicator, var(--reactist-content-secondary));
+    fill: none;
+    stroke: currentcolor;
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}

--- a/src/table/table.stories.module.css
+++ b/src/table/table.stories.module.css
@@ -1,0 +1,172 @@
+.canvas {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 560px;
+    padding: 32px;
+    color: var(--reactist-content-primary);
+    font-family: var(--reactist-font-family);
+    background: #f7f7f7;
+}
+
+.frame {
+    width: min(100%, 1040px);
+    margin: 0 auto;
+}
+
+.pageHeader {
+    display: flex;
+    gap: 24px;
+    align-items: flex-end;
+    justify-content: space-between;
+    margin-bottom: 20px;
+}
+
+.title {
+    margin: 0;
+    font-size: var(--reactist-font-size-header-large);
+    line-height: 1.25;
+}
+
+.subtitle {
+    margin: 5px 0 0;
+    color: var(--reactist-content-secondary);
+    font-size: var(--reactist-font-size-body);
+}
+
+.count {
+    flex: none;
+    padding: 5px 9px;
+    border-radius: 999px;
+    color: var(--reactist-content-secondary);
+    font-size: var(--reactist-font-size-caption);
+    font-weight: var(--reactist-font-weight-medium);
+    background: var(--reactist-bg-highlight);
+}
+
+.surface {
+    overflow: hidden;
+    border: 1px solid #e2e2e2;
+    border-radius: 12px;
+    background: var(--reactist-bg-default);
+    box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+}
+
+.scrollArea {
+    overflow-x: auto;
+}
+
+.presentationTable {
+    min-width: 760px;
+}
+
+.presentationTable th:first-child,
+.presentationTable td:first-child {
+    width: 38%;
+}
+
+.presentationTable th:nth-child(2),
+.presentationTable td:nth-child(2) {
+    width: 21%;
+}
+
+.presentationTable th:nth-child(3),
+.presentationTable td:nth-child(3) {
+    width: 17%;
+}
+
+.presentationTable th:last-child,
+.presentationTable td:last-child {
+    width: 24%;
+}
+
+.person {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    min-height: 36px;
+}
+
+.personText {
+    min-width: 0;
+}
+
+.personName {
+    overflow: hidden;
+    font-weight: var(--reactist-font-weight-medium);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.personEmail {
+    overflow: hidden;
+    margin-top: 2px;
+    color: var(--reactist-content-secondary);
+    font-size: var(--reactist-font-size-caption);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.role {
+    color: var(--reactist-content-secondary);
+}
+
+.status {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    border-radius: 999px;
+    color: var(--reactist-content-positive);
+    font-size: var(--reactist-font-size-caption);
+    font-weight: var(--reactist-font-weight-medium);
+    background: #edf8ef;
+}
+
+.statusMuted {
+    color: var(--reactist-content-secondary);
+    background: var(--reactist-bg-highlight);
+}
+
+.emptyState {
+    padding: 12px;
+}
+
+.emptyTitle {
+    margin: 0;
+    color: var(--reactist-content-primary);
+    font-size: var(--reactist-font-size-subtitle);
+    font-weight: var(--reactist-font-weight-medium);
+}
+
+.emptyDescription {
+    margin: 6px 0 0;
+    color: var(--reactist-content-secondary);
+}
+
+.placeholderRow {
+    opacity: 0.42;
+    filter: grayscale(0.5);
+}
+
+.placeholderNote {
+    margin: 12px 0 0;
+    color: var(--reactist-content-secondary);
+    font-size: var(--reactist-font-size-caption);
+}
+
+.narrowCanvas {
+    width: 420px;
+    max-width: 100%;
+}
+
+@media (max-width: 600px) {
+    .canvas {
+        min-height: 520px;
+        padding: 20px 12px;
+    }
+
+    .pageHeader {
+        flex-direction: column;
+        gap: 10px;
+        align-items: flex-start;
+    }
+}

--- a/src/table/table.stories.tsx
+++ b/src/table/table.stories.tsx
@@ -1,0 +1,364 @@
+import * as React from 'react'
+
+import classNames from 'classnames'
+
+import { Avatar } from '../avatar'
+
+import { Table, TableCell, TableRow } from './table'
+
+import styles from './table.stories.module.css'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { TableColumn, TableRowModel, TableSorting } from './table'
+
+type Person = {
+    id: string
+    name: string
+    email: string
+    role: string
+    access: 'Admin' | 'Member' | 'Guest'
+    activity: string
+    placeholder?: boolean
+}
+
+const people: Person[] = [
+    {
+        id: 'avery-morgan',
+        name: 'Avery Morgan',
+        email: 'avery@example.com',
+        role: 'Product designer',
+        access: 'Admin',
+        activity: 'Active now',
+    },
+    {
+        id: 'sam-rivera',
+        name: 'Sam Rivera',
+        email: 'sam@example.com',
+        role: 'Frontend engineer',
+        access: 'Member',
+        activity: '8 minutes ago',
+    },
+    {
+        id: 'mika-chen',
+        name: 'Mika Chen',
+        email: 'mika@example.com',
+        role: 'Product manager',
+        access: 'Admin',
+        activity: '2 hours ago',
+    },
+    {
+        id: 'noor-patel',
+        name: 'Noor Patel',
+        email: 'noor@example.com',
+        role: 'Research lead',
+        access: 'Member',
+        activity: 'Yesterday',
+    },
+    {
+        id: 'theo-williams',
+        name: 'Theo Williams',
+        email: 'theo@example.com',
+        role: 'Operations',
+        access: 'Guest',
+        activity: '3 days ago',
+    },
+]
+
+const placeholderPeople: Person[] = [
+    ...people.slice(0, 1),
+    {
+        id: 'placeholder-1',
+        name: 'Jordan Lee',
+        email: 'jordan@example.com',
+        role: 'Design',
+        access: 'Member',
+        activity: 'Example',
+        placeholder: true,
+    },
+    {
+        id: 'placeholder-2',
+        name: 'Taylor Brooks',
+        email: 'taylor@example.com',
+        role: 'Engineering',
+        access: 'Member',
+        activity: 'Example',
+        placeholder: true,
+    },
+    {
+        id: 'placeholder-3',
+        name: 'Morgan Silva',
+        email: 'morgan@example.com',
+        role: 'Marketing',
+        access: 'Guest',
+        activity: 'Example',
+        placeholder: true,
+    },
+]
+
+const columns: TableColumn<Person>[] = [
+    {
+        accessorKey: 'name',
+        header: 'Person',
+        cell: ({ row }) => <PersonCell person={row.original} />,
+    },
+    {
+        accessorKey: 'role',
+        header: 'Role',
+        cell: ({ getValue }) => <span className={styles.role}>{String(getValue())}</span>,
+    },
+    { accessorKey: 'access', header: 'Access' },
+    {
+        accessorKey: 'activity',
+        header: 'Last active',
+        cell: ({ getValue }) => {
+            const activity = String(getValue())
+            return (
+                <span
+                    className={classNames(
+                        styles.status,
+                        activity !== 'Active now' && styles.statusMuted,
+                    )}
+                >
+                    {activity}
+                </span>
+            )
+        },
+    },
+]
+
+const columnLabels = new Map([
+    ['name', 'Person'],
+    ['role', 'Role'],
+    ['access', 'Access'],
+    ['activity', 'Last active'],
+])
+
+const meta = {
+    title: '📊 Data display/Table',
+    component: Table,
+    parameters: {
+        badges: ['partiallyAccessible'],
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Presentation prototype based on Todoist’s current flat data table. The API remains provisional while sorting, selection, dependency placement, and responsive behavior are reviewed.',
+            },
+        },
+    },
+} satisfies Meta<typeof Table>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+function PersonCell({ person }: { person: Person }) {
+    return (
+        <div className={styles.person}>
+            <Avatar size={30} shape="circle" name={person.name} />
+            <div className={styles.personText}>
+                <div className={styles.personName}>{person.name}</div>
+                <div className={styles.personEmail}>{person.email}</div>
+            </div>
+        </div>
+    )
+}
+
+function PresentationFrame({
+    children,
+    count,
+    narrow = false,
+}: {
+    children: React.ReactNode
+    count: number
+    narrow?: boolean
+}) {
+    return (
+        <main className={classNames(styles.canvas, narrow && styles.narrowCanvas)}>
+            <div className={styles.frame}>
+                <header className={styles.pageHeader}>
+                    <div>
+                        <h1 className={styles.title}>People</h1>
+                        <p className={styles.subtitle}>Everyone with access to this workspace</p>
+                    </div>
+                    <span className={styles.count}>
+                        {count} {count === 1 ? 'person' : 'people'}
+                    </span>
+                </header>
+                <div className={styles.surface}>
+                    <div className={styles.scrollArea}>{children}</div>
+                </div>
+            </div>
+        </main>
+    )
+}
+
+function getSortAriaLabel({
+    columnId,
+    direction,
+}: {
+    columnId: string
+    direction: 'asc' | 'desc' | null
+}) {
+    const label = columnLabels.get(columnId) ?? columnId
+    if (direction === 'asc') return `${label}, sorted ascending. Activate to sort descending.`
+    if (direction === 'desc') return `${label}, sorted descending. Activate to sort ascending.`
+    return `${label}, activate to sort ascending.`
+}
+
+function sortPeople(data: Person[], sorting: Exclude<TableSorting, null>) {
+    return [...data].sort((first, second) => {
+        const firstValue = String(first[sorting.columnId as keyof Person] ?? '')
+        const secondValue = String(second[sorting.columnId as keyof Person] ?? '')
+        const result = firstValue.localeCompare(secondValue)
+        return sorting.direction === 'asc' ? result : -result
+    })
+}
+
+function SortableTable({ narrow = false }: { narrow?: boolean }) {
+    const [sorting, setSorting] = React.useState<Exclude<TableSorting, null>>({
+        columnId: 'name',
+        direction: 'asc',
+    })
+    const sortedPeople = sortPeople(people, sorting)
+
+    function handleSort(columnId: string) {
+        setSorting((current) => ({
+            columnId,
+            direction:
+                current.columnId === columnId && current.direction === 'asc' ? 'desc' : 'asc',
+        }))
+    }
+
+    return (
+        <PresentationFrame count={people.length} narrow={narrow}>
+            <Table
+                aria-label="Workspace people"
+                data={sortedPeople}
+                columns={columns}
+                getRowId={(person) => person.id}
+                sorting={sorting}
+                onSort={handleSort}
+                getSortAriaLabel={getSortAriaLabel}
+                exceptionallySetClassName={styles.presentationTable}
+            />
+        </PresentationFrame>
+    )
+}
+
+function handleRowKeyDown(
+    event: React.KeyboardEvent<HTMLTableRowElement>,
+    row: TableRowModel<Person>,
+    onActivate: (rowId: string) => void,
+) {
+    if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault()
+        onActivate(row.id)
+    }
+}
+
+function SelectableTable() {
+    const [selectedId, setSelectedId] = React.useState(people[1]!.id)
+    return (
+        <PresentationFrame count={people.length}>
+            <Table
+                aria-label="Selectable workspace people"
+                data={people}
+                columns={columns}
+                getRowId={(person) => person.id}
+                exceptionallySetClassName={styles.presentationTable}
+                renderRow={(row) => (
+                    <TableRow
+                        key={row.id}
+                        aria-selected={selectedId === row.id || undefined}
+                        tabIndex={0}
+                        onClick={() => setSelectedId(row.id)}
+                        onKeyDown={(event) => handleRowKeyDown(event, row, setSelectedId)}
+                    >
+                        {row.getVisibleCells().map((cell) => (
+                            <TableCell key={cell.id} cell={cell} />
+                        ))}
+                    </TableRow>
+                )}
+            />
+        </PresentationFrame>
+    )
+}
+
+function PlaceholderTable() {
+    return (
+        <PresentationFrame count={1}>
+            <Table
+                aria-label="Workspace people with examples"
+                data={placeholderPeople}
+                columns={columns}
+                getRowId={(person) => person.id}
+                exceptionallySetClassName={styles.presentationTable}
+                renderRow={(row) => {
+                    const isPlaceholder = Boolean(row.original.placeholder)
+                    return (
+                        <TableRow
+                            key={row.id}
+                            aria-hidden={isPlaceholder || undefined}
+                            exceptionallySetClassName={
+                                isPlaceholder ? styles.placeholderRow : undefined
+                            }
+                        >
+                            {row.getVisibleCells().map((cell) => (
+                                <TableCell key={cell.id} cell={cell} inert={isPlaceholder} />
+                            ))}
+                        </TableRow>
+                    )
+                }}
+            />
+            <p className={styles.placeholderNote}>
+                Faded rows demonstrate inert, assistive-technology-hidden examples without exposing
+                the component’s CSS module.
+            </p>
+        </PresentationFrame>
+    )
+}
+
+export const Default = { render: () => <SortableTable /> } satisfies Story
+
+export const ControlledSorting = {
+    name: 'Controlled sorting',
+    render: () => <SortableTable />,
+} satisfies Story
+
+export const SelectedAndClickableRows = {
+    name: 'Selected and clickable rows',
+    render: () => <SelectableTable />,
+} satisfies Story
+
+export const EmptyState = {
+    name: 'Empty state',
+    render: () => (
+        <PresentationFrame count={0}>
+            <Table
+                aria-label="Empty workspace people"
+                data={[]}
+                columns={columns}
+                exceptionallySetClassName={styles.presentationTable}
+                emptyState={
+                    <div className={styles.emptyState}>
+                        <p className={styles.emptyTitle}>No people to show</p>
+                        <p className={styles.emptyDescription}>
+                            People with workspace access will appear here.
+                        </p>
+                    </div>
+                }
+            />
+        </PresentationFrame>
+    ),
+} satisfies Story
+
+export const CustomPlaceholderRows = {
+    name: 'Custom placeholder rows',
+    render: () => <PlaceholderTable />,
+} satisfies Story
+
+export const NarrowViewport = {
+    name: 'Narrow viewport (current behavior)',
+    render: () => <SortableTable narrow />,
+} satisfies Story

--- a/src/table/table.test.tsx
+++ b/src/table/table.test.tsx
@@ -1,0 +1,194 @@
+import * as React from 'react'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
+
+import { Table, TableCell, TableRow } from './'
+
+import type { TableColumn } from './'
+
+type Person = {
+    id: string
+    name: string
+    role: string
+}
+
+const people: Person[] = [
+    { id: 'person-1', name: 'Avery Morgan', role: 'Product designer' },
+    { id: 'person-2', name: 'Sam Rivera', role: 'Engineer' },
+]
+
+const columns: TableColumn<Person>[] = [
+    { accessorKey: 'name', header: 'Name' },
+    { accessorKey: 'role', header: 'Role' },
+]
+
+describe('Table', () => {
+    it('renders typed columns and data with native table semantics', () => {
+        render(<Table data={people} columns={columns} getRowId={(person) => person.id} />)
+
+        expect(screen.getByRole('table')).toBeInTheDocument()
+        expect(screen.getAllByRole('columnheader')).toHaveLength(2)
+        expect(screen.getAllByRole('row')).toHaveLength(3)
+        expect(screen.getByRole('cell', { name: 'Avery Morgan' })).toBeInTheDocument()
+        expect(screen.getByRole('cell', { name: 'Engineer' })).toBeInTheDocument()
+    })
+
+    it('exposes controlled sorting through labeled header buttons', async () => {
+        const user = userEvent.setup()
+        const onSort = jest.fn()
+
+        render(
+            <Table
+                data={people}
+                columns={columns}
+                sorting={{ columnId: 'name', direction: 'asc' }}
+                onSort={onSort}
+                getSortAriaLabel={({ columnId, direction }) =>
+                    direction ? `${columnId}, sorted ${direction}` : `${columnId}, activate to sort`
+                }
+            />,
+        )
+
+        expect(screen.getByRole('columnheader', { name: 'Name' })).toHaveAttribute(
+            'aria-sort',
+            'ascending',
+        )
+        expect(screen.getByRole('columnheader', { name: 'Role' })).toHaveAttribute(
+            'aria-sort',
+            'none',
+        )
+
+        await user.click(screen.getByRole('button', { name: 'name, sorted asc' }))
+        screen.getByRole('button', { name: 'role, activate to sort' }).focus()
+        await user.keyboard('{Enter}')
+
+        expect(onSort).toHaveBeenNthCalledWith(1, 'name')
+        expect(onSort).toHaveBeenNthCalledWith(2, 'role')
+        expect(onSort).toHaveBeenCalledTimes(2)
+    })
+
+    it('renders empty-state content across all visible columns', () => {
+        render(<Table data={[]} columns={columns} emptyState="No people yet" />)
+
+        expect(screen.getByRole('cell', { name: 'No people yet' })).toHaveAttribute('colspan', '2')
+    })
+
+    it('supports consumer-wired row activation, selection, and custom cells', async () => {
+        const user = userEvent.setup()
+
+        function SelectablePeopleTable() {
+            const [selectedId, setSelectedId] = React.useState<string | null>(null)
+
+            return (
+                <Table
+                    data={people}
+                    columns={columns}
+                    getRowId={(person) => person.id}
+                    renderRow={(row) => (
+                        <TableRow
+                            key={row.id}
+                            aria-selected={selectedId === row.id}
+                            tabIndex={0}
+                            onClick={() => setSelectedId(row.id)}
+                            onKeyDown={(event) => {
+                                if (event.key === 'Enter' || event.key === ' ') {
+                                    event.preventDefault()
+                                    setSelectedId(row.id)
+                                }
+                            }}
+                        >
+                            {row.getVisibleCells().map((cell) => (
+                                <TableCell key={cell.id} cell={cell}>
+                                    {cell.column.id === 'name' ? (
+                                        <strong>{row.original.name}</strong>
+                                    ) : undefined}
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    )}
+                />
+            )
+        }
+
+        render(<SelectablePeopleTable />)
+
+        const averyRow = screen.getByRole('row', { name: 'Avery Morgan Product designer' })
+        const samRow = screen.getByRole('row', { name: 'Sam Rivera Engineer' })
+
+        await user.click(averyRow)
+        expect(averyRow).toHaveAttribute('aria-selected', 'true')
+
+        samRow.focus()
+        await user.keyboard(' ')
+        expect(samRow).toHaveAttribute('aria-selected', 'true')
+        expect(screen.getByText('Avery Morgan', { selector: 'strong' })).toBeInTheDocument()
+    })
+
+    it('forwards refs and styling escape hatches from the public building blocks', () => {
+        const tableRef = React.createRef<HTMLTableElement>()
+        const rowRef = React.createRef<HTMLTableRowElement>()
+        const cellRef = React.createRef<HTMLTableCellElement>()
+
+        render(
+            <Table
+                ref={tableRef}
+                data={people.slice(0, 1)}
+                columns={columns}
+                exceptionallySetClassName="custom-table"
+                renderRow={(row) => (
+                    <TableRow key={row.id} ref={rowRef} exceptionallySetClassName="custom-row">
+                        {row.getVisibleCells().map((cell, index) => (
+                            <TableCell
+                                key={cell.id}
+                                ref={index === 0 ? cellRef : undefined}
+                                cell={cell}
+                                exceptionallySetClassName="custom-cell"
+                            />
+                        ))}
+                    </TableRow>
+                )}
+            />,
+        )
+
+        expect(tableRef.current).toHaveClass('custom-table')
+        expect(rowRef.current).toHaveClass('custom-row')
+        expect(cellRef.current).toHaveClass('custom-cell')
+    })
+
+    it('applies inert to custom cells without relying on React version support', () => {
+        render(
+            <Table
+                data={people.slice(0, 1)}
+                columns={columns}
+                renderRow={(row) => (
+                    <TableRow key={row.id}>
+                        {row.getVisibleCells().map((cell) => (
+                            <TableCell key={cell.id} cell={cell} inert />
+                        ))}
+                    </TableRow>
+                )}
+            />,
+        )
+
+        expect(screen.getByRole('cell', { name: 'Avery Morgan' })).toHaveAttribute('inert')
+        expect(screen.getByRole('cell', { name: 'Product designer' })).toHaveAttribute('inert')
+    })
+
+    it('has no automated accessibility violations in its sortable state', async () => {
+        const { container } = render(
+            <Table
+                data={people}
+                columns={columns}
+                sorting={{ columnId: 'name', direction: 'desc' }}
+                onSort={jest.fn()}
+                getSortAriaLabel={({ columnId, direction }) =>
+                    direction ? `${columnId}, sorted ${direction}` : `${columnId}, sortable`
+                }
+            />,
+        )
+
+        expect(await axe(container)).toHaveNoViolations()
+    })
+})

--- a/src/table/table.tsx
+++ b/src/table/table.tsx
@@ -1,0 +1,316 @@
+'use no memo'
+
+import * as React from 'react'
+
+import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
+import classNames from 'classnames'
+import { useMergeRefs } from 'use-callback-ref'
+
+import styles from './table.module.css'
+
+import type { Cell, ColumnDef, Row } from '@tanstack/react-table'
+import type { ObfuscatedClassName } from '../utils/common-types'
+
+/** A Reactist-owned TanStack column definition for a table row. */
+type TableColumn<TData extends object> = ColumnDef<TData, unknown>
+
+/** The row model passed to `renderRow`. */
+type TableRowModel<TData extends object> = Row<TData>
+
+/** The cell model rendered by `TableCell`. */
+type TableCellModel<TData extends object> = Cell<TData, unknown>
+
+/** Props for a styled native table row. */
+type TableRowProps = Omit<React.HTMLAttributes<HTMLTableRowElement>, 'className'> &
+    ObfuscatedClassName
+
+/** Props for a styled native table cell. */
+type TableCellProps<TData extends object> = Omit<
+    React.TdHTMLAttributes<HTMLTableCellElement>,
+    'className' | 'inert'
+> &
+    ObfuscatedClassName & {
+        /** TanStack cell model used for default cell rendering. */
+        cell: TableCellModel<TData>
+
+        /** Removes this custom cell and its descendants from interaction. */
+        inert?: boolean
+    }
+
+/** Controlled sorting state for a Reactist table. */
+type TableSorting = {
+    /** The id of the column currently used for sorting. */
+    columnId: string
+
+    /** The current sort direction. */
+    direction: 'asc' | 'desc'
+} | null
+
+type TableSortLabelInput = {
+    columnId: string
+    direction: 'asc' | 'desc' | null
+}
+
+type TableSortingProps =
+    | {
+          /** Controlled sorting state. Pass `null` when no column is sorted. */
+          sorting: TableSorting
+
+          /** Called when a sortable column header is activated. */
+          onSort: (columnId: string) => void
+
+          /** Returns the complete localized accessible label for a sort button. */
+          getSortAriaLabel: (input: TableSortLabelInput) => string
+      }
+    | {
+          sorting?: never
+          onSort?: never
+          getSortAriaLabel?: never
+      }
+
+/** Props for the provisional `Table` presentation prototype. */
+type TableProps<TData extends object> = Omit<
+    React.TableHTMLAttributes<HTMLTableElement>,
+    'children' | 'className'
+> &
+    ObfuscatedClassName &
+    TableSortingProps & {
+        /** Row data. Reactist never sorts or mutates this controlled input. */
+        data: TData[]
+
+        /** Typed definitions for the table's columns. */
+        columns: TableColumn<TData>[]
+
+        /** Returns a stable identifier for a row. */
+        getRowId?: (row: TData, index: number) => string
+
+        /** Content rendered across the visible columns when `data` is empty. */
+        emptyState?: React.ReactNode
+
+        /**
+         * Renders a structurally custom row. Use `TableRow` and `TableCell` to retain the baseline
+         * styling without importing the component's CSS module.
+         */
+        renderRow?: (row: TableRowModel<TData>) => React.ReactNode
+    }
+
+type TableComponent = {
+    <TData extends object>(
+        props: TableProps<TData> & React.RefAttributes<HTMLTableElement>,
+    ): React.ReactElement | null
+    displayName?: string
+}
+
+type TableCellComponent = {
+    <TData extends object>(
+        props: TableCellProps<TData> & React.RefAttributes<HTMLTableCellElement>,
+    ): React.ReactElement | null
+    displayName?: string
+}
+
+/** Styled native row building block for custom `Table` rows. */
+const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(function TableRow(
+    { exceptionallySetClassName, onClick, ...rowProps },
+    ref,
+) {
+    return (
+        <tr
+            {...rowProps}
+            ref={ref}
+            onClick={onClick}
+            className={classNames(
+                styles.row,
+                exceptionallySetClassName,
+                onClick && styles.clickable,
+            )}
+        />
+    )
+})
+
+/** Styled native cell building block for custom `Table` rows. */
+const TableCell = React.forwardRef(function TableCell<TData extends object>(
+    {
+        cell,
+        children,
+        inert = false,
+        exceptionallySetClassName,
+        ...cellProps
+    }: TableCellProps<TData>,
+    ref: React.ForwardedRef<HTMLTableCellElement>,
+) {
+    const internalRef = React.useRef<HTMLTableCellElement>(null)
+    const combinedRef = useMergeRefs([internalRef, ref])
+
+    React.useEffect(
+        function syncInertAttribute() {
+            internalRef.current?.toggleAttribute('inert', inert)
+        },
+        [inert],
+    )
+
+    return (
+        <td
+            {...cellProps}
+            ref={combinedRef}
+            className={classNames(styles.cell, exceptionallySetClassName)}
+        >
+            {children ?? flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </td>
+    )
+}) as TableCellComponent
+
+TableRow.displayName = 'TableRow'
+TableCell.displayName = 'TableCell'
+
+/**
+ * Displays typed row data using native table markup.
+ *
+ * This API is provisional while the Reactist Table proposal is being reviewed.
+ */
+const Table = React.forwardRef(function Table<TData extends object>(
+    {
+        data,
+        columns,
+        getRowId,
+        emptyState,
+        renderRow,
+        sorting,
+        onSort,
+        getSortAriaLabel,
+        exceptionallySetClassName,
+        ...tableProps
+    }: TableProps<TData>,
+    ref: React.ForwardedRef<HTMLTableElement>,
+) {
+    const table = useReactTable({
+        data,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+        getRowId,
+        enableSorting: false,
+        manualSorting: true,
+        state: {
+            sorting: sorting ? [{ id: sorting.columnId, desc: sorting.direction === 'desc' }] : [],
+        },
+    })
+    const rows = table.getRowModel().rows
+
+    return (
+        <table
+            {...tableProps}
+            ref={ref}
+            className={classNames(styles.table, exceptionallySetClassName)}
+        >
+            <thead className={styles.header}>
+                {table.getHeaderGroups().map((headerGroup) => (
+                    <tr key={headerGroup.id} className={styles.row}>
+                        {headerGroup.headers.map((header) => {
+                            const canSort = Boolean(onSort && getSortAriaLabel)
+                            const direction =
+                                sorting?.columnId === header.column.id ? sorting.direction : null
+                            const ariaSort = canSort
+                                ? direction === 'asc'
+                                    ? 'ascending'
+                                    : direction === 'desc'
+                                      ? 'descending'
+                                      : 'none'
+                                : undefined
+                            const content = header.isPlaceholder
+                                ? null
+                                : flexRender(header.column.columnDef.header, header.getContext())
+
+                            return (
+                                <th
+                                    key={header.id}
+                                    colSpan={header.colSpan}
+                                    className={classNames(
+                                        styles.headerCell,
+                                        canSort && styles.headerCellSortable,
+                                    )}
+                                    aria-sort={ariaSort}
+                                >
+                                    {canSort && onSort && getSortAriaLabel ? (
+                                        <button
+                                            type="button"
+                                            className={styles.sortButton}
+                                            aria-label={getSortAriaLabel({
+                                                columnId: header.column.id,
+                                                direction,
+                                            })}
+                                            onClick={() => onSort(header.column.id)}
+                                            onKeyDown={(event) => {
+                                                if (event.key === 'Enter' || event.key === ' ') {
+                                                    event.preventDefault()
+                                                    onSort(header.column.id)
+                                                }
+                                            }}
+                                        >
+                                            <span className={styles.headerCellContent}>
+                                                {content}
+                                            </span>
+                                            <span
+                                                className={styles.sortIndicator}
+                                                aria-hidden="true"
+                                            >
+                                                {direction ? (
+                                                    <SortIndicator direction={direction} />
+                                                ) : null}
+                                            </span>
+                                        </button>
+                                    ) : (
+                                        content
+                                    )}
+                                </th>
+                            )
+                        })}
+                    </tr>
+                ))}
+            </thead>
+            <tbody>
+                {rows.length === 0 && emptyState !== undefined ? (
+                    <tr>
+                        <td
+                            className={classNames(styles.cell, styles.emptyCell)}
+                            colSpan={Math.max(table.getVisibleLeafColumns().length, 1)}
+                        >
+                            {emptyState}
+                        </td>
+                    </tr>
+                ) : (
+                    rows.map((row) =>
+                        renderRow ? (
+                            renderRow(row)
+                        ) : (
+                            <TableRow key={row.id}>
+                                {row.getVisibleCells().map((cell) => (
+                                    <TableCell key={cell.id} cell={cell} />
+                                ))}
+                            </TableRow>
+                        ),
+                    )
+                )}
+            </tbody>
+        </table>
+    )
+}) as TableComponent
+
+Table.displayName = 'Table'
+
+export { Table, TableCell, TableRow }
+export type {
+    TableCellModel,
+    TableCellProps,
+    TableColumn,
+    TableProps,
+    TableRowModel,
+    TableRowProps,
+    TableSorting,
+}
+
+function SortIndicator({ direction }: { direction: 'asc' | 'desc' }) {
+    return (
+        <svg className={styles.sortIndicatorIcon} viewBox="0 0 16 16" focusable="false">
+            <path d={direction === 'asc' ? 'M4 10l4-4 4 4' : 'M4 6l4 4 4-4'} />
+        </svg>
+    )
+}


### PR DESCRIPTION
<!--
Include a link to related issues, or more importantly, any issue this may close.
-->

Related: https://github.com/Doist/frontend-issues/issues/1369

## Short description

<!--
Please describe your implementation and any details that we should keep in mind during review.
-->

Adds a provisional Reactist `Table` prototype based on Todoist's current flat data table for review during the Reactist session.

- Preserves native table markup, typed columns and data, stable row IDs, controlled manual sorting, empty states, custom rows and cells, and selected-row styling.
- Exposes `TableRow` and `TableCell` building blocks without making the CSS module public.
- Adds presentation-ready Data Display stories for default, sorting, selection, empty, placeholder-row, and narrow viewport states.
- Pins and externalizes `@tanstack/react-table` 8.21.3.

The API is intentionally provisional. This does not add hierarchy, drag and drop, multi-select, persistence, responsive redesign, or Todoist integration.

To review in Storybook:

1. Run `npm run storybook`.
2. Open **Data display / Table / Default** and try sorting with pointer and keyboard.
3. Open **Selected and clickable rows**, then activate rows with pointer, Enter, and Space.
4. Review the empty, custom placeholder, and narrow viewport stories.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

- [x] Added tests for bugs / new features
- [x] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [semantic-release](https://github.com/semantic-release/semantic-release), based on the PR title.
-->
