### PR TITLE
fix: centralize the font stack and adopt Todoist's typography defaults

### DIFF
--- a/src/base-field/base-field.module.css
+++ b/src/base-field/base-field.module.css
@@ -1,6 +1,6 @@
 :root {
     --reactist-field-label-padding-bottom: 6px;
-    --reactist-field-label-line-height: inherit;
+    --reactist-field-label-line-height: 21px;
 }
 .container {
     font-family: var(--reactist-font-family);

--- a/src/prose/prose.module.css
+++ b/src/prose/prose.module.css
@@ -23,7 +23,7 @@
 
 /* Internals for spacing. These are not considered public API. */
 :root {
-    --reactist-prose-content-font-size: 15px;
+    --reactist-prose-content-font-size: 14px;
     --reactist-prose-em-multiplier: 1.5;
     --reactist-prose-space-1: calc(
         var(--reactist-prose-em-multiplier) * var(--reactist-prose-content-font-size) / 3

--- a/src/styles/design-tokens.css
+++ b/src/styles/design-tokens.css
@@ -30,9 +30,21 @@
     --reactist-width-xlarge: 1280px;
 
     /* font family */
+
+    /* 'Segoe UI' must be named before `system-ui`.
+     *
+     * On Windows, `system-ui` resolves to the locale's UI font. Under CJK locales that is
+     * Microsoft YaHei UI, Yu Gothic UI or Malgun Gothic: fonts whose Latin glyphs are wider
+     * and heavier than Segoe UI's, and which have no semibold weight. Naming 'Segoe UI'
+     * explicitly keeps Latin text consistent across locales, while CJK characters still fall
+     * through to the system font further down the stack.
+     * @see https://infinnie.github.io/blog/2017/systemui.html
+     *
+     * `-apple-system`(Safari and Firefox) and `BlinkMacSystemFont` (Chromium) both resolve to the Apple system font
+     * (San Francisco) */
     --reactist-font-family:
-        -apple-system, system-ui, 'Segoe UI', Roboto, Noto, Oxygen-Sans, Ubuntu, Cantrell,
-        'Helvetica Neue', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', system-ui, sans-serif,
+        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
     --reactist-font-family-monospace:
         ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', Consolas,
         'Liberation Mono', 'Courier New', monospace;

--- a/src/styles/design-tokens.css
+++ b/src/styles/design-tokens.css
@@ -46,8 +46,7 @@
         -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', system-ui, sans-serif,
         'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
     --reactist-font-family-monospace:
-        ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', Consolas,
-        'Liberation Mono', 'Courier New', monospace;
+        ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 
     /* font sizes */
     --reactist-font-size-caption: 12px;


### PR DESCRIPTION
## Short description

This PR updates Reactist's font stacks and the base field's line heights with the values we're using in Todoist.

#### Size/spacing changes

- `Prose`: Default font size is reduced from 15px to 14px, which also affects  its vertical spacing (via margins and padding), since they are derived from the font size
- `TextField`, `SelectField`, etc. now specifies a 21px line-height for their labels. In Comms using the `inherit` default, this resolves to 17px, so this will render more spacing around them.

#### Font stack changes

* `--reactist-font-family`: the main change is placing `Segoe UI` ahead of `system-ui`, which makes latin text more consistent on (non macOS) systems with CJK-locales
* `--reactist-font-family-monospace`: this is better aligned with the stack Todoist/GitHub uses, and should have no visible impact on most systems

#### Demo

|Before|After|
|-|-|
|<img width="760" height="900" alt="prose-00-baseline-light" src="https://github.com/user-attachments/assets/689b1e89-d39f-4aa4-85a2-4b1bccf59ac2" />|<img width="760" height="900" alt="prose-01-after-light" src="https://github.com/user-attachments/assets/dc1c8f2f-80b4-4173-beec-96abd6274298" />|

## PR Checklist

- [ ] Added tests for bugs / new features
- [ ] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI
