### PR TITLE
fix: set Comms audience to thread

### DIFF
--- a/.github/workflows/publish-package-release.yml
+++ b/.github/workflows/publish-package-release.yml
@@ -171,4 +171,5 @@ jobs:
                   workspace-id: 69
                   thread-id: BPZsUohfX5WV4tFJKMHAh
                   content: ${{ steps.announcement.outputs.message }}
+                  audience: thread
               continue-on-error: true


### PR DESCRIPTION
## Summary

Set the Comms post-comment action's `audience` input to `thread`.