### PR TITLE
ci: drop the private Renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "github>doist/renovate-config:frontend-base",
-        "github>doist/renovate-config-internal:npm-registry-token"
-    ],
+    "extends": ["github>doist/renovate-config:frontend-base"],
     "packageRules": [
         {
             "description": "Reactist releases should mirror @doist/product-libraries-tokens releases. Simple token value changes are categorized as patches.",


### PR DESCRIPTION
Closes #1104

## Short description

This follows up on #1095 by removing the private `doist/renovate-config-internal:npm-registry-token` config.

## PR Checklist

<!--
Feel free to leave unchecked or remove the lines that are not applicable.
-->

- [ ] Added tests for bugs / new features
- [ ] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI

<!--
_Note:_ versioning is handled by [semantic-release](https://github.com/semantic-release/semantic-release), based on the PR title.
-->

---

<!--
Worth deciding separately, not included in this PR:

The three @doist/product-libraries-tokens packageRules in .github/renovate.json are inert —
that package is not in package.json at all. Either add the dependency or drop the rules.
-->
