### PR TITLE
feat!: migrate Modal from Ariakit to Base UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,8 @@
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "7.29.7",
-                "aria-hidden": "1.2.6",
                 "dayjs": "1.11.21",
                 "patch-package": "8.0.1",
-                "react-focus-lock": "2.13.7",
                 "react-keyed-flatten-children": "1.3.0",
                 "react-markdown": "5.0.3",
                 "use-callback-ref": "1.3.3"
@@ -28,6 +26,7 @@
                 "@babel/preset-react": "7.29.7",
                 "@babel/preset-typescript": "7.29.7",
                 "@babel/register": "7.29.7",
+                "@base-ui/react": "1.6.0",
                 "@doist/eslint-config": "13.1.1",
                 "@doist/prettier-config": "4.0.1",
                 "@doist/product-libraries-tokens": "1.0.0",
@@ -108,6 +107,7 @@
             },
             "peerDependencies": {
                 "@ariakit/react": "~0.4.19",
+                "@base-ui/react": "^1.6.0",
                 "classnames": "^2.2.5",
                 "react": ">=18.0.0 <20.0.0",
                 "react-compiler-runtime": "^1.0.0",
@@ -2317,6 +2317,68 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@base-ui/react": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+            "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.29.2",
+                "@base-ui/utils": "0.3.1",
+                "@floating-ui/react-dom": "^2.1.8",
+                "@floating-ui/utils": "^0.2.11",
+                "use-sync-external-store": "^1.6.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@date-fns/tz": "^1.2.0",
+                "@types/react": "^17 || ^18 || ^19",
+                "date-fns": "^4.0.0",
+                "react": "^17 || ^18 || ^19",
+                "react-dom": "^17 || ^18 || ^19"
+            },
+            "peerDependenciesMeta": {
+                "@date-fns/tz": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                },
+                "date-fns": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@base-ui/utils": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+            "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.29.2",
+                "@floating-ui/utils": "^0.2.11",
+                "reselect": "^5.2.0",
+                "use-sync-external-store": "^1.6.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^17 || ^18 || ^19",
+                "react": "^17 || ^18 || ^19",
+                "react-dom": "^17 || ^18 || ^19"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@bcoe/v8-coverage": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -3677,30 +3739,44 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.7.5",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-            "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+            "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/utils": "^0.2.11"
+                "@floating-ui/utils": "^0.2.12"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.7.6",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-            "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+            "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/core": "^1.7.5",
-                "@floating-ui/utils": "^0.2.11"
+                "@floating-ui/core": "^1.8.0",
+                "@floating-ui/utils": "^0.2.12"
+            }
+        },
+        "node_modules/@floating-ui/react-dom": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+            "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/dom": "^1.8.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.11",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-            "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+            "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
             "dev": true,
             "license": "MIT"
         },
@@ -8166,18 +8242,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/aria-hidden": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-            "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/aria-query": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -10448,12 +10512,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/detect-node-es": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-            "license": "MIT"
-        },
         "node_modules/diff-sequences": {
             "version": "28.1.1",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
@@ -12448,18 +12506,6 @@
             "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/focus-lock": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
-            "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.3"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/for-each": {
             "version": "0.3.5",
@@ -21678,18 +21724,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-clientside-effect": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.8.tgz",
-            "integrity": "sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.12.13"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            }
-        },
         "node_modules/react-compiler-runtime": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-1.0.0.tgz",
@@ -21781,29 +21815,6 @@
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
-            }
-        },
-        "node_modules/react-focus-lock": {
-            "version": "2.13.7",
-            "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.7.tgz",
-            "integrity": "sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.0.0",
-                "focus-lock": "^1.3.6",
-                "prop-types": "^15.6.2",
-                "react-clientside-effect": "^1.2.7",
-                "use-callback-ref": "^1.3.3",
-                "use-sidecar": "^1.1.3"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
             }
         },
         "node_modules/react-is": {
@@ -22224,6 +22235,13 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/reselect": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+            "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
             "dev": true,
             "license": "MIT"
         },
@@ -25561,28 +25579,6 @@
             "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
             "license": "MIT",
             "dependencies": {
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/use-sidecar": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-            "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-            "license": "MIT",
-            "dependencies": {
-                "detect-node-es": "^1.1.0",
                 "tslib": "^2.0.0"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     },
     "peerDependencies": {
         "@ariakit/react": "~0.4.19",
+        "@base-ui/react": "^1.6.0",
         "classnames": "^2.2.5",
         "react": ">=18.0.0 <20.0.0",
         "react-compiler-runtime": "^1.0.0",
@@ -73,6 +74,7 @@
     },
     "devDependencies": {
         "@ariakit/react": "0.4.19",
+        "@base-ui/react": "1.6.0",
         "@babel/cli": "7.29.7",
         "@babel/core": "7.29.7",
         "@babel/plugin-transform-runtime": "7.29.7",
@@ -156,10 +158,8 @@
     },
     "dependencies": {
         "@babel/runtime": "7.29.7",
-        "aria-hidden": "1.2.6",
         "dayjs": "1.11.21",
         "patch-package": "8.0.1",
-        "react-focus-lock": "2.13.7",
         "react-keyed-flatten-children": "1.3.0",
         "react-markdown": "5.0.3",
         "use-callback-ref": "1.3.3"

--- a/scripts/jestSetup.ts
+++ b/scripts/jestSetup.ts
@@ -14,3 +14,20 @@ if (!window.ResizeObserver) {
     window.ResizeObserver = ResizeObserver
     global.ResizeObserver = ResizeObserver
 }
+
+/**
+ * When focus falls back to the body, jsdom fires focusout events with the document as the
+ * `relatedTarget`, something browsers never do. Base UI's focus manager then calls
+ * `relatedTarget.hasAttribute(...)`, which does not exist on documents and throws. Give the
+ * document a no-op `hasAttribute` so those events are processed as not matching any element.
+ *
+ * @see https://github.com/mui/base-ui/blob/master/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+ */
+if (!('hasAttribute' in document)) {
+    Object.defineProperty(Document.prototype, 'hasAttribute', {
+        value: function hasAttribute() {
+            return false
+        },
+        configurable: true,
+    })
+}

--- a/src/modal/modal.module.css
+++ b/src/modal/modal.module.css
@@ -30,7 +30,7 @@
     z-index: var(--reactist-stacking-order-modal);
 }
 
-.overlay > [data-focus-lock-disabled] {
+.overlay > .wrapper {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -40,10 +40,10 @@
     padding: var(--reactist-spacing-xxlarge);
 }
 
-.overlay.fitContent > [data-focus-lock-disabled] {
+.overlay.fitContent > .wrapper {
     padding-top: var(--reactist-modal-padding-top);
 }
-.overlay.fitContent > [data-focus-lock-disabled] .container {
+.overlay.fitContent > .wrapper .container {
     max-height: calc(100vh - 2 * var(--reactist-modal-padding-top));
 }
 
@@ -96,7 +96,7 @@
         width: 100% !important;
         max-height: none;
     }
-    .overlay.expand:not(.xsmall):not(.small) > [data-focus-lock-disabled] {
+    .overlay.expand:not(.xsmall):not(.small) > .wrapper {
         padding-left: 0;
         padding-right: 0;
         padding-bottom: 0;
@@ -112,7 +112,7 @@
         width: 100% !important;
         max-height: none;
     }
-    .overlay.expand > [data-focus-lock-disabled] {
+    .overlay.expand > .wrapper {
         padding-left: 0;
         padding-right: 0;
         padding-bottom: 0;

--- a/src/modal/modal.stories.tsx
+++ b/src/modal/modal.stories.tsx
@@ -383,15 +383,7 @@ export function ModalAutofocus() {
                     By default the `autoFocus` prop is `true`, which shifts the focus onto the first
                     focusable element in the modal. You can further refine this by using the
                     `data-autofocus` attribute if you wish to focus on elements other than the first
-                    one. This is made possible using React Focus Lock, please see its{' '}
-                    <a
-                        target="_blank"
-                        rel="noreferrer"
-                        href="https://github.com/theKashey/react-focus-lock/tree/v2.9.1#autofocus"
-                    >
-                        documentation
-                    </a>{' '}
-                    for more details.
+                    one.
                 </Text>
             </Stack>
             <Modal height="fitContent" aria-label="Confirmation modal" width="small">

--- a/src/modal/modal.tsx
+++ b/src/modal/modal.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
 import { forwardRef } from 'react'
-import FocusLock from 'react-focus-lock'
 
-import { Dialog, Portal, useDialogStore } from '@ariakit/react'
-import { hideOthers } from 'aria-hidden'
+import { Dialog } from '@base-ui/react/dialog'
 import classNames from 'classnames'
 
 import { Box } from '../box'
@@ -15,7 +13,6 @@ import { Inline } from '../inline'
 
 import styles from './modal.module.css'
 
-import type { DialogOptions, PortalOptions } from '@ariakit/react'
 import type { IconButtonProps } from '../button'
 import type { DividerProps } from '../divider'
 import type { ObfuscatedClassName } from '../utils/common-types'
@@ -100,12 +97,12 @@ export interface ModalProps extends DivProps, ObfuscatedClassName {
     /**
      * Controls if the modal is dismissed when pressing "Escape".
      */
-    hideOnEscape?: DialogOptions['hideOnEscape']
+    hideOnEscape?: boolean | ((event: KeyboardEvent) => boolean)
 
     /**
      * Controls if the modal is dismissed when clicking outside the modal body, on the overlay.
      */
-    hideOnInteractOutside?: DialogOptions['hideOnInteractOutside']
+    hideOnInteractOutside?: boolean | ((event: Event) => boolean)
 
     /**
      * An escape hatch in case you need to provide a custom class name to the overlay element.
@@ -131,23 +128,19 @@ export interface ModalProps extends DivProps, ObfuscatedClassName {
      *
      * @example
      * const [portal, setPortal] = useState(null);
-     * <Portal portalElement={portal} />;
+     * <Modal portalElement={portal} />;
      * <div ref={setPortal} />;
      *
      * @example
-     * const getPortalElement = useCallback(() => {
+     * const getPortalElement = () => {
      *   const div = document.createElement("div");
      *   const portalRoot = document.getElementById("portal-root");
      *   portalRoot.appendChild(div);
      *   return div;
-     * }, []);
-     * <Portal portalElement={getPortalElement} />;
+     * };
+     * <Modal portalElement={getPortalElement} />;
      */
-    portalElement?: PortalOptions['portalElement']
-}
-
-function isNotInternalFrame(element: HTMLElement) {
-    return !(element.ownerDocument === document && element.tagName.toLowerCase() === 'iframe')
+    portalElement?: HTMLElement | (() => HTMLElement | null) | null
 }
 
 /**
@@ -173,135 +166,130 @@ export function Modal({
     children,
     portalElement,
     onKeyDown,
-    // @ts-expect-error we want to make sure to not pass it to the Dialog component
+    // @ts-expect-error we want to make sure to not pass it to the dialog element
     className,
     ...props
 }: ModalProps) {
-    const setOpen = React.useCallback(
-        (visible: boolean) => {
-            if (!visible) {
-                onDismiss?.()
-            }
-        },
-        [onDismiss],
-    )
-    const store = useDialogStore({ open: isOpen, setOpen })
+    const contextValue: ModalContextValue = { onDismiss, height, dividers }
 
-    const contextValue: ModalContextValue = React.useMemo(
-        () => ({ onDismiss, height, dividers }),
-        [onDismiss, height, dividers],
-    )
-
-    const portalRef = React.useRef<HTMLElement | null>(null)
     const dialogRef = React.useRef<HTMLDivElement | null>(null)
-    const backdropRef = React.useRef<HTMLDivElement | null>(null)
-    const handleBackdropClick = React.useCallback(
-        (event: React.MouseEvent) => {
-            if (
-                // The focus lock element takes up the same space as the backdrop and is where the event bubbles up from,
-                // so instead of checking the backdrop as the event target, we need to make sure it's just above the dialog
-                !dialogRef.current?.contains(event.target as Node) &&
-                // Events fired from other portals will bubble up to the backdrop, even if it isn't a child in the DOM
-                backdropRef.current?.contains(event.target as Node)
-            ) {
-                event.stopPropagation()
-                onDismiss?.()
+
+    // Resolve the portal element upfront when given as a function, so that the dialog is only
+    // rendered once its final portal element is known
+    const [resolvedPortalElement, setResolvedPortalElement] = React.useState<HTMLElement | null>(
+        null,
+    )
+    React.useLayoutEffect(
+        function resolvePortalElement() {
+            if (typeof portalElement === 'function') {
+                // eslint-disable-next-line react-hooks/set-state-in-effect
+                setResolvedPortalElement(portalElement())
             }
         },
-        [onDismiss],
+        [portalElement],
     )
 
-    React.useLayoutEffect(
-        function disableAccessibilityTreeOutside() {
-            if (!isOpen || !portalRef.current) {
+    function handleOpenChange(open: boolean, eventDetails: Dialog.Root.ChangeEventDetails) {
+        if (open) {
+            return
+        }
+
+        if (eventDetails.reason === 'outside-press') {
+            const shouldHide =
+                typeof hideOnInteractOutside === 'function'
+                    ? hideOnInteractOutside(eventDetails.event)
+                    : hideOnInteractOutside
+            if (shouldHide && onDismiss != null) {
+                onDismiss()
                 return
             }
+        }
 
-            return hideOthers(portalRef.current)
-        },
-        [isOpen],
-    )
+        // Reject any other close request. Escape is handled by our own keydown handler below, so a
+        // nested widget that handles Escape (and stops React propagation) does not also close the
+        // modal, and so the key does not propagate beyond the modal when it triggers the dismissal
+        eventDetails.cancel()
+    }
 
-    const handleKeyDown = React.useCallback(
-        function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
-            if (
-                hideOnEscape &&
-                onDismiss != null &&
-                event.key === 'Escape' &&
-                !event.defaultPrevented
-            ) {
+    function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+        if (event.key === 'Escape' && onDismiss != null && !event.defaultPrevented) {
+            const shouldHide =
+                typeof hideOnEscape === 'function' ? hideOnEscape(event.nativeEvent) : hideOnEscape
+            if (shouldHide) {
                 event.stopPropagation()
                 onDismiss()
             }
-            onKeyDown?.(event)
-        },
-        [onDismiss, hideOnEscape, onKeyDown],
-    )
+        }
+        onKeyDown?.(event)
+    }
 
-    if (!isOpen) {
+    function handleOverlayMouseDown(event: React.MouseEvent<HTMLDivElement>) {
+        // Keep focus inside the modal when pressing on the overlay, so keyboard handling (such as
+        // Escape to dismiss) keeps working even when the press does not close the modal
+        if (!dialogRef.current?.contains(event.target as Node)) {
+            event.preventDefault()
+        }
+    }
+
+    /**
+     * Focus the element marked with the `data-autofocus` attribute if present, or fall back to
+     * the default behaviour of focusing the first focusable element inside the modal.
+     */
+    function getInitialFocus() {
+        const autofocusElement = dialogRef.current?.querySelector('[data-autofocus]')
+        return autofocusElement instanceof HTMLElement ? autofocusElement : true
+    }
+
+    if (typeof portalElement === 'function' && resolvedPortalElement == null) {
         return null
     }
 
     return (
-        <Portal portalRef={portalRef} portalElement={portalElement}>
-            <Box
-                data-testid="modal-overlay"
-                data-overlay
-                className={classNames(
-                    styles.overlay,
-                    styles[height],
-                    styles[width],
-                    exceptionallySetOverlayClassName,
-                )}
-                /**
-                 * We're using `onPointerDown` instead of `onClick` to prevent the modal from
-                 * closing when the click starts inside the modal and ends on the backdrop.
-                 */
-                onPointerDown={hideOnInteractOutside ? handleBackdropClick : undefined}
-                ref={backdropRef}
+        <Dialog.Root open={isOpen} onOpenChange={handleOpenChange} modal>
+            <Dialog.Portal
+                container={
+                    (typeof portalElement === 'function' ? resolvedPortalElement : portalElement) ??
+                    undefined
+                }
             >
-                <FocusLock
-                    autoFocus={autoFocus}
-                    whiteList={isNotInternalFrame}
-                    returnFocus={true}
-                    crossFrame={false}
+                <Box
+                    data-testid="modal-overlay"
+                    data-overlay
+                    className={classNames(
+                        styles.overlay,
+                        styles[height],
+                        styles[width],
+                        exceptionallySetOverlayClassName,
+                    )}
+                    onMouseDown={handleOverlayMouseDown}
                 >
-                    <Dialog
-                        {...props}
-                        ref={dialogRef}
-                        render={
-                            <Box
-                                borderRadius="full"
-                                background="default"
-                                display="flex"
-                                flexDirection="column"
-                                overflow="hidden"
-                                height={height === 'expand' ? 'full' : undefined}
-                                flexGrow={height === 'expand' ? 1 : 0}
-                            />
-                        }
-                        className={classNames(exceptionallySetClassName, styles.container)}
-                        store={store}
-                        preventBodyScroll
-                        // Disable focus lock as we set up our own using ReactFocusLock
-                        modal={false}
-                        autoFocus={false}
-                        autoFocusOnShow={false}
-                        autoFocusOnHide={false}
-                        // Disable portal and backdrop as we control their markup
-                        portal={false}
-                        backdrop={false}
-                        hideOnInteractOutside={false}
-                        hideOnEscape={false}
-                        onKeyDown={handleKeyDown}
-                    >
-                        <ModalContext.Provider value={contextValue}>
-                            {children}
-                        </ModalContext.Provider>
-                    </Dialog>
-                </FocusLock>
-            </Box>
-        </Portal>
+                    <div className={styles.wrapper}>
+                        <Dialog.Popup
+                            {...props}
+                            ref={dialogRef}
+                            onKeyDown={handleKeyDown}
+                            initialFocus={autoFocus ? getInitialFocus : false}
+                            render={
+                                <Box
+                                    borderRadius="full"
+                                    background="default"
+                                    display="flex"
+                                    flexDirection="column"
+                                    overflow="hidden"
+                                    height={height === 'expand' ? 'full' : undefined}
+                                    flexGrow={height === 'expand' ? 1 : 0}
+                                />
+                            }
+                            className={classNames(exceptionallySetClassName, styles.container)}
+                        >
+                            <ModalContext.Provider value={contextValue}>
+                                {children}
+                            </ModalContext.Provider>
+                        </Dialog.Popup>
+                    </div>
+                </Box>
+            </Dialog.Portal>
+        </Dialog.Root>
     )
 }
 


### PR DESCRIPTION
## What

A spike to reimplement `Modal` with [`@base-ui/react`](https://base-ui.com/react/components/dialog)'s `Dialog` instead of `@ariakit/react`, as part of the Reactist Ariakit → Base UI migration (Denmark component workshop follow-up).

Base UI's `Dialog` now owns focus trapping, scroll locking, outside-press detection, and hiding background content from assistive tech. This replaces the hand-wired `react-focus-lock` + `aria-hidden` combination, and both dependencies are dropped.

The public component API is unchanged: `Modal`, `ModalHeader`, `ModalBody`, `ModalFooter`, `ModalActions`, `ModalCloseButton`, and props like `isOpen` / `onDismiss` / `width` / `height` / `autoFocus` / `data-autofocus` all behave as before. Most apps only need to install the new peer dependency.

## Breaking changes

### 1. New peer dependency

Consumers must now install `@base-ui/react` (`^1.6.0`) alongside the still-present `@ariakit/react` (the latter stays until the other components migrate).

### 2. `hideOnEscape` / `hideOnInteractOutside` types

These were typed via Ariakit's `DialogOptions`. They're now local types (`boolean | ((event) => boolean)`). Booleans and simple callbacks are unaffected.

### 3. `portalElement` callback signature

The function form no longer receives the default element argument: `(element) => HTMLElement | null` → `() => HTMLElement | null`.

## Behaviour changes

- **Focus, scroll lock, and background `aria-hidden` are now Base UI's**, not `react-focus-lock` / `aria-hidden`.
- **The iframe focus whitelist is gone.** The old `FocusLock` allowlisted non-iframe elements; modals embedding iframes need a manual QA pass.
- **Outside-press and Escape run through Base UI's native listeners.** Validated as equivalent, but app-level `document` handlers may see slightly different event flow.
- **Internal DOM changed**: the `react-focus-lock` wrapper (`[data-focus-lock-disabled]`) is replaced by our own `.wrapper` div, and Base UI adds its own `data-*` attributes / focus guards. Consumer CSS or snapshots reaching into the modal's internals may need updating.

## Notes for review (WIP)

- `scripts/jestSetup.ts` adds a jsdom-only shim for an upstream Base UI focus-manager bug (`relatedTarget` can be the `Document` on blur-to-body, where it calls `.hasAttribute` without an element guard). Worth reporting upstream.
- Escape is intentionally handled on the popup's `onKeyDown` (not Base UI's document-level dismissal) so a nested widget that handles Escape — e.g. an Ariakit `Menu` inside the modal — closes only itself, not the modal. A non-closing overlay press calls `preventDefault` to keep focus inside so Escape keeps working.
- Validated: full `jest` suite (620 tests) green, and a manual Storybook + Playwright pass across all 8 modal stories (open/close, focus, Escape, overlay dismiss + opt-outs, `data-autofocus`, nested menu, stacking, tabs-in-modal).

## PR Checklist

- [x] Added tests for bugs / new features (existing modal suite passes unchanged)
- [ ] Updated docs (storybooks, readme)
- [ ] Reviewed and approved Chromatic visual regression tests in CI
